### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/Hagalaz.AppHost/Extensions.cs
+++ b/Hagalaz.AppHost/Extensions.cs
@@ -132,7 +132,15 @@ namespace Hagalaz.AppHost
                 Directory.CreateDirectory(tempDir);
             }
 
-            string[] args = ["dev-certs", "https", "--export-path", $"\"{certExportPath}\"", "--format", "Pem", "--no-password"];
+            var baseTempDir = Path.GetTempPath();
+            var fullCertExportPath = Path.GetFullPath(certExportPath, baseTempDir);
+
+            if (!fullCertExportPath.StartsWith(baseTempDir, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("The export path is outside the allowed temporary directory.");
+            }
+
+            string[] args = ["dev-certs", "https", "--export-path", $"\"{fullCertExportPath}\"", "--format", "Pem", "--no-password"];
             var argsString = string.Join(' ', args);
 
             logger.LogTrace("Running command to export dev cert: {ExportCmd}", $"dotnet {argsString}");


### PR DESCRIPTION
Potential fix for [https://github.com/frankvdb7/Hagalaz/security/code-scanning/1](https://github.com/frankvdb7/Hagalaz/security/code-scanning/1)

To fix the problem, we need to ensure that the `certExportPath` is validated and sanitized before being used in the command line arguments. One way to achieve this is by using a whitelist approach, where we only allow paths within a specific directory that we control. Additionally, we can use the `Path.GetFullPath` method to resolve the full path and ensure it is within the expected directory.

1. Validate and sanitize the `certExportPath` to ensure it is within a specific directory.
2. Use `Path.GetFullPath` to resolve the full path and check if it is within the expected directory.
3. Update the `args` array to use the sanitized path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
