### PR TITLE
Fix SynchronizedList Locking Bug during Enumeration

### DIFF
--- a/.jules/patchwork.md
+++ b/.jules/patchwork.md
@@ -3,3 +3,9 @@
 **Cause:** The code was modifying the `iEnd` index variable when `includeEnd` was true, and then using `iEnd + strEnd.Length` to calculate the starting index for the remainder string. This resulted in skipping the delimiter's length twice.
 **Fix:** Decoupled the extracted result's length from the remainder's starting index calculation.
 **Prevention:** Avoid reusing and modifying index variables for different purposes (result extraction vs. remainder calculation). Added explicit unit tests for both parts of the returned array.
+
+## 2025-05-15 - [SynchronizedList Synchronization Mismatch]
+**Bug:** `SynchronizedList<T>` enumerator did not correctly lock the collection against modifications from other threads.
+**Cause:** The code was using the .NET 9 `System.Threading.Lock` type for `SyncRoot` but using `Monitor.Enter/Exit` (via the `SynchronizedEnumerator` constructor/Dispose) for enumeration locking. These use different underlying mechanisms, allowing other threads to acquire the lock via `lock(SyncRoot)` while the enumerator thought it held it.
+**Fix:** Reverted `SyncRoot` to a standard `object` to ensure consistent `Monitor`-based locking across all operations. Also changed `SynchronizedEnumerator` from a `struct` to a `class` to safely manage lock state and disposal.
+**Prevention:** Avoid mixing new .NET 9 `Lock` types with legacy `Monitor` methods or `lock` statements if the lock must be held across method boundaries. Ensure the same lock object and mechanism are used throughout the class.

--- a/Hagalaz.Collections.Tests/SynchronizedListTests.cs
+++ b/Hagalaz.Collections.Tests/SynchronizedListTests.cs
@@ -46,5 +46,42 @@ namespace Hagalaz.Collections.Tests
             System.Threading.Tasks.Task.WaitAll(tasks);
             Assert.AreEqual(100, list.Count);
         }
+
+        [TestMethod]
+        public void TestEnumerationLocksCollection()
+        {
+            var list = new SynchronizedList<int>();
+            list.Add(1);
+
+            var enumerator = ((System.Collections.Generic.IEnumerable<int>)list).GetEnumerator();
+            try
+            {
+                // The enumerator should hold the lock now.
+                // We try to acquire the lock from another thread.
+                bool lockAcquired = false;
+                var task = System.Threading.Tasks.Task.Factory.StartNew(() =>
+                {
+                    // Use Monitor.TryEnter to check if the lock is available.
+                    // It should fail because the enumerator thread holds it.
+                    lockAcquired = System.Threading.Monitor.TryEnter(list.SyncRoot, 1000);
+                    if (lockAcquired)
+                    {
+                        System.Threading.Monitor.Exit(list.SyncRoot);
+                    }
+                }, System.Threading.Tasks.TaskCreationOptions.LongRunning);
+
+                task.Wait();
+
+                Assert.IsFalse(lockAcquired, "Lock should be held by the enumerator and not acquirable by others.");
+
+                // Ensure MoveNext still works
+                Assert.IsTrue(enumerator.MoveNext());
+                Assert.AreEqual(1, enumerator.Current);
+            }
+            finally
+            {
+                enumerator.Dispose();
+            }
+        }
     }
 }

--- a/Hagalaz.Collections/SynchronizedList.cs
+++ b/Hagalaz.Collections/SynchronizedList.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
-#pragma warning disable CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement
 
 namespace Hagalaz.Collections
 {
@@ -18,6 +17,7 @@ namespace Hagalaz.Collections
     public class SynchronizedList<T> : IList<T>
     {
         private readonly List<T> _list;
+        private readonly object _syncRoot = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SynchronizedList{T}"/> class that is empty and has the default initial capacity.
@@ -27,7 +27,7 @@ namespace Hagalaz.Collections
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see cref="SynchronizedList{T}"/>.
         /// </summary>
-        public Lock SyncRoot { get; } = new();
+        public object SyncRoot => _syncRoot;
 
         /// <summary>
         /// Gets the number of elements contained in the <see cref="SynchronizedList{T}"/>.
@@ -204,22 +204,22 @@ namespace Hagalaz.Collections
     /// This enumerator acquires a lock on the sync root of the collection when it is created and releases
     /// the lock when it is disposed. This prevents the collection from being modified while it is being enumerated.
     /// </remarks>
-    public readonly struct SynchronizedEnumerator<T> : IEnumerator<T>
+    public sealed class SynchronizedEnumerator<T> : IEnumerator<T>
     {
         private readonly IEnumerator<T> _enumerator;
-        private readonly Lock _root;
+        private readonly object _root;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SynchronizedEnumerator{T}"/> struct.
+        /// Initializes a new instance of the <see cref="SynchronizedEnumerator{T}"/> class.
         /// The constructor acquires a lock on the provided sync root.
         /// </summary>
         /// <param name="enumerator">The underlying enumerator from the collection.</param>
         /// <param name="root">The synchronization lock object.</param>
-        public SynchronizedEnumerator(IEnumerator<T> enumerator, Lock root)
+        public SynchronizedEnumerator(IEnumerator<T> enumerator, object root)
         {
             _enumerator = enumerator;
             _root = root;
-            
+
             // entering lock in constructor
             Monitor.Enter(_root);
         }


### PR DESCRIPTION
This PR fixes a critical thread-safety bug in `SynchronizedList<T>`. The issue was caused by a mismatch between the new .NET 9 `Lock` type used for the `SyncRoot` and the legacy `Monitor.Enter/Exit` methods used by the enumerator to hold a lock across method calls. 

By reverting to a standard `object` for synchronization, we ensure that all operations (Add, Remove, Enumeration) use the same underlying locking mechanism. Additionally, the `SynchronizedEnumerator` was changed to a class to prevent issues related to copying synchronization state in a value type.

Verified with a new test case that simulates concurrent modification attempts during enumeration.

---
*PR created automatically by Jules for task [4020534114769541055](https://jules.google.com/task/4020534114769541055) started by @frankvdb7*