### PR TITLE
Add JsonDictionary TryGetObject non-existing key test

### DIFF
--- a/Hagalaz.Text.Json.Tests/JsonDictionaryTests.cs
+++ b/Hagalaz.Text.Json.Tests/JsonDictionaryTests.cs
@@ -319,6 +319,16 @@ namespace Hagalaz.Text.Json.Tests
         }
 
         [TestMethod]
+        public void Dictionary_Try_Get_Object_NonExisting()
+        {
+            var dictionary = new JsonDictionary(_jsonOptions);
+
+            var result = dictionary.TryGetObject<ADto>("non.existing.key", out var value);
+            Assert.IsFalse(result);
+            Assert.IsNull(value);
+        }
+
+        [TestMethod]
         public void Dictionary_Set_Array()
         {
             var dictionary = new JsonDictionary(_jsonOptions);


### PR DESCRIPTION
## Summary
- ensure TryGetObject returns `false` and `null` for missing keys

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683ffba4f104832aa87401d12d0f62f4