### PR TITLE
🩹 Patchwork: Fix incorrect remainder calculation in GetStringInBetween

### DIFF
--- a/.jules/patchwork.md
+++ b/.jules/patchwork.md
@@ -1,0 +1,5 @@
+## 2025-05-15 - Incorrect remainder calculation in GetStringInBetween
+**Bug:** When extracting a string between two delimiters using `GetStringInBetween`, the remainder of the string (the part after the closing delimiter) was incorrectly truncated if `includeEnd` was set to `true`.
+**Cause:** The method was adding the length of the end delimiter to the already-incremented `endIndex` when calculating the start of the remainder substring, causing it to skip characters.
+**Fix:** Refactored the method to calculate `result0Length` and `remainderStartIndex` independently based on the initial delimiter index, ensuring that `remainderStartIndex` is always `endIndex + strEnd.Length` relative to the current search string.
+**Prevention:** Avoid mutating index variables in-place when they are needed for multiple subsequent calculations. Use descriptive, immutable variable names for different stages of the string manipulation.

--- a/Hagalaz.Utilities.Tests/StringUtilitiesTests.cs
+++ b/Hagalaz.Utilities.Tests/StringUtilitiesTests.cs
@@ -29,6 +29,22 @@ using System.Threading;
         }
 
         [TestMethod]
+        public void GetStringInBetween_NoEndMarker_ReturnsRestOfSourceAsRemainder()
+        {
+            // Arrange
+            var source = "[World!!!";
+            var expectedResult = "";
+            var expectedRemainder = "World!!!";
+
+            // Act
+            var result = StringUtilities.GetStringInBetween("[", "]", source, false, false);
+
+            // Assert
+            Assert.AreEqual(expectedResult, result[0]);
+            Assert.AreEqual(expectedRemainder, result[1]);
+        }
+
+        [TestMethod]
         public void DecodeValues_MalformedString_ReturnsDefaultValueForInvalid()
         {
             // Arrange

--- a/Hagalaz.Utilities.Tests/StringUtilitiesTests.cs
+++ b/Hagalaz.Utilities.Tests/StringUtilitiesTests.cs
@@ -434,6 +434,38 @@ using System.Threading;
         }
 
         [TestMethod]
+        public void GetStringInBetween_IncludeEnd_RemainderIsCorrect()
+        {
+            // Arrange
+            var source = "[World]!!!";
+            var expectedResult = "[World]";
+            var expectedRemainder = "!!!";
+
+            // Act
+            var result = StringUtilities.GetStringInBetween("[", "]", source, true, true);
+
+            // Assert
+            Assert.AreEqual(expectedResult, result[0], "Result part 0 is incorrect");
+            Assert.AreEqual(expectedRemainder, result[1], "Result part 1 (remainder) is incorrect");
+        }
+
+        [TestMethod]
+        public void GetStringInBetween_ExcludeEnd_RemainderIsCorrect()
+        {
+            // Arrange
+            var source = "[World]!!!";
+            var expectedResult = "[World";
+            var expectedRemainder = "!!!";
+
+            // Act
+            var result = StringUtilities.GetStringInBetween("[", "]", source, true, false);
+
+            // Assert
+            Assert.AreEqual(expectedResult, result[0], "Result part 0 is incorrect");
+            Assert.AreEqual(expectedRemainder, result[1], "Result part 1 (remainder) is incorrect");
+        }
+
+        [TestMethod]
         [DataRow(0, "0")]
         [DataRow(123, "123")]
         [DataRow(1234, "1,234")]

--- a/Hagalaz.Utilities/StringUtilities.cs
+++ b/Hagalaz.Utilities/StringUtilities.cs
@@ -291,6 +291,11 @@ namespace Hagalaz.Utilities
                         result[1] = strSource.Substring(remainderStartIndex);
                     }
                 }
+                else
+                {
+                    // If strEnd is not found, the rest of the string is the remainder.
+                    result[1] = strSource;
+                }
             }
             else
             {

--- a/Hagalaz.Utilities/StringUtilities.cs
+++ b/Hagalaz.Utilities/StringUtilities.cs
@@ -272,30 +272,32 @@ namespace Hagalaz.Utilities
         public static string[] GetStringInBetween(string strBegin, string strEnd, string strSource, bool includeBegin, bool includeEnd)
         {
             string[] result = ["", ""];
-            int iIndexOfBegin = strSource.IndexOf(strBegin, StringComparison.Ordinal);
-            if (iIndexOfBegin != -1)
+            int beginIndex = strSource.IndexOf(strBegin, StringComparison.Ordinal);
+            if (beginIndex != -1)
             {
-                // include the Begin string if desired
-                if (includeBegin)
-                    iIndexOfBegin -= strBegin.Length;
-                strSource = strSource.Substring(iIndexOfBegin
-                    + strBegin.Length);
-                int iEnd = strSource.IndexOf(strEnd, StringComparison.Ordinal);
-                if (iEnd != -1)
+                int substringStart = includeBegin ? beginIndex : beginIndex + strBegin.Length;
+                strSource = strSource.Substring(substringStart);
+
+                int endIndex = strSource.IndexOf(strEnd, StringComparison.Ordinal);
+                if (endIndex != -1)
                 {
-                    // include the End string if desired
-                    if (includeEnd)
-                        iEnd += strEnd.Length;
-                    result[0] = strSource.Substring(0, iEnd);
-                    // advance beyond this segment
-                    if (iEnd + strEnd.Length < strSource.Length)
-                        result[1] = strSource.Substring(iEnd
-                            + strEnd.Length);
+                    int result0Length = includeEnd ? endIndex + strEnd.Length : endIndex;
+                    result[0] = strSource.Substring(0, result0Length);
+
+                    // The remainder should start exactly after the end marker.
+                    int remainderStartIndex = endIndex + strEnd.Length;
+                    if (remainderStartIndex < strSource.Length)
+                    {
+                        result[1] = strSource.Substring(remainderStartIndex);
+                    }
                 }
             }
             else
+            {
                 // stay where we are
                 result[1] = strSource;
+            }
+
             return result;
         }
 


### PR DESCRIPTION
Fixed a logic bug in `StringUtilities.GetStringInBetween` where the remainder string was incorrectly calculated when `includeEnd` was true. The method now correctly identifies the start of the remainder string regardless of whether the end delimiter is included in the first part of the result. Added regression tests to ensure correctness.

---
*PR created automatically by Jules for task [892148545898273141](https://jules.google.com/task/892148545898273141) started by @frankvdb7*