### PR TITLE
Fix redundant DefenceExp in OverallExperience calculation

### DIFF
--- a/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
+++ b/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Hagalaz.Services.Characters.Model;
+
+namespace Hagalaz.Services.Characters.Tests.Model
+{
+    [TestClass]
+    public class CharactersStatisticsDtoTests
+    {
+        [TestMethod]
+        public void OverallExperience_ShouldSumAllSkillsExactlyOnce()
+        {
+            // Arrange
+            var dto = new CharactersStatisticsDto
+            {
+                DisplayName = "Test Player",
+                AgilityExp = 1,
+                AttackExp = 2,
+                ConstitutionExp = 4,
+                ConstructionExp = 8,
+                CookingExp = 16,
+                CraftingExp = 32,
+                DefenceExp = 64, // This is the one suspected to be added twice
+                DungeoneeringExp = 128,
+                FarmingExp = 256,
+                FiremakingExp = 512,
+                FishingExp = 1024,
+                FletchingExp = 2048,
+                HerbloreExp = 4096,
+                HunterExp = 8192,
+                MagicExp = 16384,
+                MiningExp = 32768,
+                PrayerExp = 65536,
+                RangeExp = 131072,
+                RunecraftingExp = 262144,
+                SlayerExp = 524288,
+                SmithingExp = 1048576,
+                StrengthExp = 2097152,
+                SummoningExp = 4194304,
+                ThievingExp = 8388608,
+                WoodcuttingExp = 16777216
+            };
+
+            // Sum of 2^0 to 2^24 is 2^25 - 1 = 33554431
+            // If DefenceExp (64) is added twice, it will be 33554431 + 64 = 33554495
+            double expectedExperience = 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 + 512 + 1024 + 2048 + 4096 + 8192 + 16384 + 32768 + 65536 + 131072 + 262144 + 524288 + 1048576 + 2097152 + 4194304 + 8388608 + 16777216;
+
+            // Act
+            var actualExperience = dto.OverallExperience;
+
+            // Assert
+            Assert.AreEqual(expectedExperience, actualExperience, "OverallExperience should be the sum of all individual skill experiences.");
+        }
+    }
+}

--- a/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
+++ b/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
@@ -19,7 +19,7 @@ namespace Hagalaz.Services.Characters.Tests.Model
                 ConstructionExp = 8,
                 CookingExp = 16,
                 CraftingExp = 32,
-                DefenceExp = 64, // This is the one suspected to be added twice
+                DefenceExp = 64,
                 DungeoneeringExp = 128,
                 FarmingExp = 256,
                 FiremakingExp = 512,
@@ -40,8 +40,6 @@ namespace Hagalaz.Services.Characters.Tests.Model
                 WoodcuttingExp = 16777216
             };
 
-            // Sum of 2^0 to 2^24 is 2^25 - 1 = 33554431
-            // If DefenceExp (64) is added twice, it will be 33554431 + 64 = 33554495
             double expectedExperience = 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 + 512 + 1024 + 2048 + 4096 + 8192 + 16384 + 32768 + 65536 + 131072 + 262144 + 524288 + 1048576 + 2097152 + 4194304 + 8388608 + 16777216;
 
             // Act
@@ -49,6 +47,51 @@ namespace Hagalaz.Services.Characters.Tests.Model
 
             // Assert
             Assert.AreEqual(expectedExperience, actualExperience, "OverallExperience should be the sum of all individual skill experiences.");
+        }
+
+        [TestMethod]
+        public void OverallExperience_ShouldNotOverflow_WhenTotalExperienceExceedsIntMaxValue()
+        {
+            // Arrange
+            int largeValue = 200_000_000;
+            var dto = new CharactersStatisticsDto
+            {
+                DisplayName = "Test Player",
+                AgilityExp = largeValue,
+                AttackExp = largeValue,
+                ConstitutionExp = largeValue,
+                ConstructionExp = largeValue,
+                CookingExp = largeValue,
+                CraftingExp = largeValue,
+                DefenceExp = largeValue,
+                DungeoneeringExp = largeValue,
+                FarmingExp = largeValue,
+                FiremakingExp = largeValue,
+                FishingExp = largeValue,
+                FletchingExp = largeValue,
+                HerbloreExp = largeValue,
+                HunterExp = largeValue,
+                MagicExp = largeValue,
+                MiningExp = largeValue,
+                PrayerExp = largeValue,
+                RangeExp = largeValue,
+                RunecraftingExp = largeValue,
+                SlayerExp = largeValue,
+                SmithingExp = largeValue,
+                StrengthExp = largeValue,
+                SummoningExp = largeValue,
+                ThievingExp = largeValue,
+                WoodcuttingExp = largeValue
+            };
+
+            // 25 skills * 200,000,000 = 5,000,000,000 (exceeds int.MaxValue which is ~2.14B)
+            double expectedExperience = 25.0 * largeValue;
+
+            // Act
+            var actualExperience = dto.OverallExperience;
+
+            // Assert
+            Assert.AreEqual(expectedExperience, actualExperience, "OverallExperience should handle values exceeding int.MaxValue without overflowing.");
         }
     }
 }

--- a/Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs
+++ b/Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs
@@ -65,11 +65,7 @@ namespace Hagalaz.Services.Characters.Mediator.Consumers
             type switch
             {
                 CharacterStatisticType.Overall => _mapper.ProjectTo<CharactersStatisticsDto>(statsQuery)
-                    .OrderByDescending(dto => dto.AgilityExp + dto.AttackExp + dto.ConstitutionExp + dto.ConstructionExp + dto.CookingExp + dto.CraftingExp +
-                                              dto.DefenceExp + dto.DefenceExp + dto.DungeoneeringExp + dto.FarmingExp + dto.FiremakingExp + dto.FishingExp +
-                                              dto.FletchingExp + dto.HerbloreExp + dto.HunterExp + dto.MagicExp + dto.MiningExp + dto.PrayerExp + dto.RangeExp +
-                                              dto.RunecraftingExp + dto.SlayerExp + dto.SmithingExp + dto.StrengthExp + dto.SummoningExp + dto.ThievingExp +
-                                              dto.WoodcuttingExp)
+                    .OrderByDescending(dto => dto.OverallExperience)
                     .Select(dto => new CharacterStatisticCollectionDto
                     {
                         DisplayName = dto.DisplayName,

--- a/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
+++ b/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
@@ -61,7 +61,7 @@ namespace Hagalaz.Services.Characters.Model
             RunecraftingLevel + SlayerLevel + SmithingLevel + StrengthLevel + SummoningLevel + ThievingLevel + WoodcuttingLevel;
 
         public double OverallExperience =>
-            AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DungeoneeringExp + FarmingExp +
+            (double)AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DungeoneeringExp + FarmingExp +
             FiremakingExp + FishingExp + FletchingExp + HerbloreExp + HunterExp + MagicExp + MiningExp + PrayerExp + RangeExp + RunecraftingExp + SlayerExp +
             SmithingExp + StrengthExp + SummoningExp + ThievingExp + WoodcuttingExp;
     }

--- a/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
+++ b/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
@@ -61,7 +61,7 @@ namespace Hagalaz.Services.Characters.Model
             RunecraftingLevel + SlayerLevel + SmithingLevel + StrengthLevel + SummoningLevel + ThievingLevel + WoodcuttingLevel;
 
         public double OverallExperience =>
-            AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DefenceExp + DungeoneeringExp + FarmingExp +
+            AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DungeoneeringExp + FarmingExp +
             FiremakingExp + FishingExp + FletchingExp + HerbloreExp + HunterExp + MagicExp + MiningExp + PrayerExp + RangeExp + RunecraftingExp + SlayerExp +
             SmithingExp + StrengthExp + SummoningExp + ThievingExp + WoodcuttingExp;
     }

--- a/Hagalaz.Services.Characters/Profiles/CharacterStatisticsProfile.cs
+++ b/Hagalaz.Services.Characters/Profiles/CharacterStatisticsProfile.cs
@@ -15,8 +15,16 @@ namespace Hagalaz.Services.Characters.Profiles
         {
             CreateMap<CharactersStatistic, CharactersStatisticsDto>()
                 .ForMember(dto => dto.DisplayName, opt => opt.MapFrom(src => src.Master.DisplayName))
-                .ForMember(dto => dto.OverallExperience, opt => opt.Ignore())
-                .ForMember(dto => dto.OverallLevel, opt => opt.Ignore());
+                .ForMember(dto => dto.OverallExperience, opt => opt.MapFrom(src =>
+                    (double)src.AgilityExp + src.AttackExp + src.ConstitutionExp + src.ConstructionExp + src.CookingExp + src.CraftingExp + src.DefenceExp +
+                    src.DungeoneeringExp + src.FarmingExp + src.FiremakingExp + src.FishingExp + src.FletchingExp + src.HerbloreExp + src.HunterExp +
+                    src.MagicExp + src.MiningExp + src.PrayerExp + src.RangeExp + src.RunecraftingExp + src.SlayerExp + src.SmithingExp +
+                    src.StrengthExp + src.SummoningExp + src.ThievingExp + src.WoodcuttingExp))
+                .ForMember(dto => dto.OverallLevel, opt => opt.MapFrom(src =>
+                    (int)src.AgilityLevel + src.AttackLevel + src.ConstitutionLevel + src.ConstructionLevel + src.CookingLevel + src.CraftingLevel + src.DefenceLevel +
+                    src.DungeoneeringLevel + src.FarmingLevel + src.FiremakingLevel + src.FishingLevel + src.FletchingLevel + src.HerbloreLevel + src.HunterLevel +
+                    src.MagicLevel + src.MiningLevel + src.PrayerLevel + src.RangeLevel + src.RunecraftingLevel + src.SlayerLevel + src.SmithingLevel +
+                    src.StrengthLevel + src.SummoningLevel + src.ThievingLevel + src.WoodcuttingLevel));
 
             CreateMap<CharactersStatistic, Statistics>()
                 .ForMember(dest => dest.AttackLevel, opt => opt.MapFrom(src => (int)src.AttackLevel))


### PR DESCRIPTION
Fixed a logic error in `Hagalaz.Services.Characters` where `DefenceExp` was counted twice in the overall experience calculation and sorting.

Changes:
- Modified `Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs` to remove the duplicate `DefenceExp` in the `OverallExperience` getter.
- Updated `Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs` to use `dto.OverallExperience` for sorting, eliminating another instance of the manual duplicate summation.
- Added `Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs` with a test case that uses unique powers of 2 for each skill experience to prove every skill is counted exactly once.
- Verified backend functionality with `dotnet test Hagalaz.sln`.
- Verified frontend build integrity with `pnpm build` in `Hagalaz.Web.App`.

---
*PR created automatically by Jules for task [15477910271334610782](https://jules.google.com/task/15477910271334610782) started by @frankvdb7*