### PR TITLE
Fix 5 critical path warnings with test coverage

### DIFF
--- a/Hagalaz.Cache.Abstractions/Types/IAnimationType.cs
+++ b/Hagalaz.Cache.Abstractions/Types/IAnimationType.cs
@@ -8,7 +8,6 @@
         /// <summary>
         /// Gets the unique identifier for this animation type.
         /// </summary>
-        int Id { get; }
 
         /// <summary>
         /// Gets the priority level of the animation. Higher priority animations can override lower priority ones.

--- a/Hagalaz.Cache.Abstractions/Types/IItemType.cs
+++ b/Hagalaz.Cache.Abstractions/Types/IItemType.cs
@@ -12,7 +12,6 @@ namespace Hagalaz.Cache.Abstractions.Types
         /// <summary>
         /// Gets the unique identifier for this item type.
         /// </summary>
-        int Id { get; }
 
         /// <summary>
         /// Gets the name of the item as it appears in-game.

--- a/Hagalaz.Cache.Abstractions/Types/INpcType.cs
+++ b/Hagalaz.Cache.Abstractions/Types/INpcType.cs
@@ -9,7 +9,6 @@
         /// <summary>
         /// Gets the unique identifier for this NPC type.
         /// </summary>
-        int Id { get; }
 
         /// <summary>
         /// Gets or sets the combat level of the NPC. This value may be adjusted after being loaded from the cache.

--- a/Hagalaz.Cache.Abstractions/Types/IObjectType.cs
+++ b/Hagalaz.Cache.Abstractions/Types/IObjectType.cs
@@ -9,7 +9,6 @@
         /// <summary>
         /// Gets the unique identifier for this object type.
         /// </summary>
-        int Id { get; }
 
         /// <summary>
         /// Gets or sets the name of the object as it appears in-game.

--- a/Hagalaz.Cache.Abstractions/Types/Providers/IMapProvider.cs
+++ b/Hagalaz.Cache.Abstractions/Types/Providers/IMapProvider.cs
@@ -7,16 +7,16 @@ namespace Hagalaz.Cache.Abstractions.Types.Providers
     public class DecodePartRequest
     {
         public int RegionID { get; set; }
-        public int[] XteaKeys { get; set; }
+        public int[] XteaKeys { get; set; } = null!;
         public int MinX { get; set; }
         public int MinY { get; set; }
         public int MaxX { get; set; }
         public int MaxY { get; set; }
         public int PartZ { get; set; }
         public int PartRotation { get; set; }
-        public CalculateObjectPartRotation PartRotationCallback { get; set; }
-        public ObjectDecoded Callback { get; set; }
-        public ImpassibleTerrainDecoded GroundCallback { get; set; }
+        public CalculateObjectPartRotation PartRotationCallback { get; set; } = null!;
+        public ObjectDecoded Callback { get; set; } = null!;
+        public ImpassibleTerrainDecoded GroundCallback { get; set; } = null!;
     }
 
     public interface IMapProvider : ITypeProvider<IMapType>

--- a/Hagalaz.Cache.Abstractions/Types/Providers/IMapProvider.cs
+++ b/Hagalaz.Cache.Abstractions/Types/Providers/IMapProvider.cs
@@ -7,7 +7,7 @@ namespace Hagalaz.Cache.Abstractions.Types.Providers
     public class DecodePartRequest
     {
         public int RegionID { get; set; }
-        public int[] XteaKeys { get; set; } = null!;
+        public int[] XteaKeys { get; set; } = [];
         public int MinX { get; set; }
         public int MinY { get; set; }
         public int MaxX { get; set; }

--- a/Hagalaz.Cache.Tests/DecodePartRequestTests.cs
+++ b/Hagalaz.Cache.Tests/DecodePartRequestTests.cs
@@ -1,0 +1,23 @@
+using Hagalaz.Cache.Abstractions.Types.Providers;
+using Xunit;
+
+namespace Hagalaz.Cache.Tests
+{
+    public class DecodePartRequestTests
+    {
+        [Fact]
+        public void Properties_AreInitializable()
+        {
+            // Arrange
+            var request = new DecodePartRequest();
+
+            // Act
+            request.RegionID = 123;
+            request.XteaKeys = new int[] { 1, 2, 3, 4 };
+
+            // Assert
+            Assert.Equal(123, request.RegionID);
+            Assert.Equal(new int[] { 1, 2, 3, 4 }, request.XteaKeys);
+        }
+    }
+}

--- a/Hagalaz.Cache.Tests/TypeInheritanceTests.cs
+++ b/Hagalaz.Cache.Tests/TypeInheritanceTests.cs
@@ -1,0 +1,41 @@
+using Hagalaz.Cache.Abstractions.Types;
+using NSubstitute;
+using Xunit;
+
+namespace Hagalaz.Cache.Tests
+{
+    public class TypeInheritanceTests
+    {
+        [Fact]
+        public void IItemType_HasAccessToId()
+        {
+            var item = Substitute.For<IItemType>();
+            item.Id.Returns(1);
+            Assert.Equal(1, item.Id);
+        }
+
+        [Fact]
+        public void INpcType_HasAccessToId()
+        {
+            var npc = Substitute.For<INpcType>();
+            npc.Id.Returns(2);
+            Assert.Equal(2, npc.Id);
+        }
+
+        [Fact]
+        public void IObjectType_HasAccessToId()
+        {
+            var obj = Substitute.For<IObjectType>();
+            obj.Id.Returns(3);
+            Assert.Equal(3, obj.Id);
+        }
+
+        [Fact]
+        public void IAnimationType_HasAccessToId()
+        {
+            var anim = Substitute.For<IAnimationType>();
+            anim.Id.Returns(4);
+            Assert.Equal(4, anim.Id);
+        }
+    }
+}

--- a/Hagalaz.Game.Abstractions/Model/Creatures/ICreatureRenderInformation.cs
+++ b/Hagalaz.Game.Abstractions/Model/Creatures/ICreatureRenderInformation.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Gets the current animation being performed by the creature.
         /// </summary>
-        IAnimation CurrentAnimation { get; }
+        IAnimation? CurrentAnimation { get; }
 
         /// <summary>
         /// Gets a value indicating whether a visual update (e.g., for appearance changes) is required for the creature.

--- a/Hagalaz.Services.GameWorld.Tests/CharacterRenderInformationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CharacterRenderInformationTests.cs
@@ -25,6 +25,7 @@ namespace Hagalaz.Services.GameWorld.Tests
         private ICharacterStore _characterStore = null!;
         private ICharacterLocationService _locationService = null!;
         private CharacterRenderInformation _renderInfo = null!;
+        private ILocation _location = null!;
 
         [TestInitialize]
         public void Setup()
@@ -33,8 +34,12 @@ namespace Hagalaz.Services.GameWorld.Tests
             _serviceProvider = Substitute.For<IServiceProvider>();
             _characterStore = Substitute.For<ICharacterStore>();
             _locationService = Substitute.For<ICharacterLocationService>();
+            _location = Substitute.For<ILocation>();
 
             _owner.ServiceProvider.Returns(_serviceProvider);
+            _owner.Location.Returns(_location);
+            _location.Clone().Returns(_location);
+
             _serviceProvider.GetService(typeof(ICharacterStore)).Returns(_characterStore);
             _serviceProvider.GetService(typeof(ICharacterLocationService)).Returns(_locationService);
 
@@ -44,16 +49,11 @@ namespace Hagalaz.Services.GameWorld.Tests
         [TestMethod]
         public void OnRegistered_InitializesLastLocationAndLocalCharacters()
         {
-            // Arrange
-            var location = Substitute.For<ILocation>();
-            _owner.Location.Returns(location);
-            location.Clone().Returns(location);
-
             // Act
             _renderInfo.OnRegistered();
 
             // Assert
-            Assert.AreEqual(location, _renderInfo.LastLocation);
+            Assert.AreEqual(_location, _renderInfo.LastLocation);
             Assert.Contains(_owner, _renderInfo.LocalCharacters);
             Assert.IsTrue(_renderInfo.IsInViewport(_owner.Index));
         }
@@ -62,9 +62,6 @@ namespace Hagalaz.Services.GameWorld.Tests
         public void Reset_ClearsFlagsAndUpdatesLocation()
         {
             // Arrange
-            var location = Substitute.For<ILocation>();
-            _owner.Location.Returns(location);
-            location.Clone().Returns(location);
             _renderInfo.ScheduleFlagUpdate(Hagalaz.Game.Abstractions.Model.Creatures.Characters.UpdateFlags.Animation);
             _renderInfo.ScheduleItemAppearanceUpdate();
 
@@ -74,7 +71,7 @@ namespace Hagalaz.Services.GameWorld.Tests
             // Assert
             Assert.IsFalse(_renderInfo.FlagUpdateRequired);
             Assert.IsFalse(_renderInfo.ItemAppearanceUpdateRequired);
-            _locationService.Received(1).SetLocationByIndex(_owner.Index, location);
+            _locationService.Received(1).SetLocationByIndex(_owner.Index, _location);
         }
 
         [TestMethod]
@@ -121,6 +118,14 @@ namespace Hagalaz.Services.GameWorld.Tests
             // IdleOnThisLoop is moved to Idle, then cleared
             Assert.IsTrue(_renderInfo.IsIdle(5));
             Assert.IsFalse(_renderInfo.IsIdleOnThisLoop(5));
+        }
+
+        [TestMethod]
+        public void Properties_AreSafe_AfterConstruction()
+        {
+            // Assert
+            Assert.IsNull(_renderInfo.CurrentAnimation, "CurrentAnimation should be null by default.");
+            Assert.IsNotNull(_renderInfo.LastLocation, "LastLocation should be initialized in constructor.");
         }
     }
 }

--- a/Hagalaz.Services.GameWorld.Tests/Model/Creatures/Combat/Experimental/Combat/CombatSelectorsTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Model/Creatures/Combat/Experimental/Combat/CombatSelectorsTests.cs
@@ -1,0 +1,57 @@
+using Hagalaz.Services.GameWorld.Model.Creatures.Combat.Experimental.Combat;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+
+namespace Hagalaz.Services.GameWorld.Tests.Model.Creatures.Combat.Experimental.Combat
+{
+    [TestClass]
+    public class CombatSelectorsTests
+    {
+        [TestMethod]
+        public void ProbabilitySelector_WithValidRotations_ReturnsRotation()
+        {
+            // Arrange
+            var rotation1 = Substitute.For<ICombatRotation>();
+            rotation1.Probability.Returns(1.0);
+            var rotations = new List<ICombatRotation> { rotation1 };
+            var selector = CombatSelectors.ProbabilitySelector<ICombatRotation>();
+
+            // Act
+            var result = selector(rotations);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(rotation1, result);
+        }
+
+        [TestMethod]
+        public void ProbabilitySelector_WithSmallProbabilities_ReturnsRotation()
+        {
+            // Arrange
+            var rotation1 = Substitute.For<ICombatRotation>();
+            rotation1.Probability.Returns(0.1);
+            var rotations = new List<ICombatRotation> { rotation1 };
+            var selector = CombatSelectors.ProbabilitySelector<ICombatRotation>();
+
+            // Act
+            var result = selector(rotations);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(rotation1, result);
+        }
+
+        [TestMethod]
+        public void ProbabilitySelector_WithEmptyList_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var rotations = new List<ICombatRotation>();
+            var selector = CombatSelectors.ProbabilitySelector<ICombatRotation>();
+
+            // Act & Assert
+            Assert.ThrowsExactly<InvalidOperationException>(() => selector(rotations));
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
@@ -105,10 +105,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 characterKiller = character;
             }
 
-            characterKiller?.SendChatMessage(string.Format(
-                GameStrings.ResourceManager.GetString(GameStrings.Combat_VictorKillMessage + RandomStatic.Generator.Next(9)),
-                _character.DisplayName));
-            // TODO
+            var format = GameStrings.ResourceManager.GetString(GameStrings.Combat_VictorKillMessage + RandomStatic.Generator.Next(9));
+            if (format != null)
+            {
+                characterKiller?.SendChatMessage(string.Format(format, _character.DisplayName));
+            }
             //var database = ServiceLocator.Current.GetInstance<ISqlDatabaseManager>();
             //database.ExecuteAsync(new ActivityLogQuery(characterKiller.MasterId, "Player Kill", "I have defeated " + _character.DisplayName + " in combat."));
 

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
@@ -106,9 +106,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             }
 
             var format = GameStrings.ResourceManager.GetString(GameStrings.Combat_VictorKillMessage + RandomStatic.Generator.Next(9));
-            if (format != null)
+            if (characterKiller != null && format != null)
             {
-                characterKiller?.SendChatMessage(string.Format(format, _character.DisplayName));
+                characterKiller.SendChatMessage(string.Format(format, _character.DisplayName));
             }
             //var database = ServiceLocator.Current.GetInstance<ISqlDatabaseManager>();
             //database.ExecuteAsync(new ActivityLogQuery(characterKiller.MasterId, "Player Kill", "I have defeated " + _character.DisplayName + " in combat."));

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterRenderInformation.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterRenderInformation.cs
@@ -108,7 +108,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             _currentGraphics = new IGraphic[4];
             _characterStore = renderable.ServiceProvider.GetRequiredService<ICharacterStore>();
             _characterLocationMap = renderable.ServiceProvider.GetRequiredService<ICharacterLocationService>();
-            LastLocation = renderable.Location?.Clone() ?? null!;
+            LastLocation = renderable.Location.Clone();
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterRenderInformation.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterRenderInformation.cs
@@ -54,7 +54,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Contains last character location.
         /// </summary>
         /// <value>The last location.</value>
-        public ILocation LastLocation { get; private set; } = default!;
+        public ILocation LastLocation { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether [large scene view].
@@ -98,7 +98,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Contains current animation.
         /// </summary>
         /// <value>The current animation.</value>
-        public IAnimation CurrentAnimation { get; private set; }
+        public IAnimation? CurrentAnimation { get; private set; }
 
         public CharacterRenderInformation(ICharacter renderable)
         {
@@ -108,6 +108,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             _currentGraphics = new IGraphic[4];
             _characterStore = renderable.ServiceProvider.GetRequiredService<ICharacterStore>();
             _characterLocationMap = renderable.ServiceProvider.GetRequiredService<ICharacterLocationService>();
+            LastLocation = renderable.Location?.Clone() ?? null!;
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Combat/Experimental/Combat/CombatSelectors.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Combat/Experimental/Combat/CombatSelectors.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Hagalaz.Game.Extensions;
@@ -17,7 +17,13 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Combat.Experimental.Combat
         public static Func<IList<T>, T> ProbabilitySelector<T>() where T : ICombatRotation =>
             (rotations) =>
             {
-                double hitValue = Random.Shared.Next(rotations.Sum(r => r.Probability));
+                if (rotations.Count == 0)
+                {
+                    throw new InvalidOperationException("Cannot select a rotation from an empty list.");
+                }
+
+                int totalProbability = (int)rotations.Sum(r => r.Probability);
+                double hitValue = Random.Shared.Next(Math.Max(1, totalProbability));
                 double runningValue = 0.0;
                 foreach (T rotation in rotations)
                 {
@@ -28,7 +34,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Combat.Experimental.Combat
                     }
                 }
 
-                return default;
+                return rotations[0];
             };
     }
 }

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Combat/Experimental/Combat/CombatSelectors.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Combat/Experimental/Combat/CombatSelectors.cs
@@ -22,8 +22,8 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Combat.Experimental.Combat
                     throw new InvalidOperationException("Cannot select a rotation from an empty list.");
                 }
 
-                int totalProbability = (int)rotations.Sum(r => r.Probability);
-                double hitValue = Random.Shared.Next(Math.Max(1, totalProbability));
+                double totalProbability = rotations.Sum(r => r.Probability);
+                double hitValue = Random.Shared.NextDouble() * totalProbability;
                 double runningValue = 0.0;
                 foreach (T rotation in rotations)
                 {

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Combat/Experimental/Combat/CombatSelectors.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Combat/Experimental/Combat/CombatSelectors.cs
@@ -34,7 +34,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Combat.Experimental.Combat
                     }
                 }
 
-                return rotations[0];
+                return rotations[^1];
             };
     }
 }

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Npcs/NpcRenderInformation.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Npcs/NpcRenderInformation.cs
@@ -46,7 +46,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Npcs
         /// <summary>
         /// Contains current animation.
         /// </summary>
-        public IAnimation CurrentAnimation { get; private set; }
+        public IAnimation? CurrentAnimation { get; private set; }
 
         /// <summary>
         /// Create's new rendering information instance.
@@ -56,6 +56,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Npcs
         {
             _owner = owner;
             _currentGraphics = new IGraphic[4];
+            LastLocation = owner.Location?.Clone() ?? null!;
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Npcs/NpcRenderInformation.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Npcs/NpcRenderInformation.cs
@@ -56,7 +56,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Npcs
         {
             _owner = owner;
             _currentGraphics = new IGraphic[4];
-            LastLocation = owner.Location?.Clone() ?? null!;
+            LastLocation = owner.Location.Clone();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes 5 high-priority compiler and analyzer warnings in critical runtime paths.

Key changes include:
1. CombatSelectors.cs (CS8603): Added empty list validation and a fallback return.
2. CharacterCombat.cs (CS8604): Added null validation for localized resource strings.
3. Rendering Information (CS8618/CS8766): Initialized LastLocation and updated ICreatureRenderInformation.CurrentAnimation to be nullable.
4. IMapProvider.cs (CS8618): Initialized mandatory-injection properties with null!.
5. Cache Interfaces (CS0108): Removed redundant Id property declarations in derived interfaces.

Supported by new unit tests and verified with full solution test run.

---
*PR created automatically by Jules for task [17700814706816625695](https://jules.google.com/task/17700814706816625695) started by @frankvdb7*