### PR TITLE
Fix NullReferenceException on deconstruction in StatsController.GetAll

### DIFF
--- a/.jules/patchwork.md
+++ b/.jules/patchwork.md
@@ -9,3 +9,9 @@
 **Cause:** Incorrect usage of the MassTransit `GetResponse` return value in the controller action.
 **Fix:** Changed the return statement to use `response.Message.Result` instead of `response`.
 **Prevention:** Always extract the actual DTO (`Result` property) from MassTransit/Mediator response messages before returning them in a Web API controller to match the `ActionResult<T>` signature. Added unit tests for `StatsController` to verify correct return types.
+
+## 2025-05-16 - [StatsController.GetAll NullReferenceException on Deconstruction]
+**Bug:** The `StatsController.GetAll` method would crash with a `NullReferenceException` if the request body was empty.
+**Cause:** Attempting to deconstruct a null `GetAllCharacterStatisticsRequest` object (`var (sort, filter) = request;`).
+**Fix:** Added an explicit null check for the `request` parameter and return `BadRequest()` if it is null.
+**Prevention:** Always perform null checks on `[FromBody]` parameters in ASP.NET Core controllers before deconstructing or accessing their properties. Added a unit test to verify that a null request returns `BadRequest`.

--- a/Hagalaz.Services.Characters.Tests/Controllers/StatsControllerTests.cs
+++ b/Hagalaz.Services.Characters.Tests/Controllers/StatsControllerTests.cs
@@ -119,5 +119,15 @@ namespace Hagalaz.Services.Characters.Tests.Controllers
             var okResult = (OkObjectResult)result.Result;
             Assert.AreEqual(expectedResult, okResult.Value);
         }
+
+        [TestMethod]
+        public async Task GetAll_WithNullRequest_ReturnsBadRequest()
+        {
+            // Act
+            var result = await _controller.GetAll(null!);
+
+            // Assert
+            Assert.IsInstanceOfType(result.Result, typeof(BadRequestResult));
+        }
     }
 }

--- a/Hagalaz.Services.Characters/Controllers/StatsController.cs
+++ b/Hagalaz.Services.Characters/Controllers/StatsController.cs
@@ -46,6 +46,12 @@ namespace Hagalaz.Services.Characters.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<GetAllCharacterStatisticsResult>> GetAll([FromBody] GetAllCharacterStatisticsRequest request)
         {
+            // Guard against null request to prevent NullReferenceException on deconstruction.
+            if (request == null)
+            {
+                return BadRequest();
+            }
+
             var (sort, filter) = request;
             var response = await _getAllCharacterStatisticsQuery.GetResponse<GetAllCharacterStatisticsResult>(new GetAllCharacterStatisticsQuery
             {


### PR DESCRIPTION
The `StatsController.GetAll` method was susceptible to a `NullReferenceException` if the `[FromBody]` request object was null (e.g., when an empty request body was sent). This occurred because the code attempted to deconstruct the null object immediately. This PR adds a guard clause to return `BadRequest` in such cases and includes a corresponding unit test.

---
*PR created automatically by Jules for task [9279797956437924016](https://jules.google.com/task/9279797956437924016) started by @frankvdb7*