### PR TITLE
Fix master WorldId and contact settings in AddRemoveContactConsumer

### DIFF
--- a/Hagalaz.Services.Contacts.Tests/AddRemoveContactConsumerTests.cs
+++ b/Hagalaz.Services.Contacts.Tests/AddRemoveContactConsumerTests.cs
@@ -112,5 +112,39 @@ namespace Hagalaz.Services.Contacts.Tests
                 m.Contact.Settings != null && m.Contact.Settings.Availability == ContactAvailability.Friends
             ), It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [TestMethod]
+        public async Task Consume_AddContactRequest_HandlesNullAvailabilityGracefully()
+        {
+            // Arrange
+            uint masterId = 100;
+            uint contactId = 200;
+            string contactName = "ContactUser";
+
+            var masterCharacter = new Hagalaz.Services.Contacts.Services.Model.CharacterDto { MasterId = masterId, DisplayName = "Master" };
+            var contactCharacter = new Hagalaz.Services.Contacts.Services.Model.CharacterDto { MasterId = contactId, DisplayName = contactName };
+
+            _characterServiceMock.Setup(x => x.FindCharacterByIdAsync(masterId)).ReturnsAsync(masterCharacter);
+            _characterServiceMock.Setup(x => x.FindCharacterByDisplayName(contactName)).ReturnsAsync(contactCharacter);
+            _contactServiceMock.Setup(x => x.AddContactAsync(masterId, contactId, false)).ReturnsAsync(Hagalaz.Services.Common.Model.Result.Success);
+
+            // contactSettings is NOT null, but Availability IS null
+            var contactSettings = new ContactSettingsDto { Availability = null! };
+            _contactServiceMock.Setup(x => x.FindContactSettingsAsync(contactId)).ReturnsAsync(contactSettings);
+
+            _mapperMock.Setup(m => m.Map<MsgContactDto>(contactCharacter)).Returns(new MsgContactDto { MasterId = contactId, DisplayName = contactName });
+            _mapperMock.Setup(m => m.Map<MsgContactDto>(masterCharacter)).Returns(new MsgContactDto { MasterId = masterId, DisplayName = "Master" });
+
+            var contextMock = new Mock<ConsumeContext<AddContactRequest>>();
+            contextMock.Setup(x => x.Message).Returns(new AddContactRequest { MasterId = masterId, ContactDisplayName = contactName, Ignore = false });
+
+            // Act
+            await _consumer.Consume(contextMock.Object);
+
+            // Assert
+            contextMock.Verify(x => x.Publish(It.Is<ContactAddedMessage>(m =>
+                m.Contact.Settings != null && m.Contact.Settings.Availability == ContactAvailability.Everyone
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
     }
 }

--- a/Hagalaz.Services.Contacts.Tests/AddRemoveContactConsumerTests.cs
+++ b/Hagalaz.Services.Contacts.Tests/AddRemoveContactConsumerTests.cs
@@ -1,0 +1,116 @@
+using AutoMapper;
+using Hagalaz.Contacts.Messages;
+using Hagalaz.Contacts.Messages.Model;
+using Hagalaz.Services.Contacts.Consumers;
+using Hagalaz.Services.Contacts.Services;
+using Hagalaz.Services.Contacts.Store;
+using Hagalaz.Services.Contacts.Store.Model;
+using MassTransit;
+using Moq;
+using ContactDto = Hagalaz.Services.Contacts.Services.Model.ContactDto;
+using MsgContactDto = Hagalaz.Contacts.Messages.Model.ContactDto;
+using ContactSettingsDto = Hagalaz.Services.Contacts.Services.Model.ContactSettingsDto;
+
+namespace Hagalaz.Services.Contacts.Tests
+{
+    [TestClass]
+    public class AddRemoveContactConsumerTests
+    {
+        private Mock<IContactService> _contactServiceMock = null!;
+        private Mock<ICharacterService> _characterServiceMock = null!;
+        private Mock<IMapper> _mapperMock = null!;
+        private ContactSessionStore _contactSessions = null!;
+        private WorldSessionStore _worldSessions = null!;
+        private AddRemoveContactConsumer _consumer = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _contactServiceMock = new Mock<IContactService>();
+            _characterServiceMock = new Mock<ICharacterService>();
+            _mapperMock = new Mock<IMapper>();
+            _contactSessions = new ContactSessionStore();
+            _worldSessions = new WorldSessionStore();
+            _consumer = new AddRemoveContactConsumer(_contactSessions, _worldSessions, _contactServiceMock.Object, _characterServiceMock.Object, _mapperMock.Object);
+        }
+
+        [TestMethod]
+        public async Task Consume_AddContactRequest_PublishesCorrectWorldIdForMaster()
+        {
+            // Arrange
+            uint masterId = 100;
+            uint contactId = 200;
+            string contactName = "ContactUser";
+            int masterWorldId = 1;
+            int contactWorldId = 2;
+
+            var masterCharacter = new Hagalaz.Services.Contacts.Services.Model.CharacterDto { MasterId = masterId, DisplayName = "Master" };
+            var contactCharacter = new Hagalaz.Services.Contacts.Services.Model.CharacterDto { MasterId = contactId, DisplayName = contactName };
+
+            _characterServiceMock.Setup(x => x.FindCharacterByIdAsync(masterId)).ReturnsAsync(masterCharacter);
+            _characterServiceMock.Setup(x => x.FindCharacterByDisplayName(contactName)).ReturnsAsync(contactCharacter);
+            _contactServiceMock.Setup(x => x.AddContactAsync(masterId, contactId, false)).ReturnsAsync(Hagalaz.Services.Common.Model.Result.Success);
+
+            _contactSessions.TryAdd(masterId, new ContactSessionContext(masterId, masterWorldId, "World 1"));
+            _contactSessions.TryAdd(contactId, new ContactSessionContext(contactId, contactWorldId, "World 2"));
+            _worldSessions.TryAdd(masterWorldId, new WorldSessionContext(masterWorldId, "World 1"));
+            _worldSessions.TryAdd(contactWorldId, new WorldSessionContext(contactWorldId, "World 2"));
+
+            _mapperMock.Setup(m => m.Map<MsgContactDto>(contactCharacter)).Returns(new MsgContactDto { MasterId = contactId, DisplayName = contactName });
+            _mapperMock.Setup(m => m.Map<MsgContactDto>(masterCharacter)).Returns(new MsgContactDto { MasterId = masterId, DisplayName = "Master" });
+
+            var contextMock = new Mock<ConsumeContext<AddContactRequest>>();
+            contextMock.Setup(x => x.Message).Returns(new AddContactRequest { MasterId = masterId, ContactDisplayName = contactName, Ignore = false });
+
+            // Act
+            await _consumer.Consume(contextMock.Object);
+
+            // Assert
+            contextMock.Verify(x => x.Publish(It.Is<ContactAddedMessage>(m =>
+                m.Master.MasterId == masterId &&
+                m.Master.WorldId == masterWorldId &&
+                m.Contact.MasterId == contactId &&
+                m.Contact.WorldId == contactWorldId
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task Consume_AddContactRequest_SetsCorrectAvailabilityFromSettings()
+        {
+            // Arrange
+            uint masterId = 100;
+            uint contactId = 200;
+            string contactName = "ContactUser";
+
+            var masterCharacter = new Hagalaz.Services.Contacts.Services.Model.CharacterDto { MasterId = masterId, DisplayName = "Master" };
+            var contactCharacter = new Hagalaz.Services.Contacts.Services.Model.CharacterDto { MasterId = contactId, DisplayName = contactName };
+
+            _characterServiceMock.Setup(x => x.FindCharacterByIdAsync(masterId)).ReturnsAsync(masterCharacter);
+            _characterServiceMock.Setup(x => x.FindCharacterByDisplayName(contactName)).ReturnsAsync(contactCharacter);
+            _contactServiceMock.Setup(x => x.AddContactAsync(masterId, contactId, false)).ReturnsAsync(Hagalaz.Services.Common.Model.Result.Success);
+
+            // Contact has Friends-only availability
+            var contactFriendOfMaster = new ContactDto
+            {
+                MasterId = contactId,
+                DisplayName = contactName,
+                Settings = new ContactSettingsDto { Availability = new ContactSettingsDto.AvailabilitySettingsDto { Friends = true, Everyone = false, Off = false } }
+            };
+            _contactServiceMock.Setup(x => x.FindFriendByIdAsync(contactId, masterId)).ReturnsAsync(contactFriendOfMaster);
+
+            _mapperMock.Setup(m => m.Map<MsgContactDto>(contactCharacter)).Returns(new MsgContactDto { MasterId = contactId, DisplayName = contactName });
+            _mapperMock.Setup(m => m.Map<MsgContactDto>(masterCharacter)).Returns(new MsgContactDto { MasterId = masterId, DisplayName = "Master" });
+
+            var contextMock = new Mock<ConsumeContext<AddContactRequest>>();
+            contextMock.Setup(x => x.Message).Returns(new AddContactRequest { MasterId = masterId, ContactDisplayName = contactName, Ignore = false });
+
+            // Act
+            await _consumer.Consume(contextMock.Object);
+
+            // Assert
+            contextMock.Verify(x => x.Publish(It.Is<ContactAddedMessage>(m =>
+                m.Contact.Settings != null && m.Contact.Settings.Availability == ContactAvailability.Friends
+            ), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/Hagalaz.Services.Contacts/Consumers/AddRemoveContactConsumer.cs
+++ b/Hagalaz.Services.Contacts/Consumers/AddRemoveContactConsumer.cs
@@ -63,8 +63,8 @@ namespace Hagalaz.Services.Contacts.Consumers
                 WorldId = contactWorldSession?.WorldId,
                 WorldName = contactWorldSession?.WorldName,
                 Rank = FriendsChatRank.Friend,
-                Settings = new ContactSettingsDto(contactSettings?.Availability.Off == true ? ContactAvailability.Off :
-                    contactSettings?.Availability.Friends == true ? ContactAvailability.Friends : ContactAvailability.Everyone)
+                Settings = new ContactSettingsDto(contactSettings?.Availability?.Off == true ? ContactAvailability.Off :
+                    contactSettings?.Availability?.Friends == true ? ContactAvailability.Friends : ContactAvailability.Everyone)
             };
 
             var characterSession = _contactSessions.GetOrDefault(message.MasterId);

--- a/Hagalaz.Services.Contacts/Consumers/AddRemoveContactConsumer.cs
+++ b/Hagalaz.Services.Contacts/Consumers/AddRemoveContactConsumer.cs
@@ -54,20 +54,25 @@ namespace Hagalaz.Services.Contacts.Consumers
             var contactFriend = await _contactService.FindFriendByIdAsync(characterContact.MasterId, message.MasterId);
             var contactSession = _contactSessions.GetOrDefault(characterContact.MasterId);
             var contactWorldSession = _worldSessions.GetOrDefault(contactSession?.WorldId ?? 0);
+
+            // Fetch actual contact settings if mutual friendship is not yet established.
+            var contactSettings = contactFriend?.Settings ?? await _contactService.FindContactSettingsAsync(characterContact.MasterId);
             var contactDto = _mapper.Map<ContactDto>(characterContact) with
             {
                 AreMutualFriends = contactFriend != null,
                 WorldId = contactWorldSession?.WorldId,
                 WorldName = contactWorldSession?.WorldName,
                 Rank = FriendsChatRank.Friend,
-                Settings = new ContactSettingsDto(contactFriend?.Settings?.Availability.Off == true ? ContactAvailability.Off :
-                    contactFriend?.Settings?.Availability.Friends == true ? ContactAvailability.Friends : ContactAvailability.Everyone)
+                Settings = new ContactSettingsDto(contactSettings?.Availability.Off == true ? ContactAvailability.Off :
+                    contactSettings?.Availability.Friends == true ? ContactAvailability.Friends : ContactAvailability.Everyone)
             };
+
             var characterSession = _contactSessions.GetOrDefault(message.MasterId);
             var characterWorldSession = _worldSessions.GetOrDefault(characterSession?.WorldId ?? 0);
+            // Fix: Use characterWorldSession instead of contactWorldSession to ensure the correct WorldId is sent for the adder.
             var masterDto = _mapper.Map<ContactDto>(character) with
             { 
-                WorldId = contactWorldSession?.WorldId,
+                WorldId = characterWorldSession?.WorldId,
                 WorldName = characterWorldSession?.WorldName
             };
             var responseTask = context.RespondAsync(new AddContactResponse


### PR DESCRIPTION
This PR fixes a critical data mapping bug and improves the correctness of privacy settings in the Contacts service.

### Changes:
- **Bug Fix**: In `AddRemoveContactConsumer.Consume(AddContactRequest)`, corrected the assignment of `WorldId` for the `masterDto` (the person adding the contact). It now correctly uses `characterWorldSession` instead of `contactWorldSession`.
- **Correctness Improvement**: Updated the logic for resolving a contact's availability settings. It now explicitly fetches the contact's actual settings via `IContactService.FindContactSettingsAsync` if they are not already a mutual friend, ensuring privacy preferences are respected from the moment they are added.
- **New Tests**: Added `Hagalaz.Services.Contacts.Tests/AddRemoveContactConsumerTests.cs` which contains:
    - `Consume_AddContactRequest_PublishesCorrectWorldIdForMaster`: Verifies the bug fix for `WorldId` mismatch.
    - `Consume_AddContactRequest_SetsCorrectAvailabilityFromSettings`: Verifies the improved settings resolution logic.

### Verification:
- Backend: `dotnet build Hagalaz.sln` passed.
- Tests: `dotnet test Hagalaz.Services.Contacts.Tests` passed (4/4 tests).
- Frontend: `pnpm build` in `Hagalaz.Web.App` passed.

---
*PR created automatically by Jules for task [6700464500613703979](https://jules.google.com/task/6700464500613703979) started by @frankvdb7*