### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/frankvdb7/Hagalaz/security/code-scanning/22](https://github.com/frankvdb7/Hagalaz/security/code-scanning/22)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. We will set the permissions to the least privilege required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
