### PR TITLE
Fix NullReferenceException in Character Rendering Protocol

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/Network/Protocol/CharacterRenderMasksWriterTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Network/Protocol/CharacterRenderMasksWriterTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Cache.Abstractions.Types.Providers;
+using Hagalaz.Game.Abstractions.Providers;
+using Hagalaz.Services.GameWorld.Store;
+using Hagalaz.Services.GameWorld.Network.Protocol._742;
+using Raido.Common.Buffers;
+using Hagalaz.Cache.Abstractions.Types;
+
+namespace Hagalaz.Services.GameWorld.Tests.Network.Protocol
+{
+    [TestClass]
+    public class CharacterRenderMasksWriterTests
+    {
+        private ItemStore _itemStore;
+        private IHitSplatRenderTypeProvider _hitRenderMasksMock;
+        private IBodyDataRepository _bodyDataRepositoryMock;
+        private IClientMapDefinitionProvider _clientMapDefinitionProviderMock;
+        private CharacterRenderMasksWriter _writer;
+        private ITypeProvider<IItemDefinition> _itemProviderMock;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _itemProviderMock = Substitute.For<ITypeProvider<IItemDefinition>>();
+            _itemStore = new ItemStore(Substitute.For<IServiceProvider>(), _itemProviderMock, Substitute.For<Microsoft.Extensions.Logging.ILogger<ItemStore>>());
+
+            _hitRenderMasksMock = Substitute.For<IHitSplatRenderTypeProvider>();
+            _bodyDataRepositoryMock = Substitute.For<IBodyDataRepository>();
+            _clientMapDefinitionProviderMock = Substitute.For<IClientMapDefinitionProvider>();
+            _writer = new CharacterRenderMasksWriter(_itemStore, _hitRenderMasksMock, _bodyDataRepositoryMock, _clientMapDefinitionProviderMock);
+        }
+
+        [TestMethod]
+        public void WriteItemAppearance_MissingItemDefinition_WritesZeroByteAndDoesNotThrow()
+        {
+            // Arrange
+            var characterMock = Substitute.For<ICharacter>();
+            var appearanceMock = Substitute.For<ICharacterAppearance>();
+            characterMock.Appearance.Returns(appearanceMock);
+
+            var itemPartMock = Substitute.For<IItemPart>();
+            itemPartMock.ItemId.Returns(123);
+            itemPartMock.Flags.Returns(ItemUpdateFlags.Model);
+            itemPartMock.MaleModels.Returns(new[] { 1 });
+            itemPartMock.FemaleModels.Returns(new[] { 1 });
+
+            _bodyDataRepositoryMock.BodySlotCount.Returns(1);
+            _bodyDataRepositoryMock.IsDisabledSlot(Arg.Any<BodyPart>()).Returns(false);
+
+            appearanceMock.GetDrawnItemPart(Arg.Any<BodyPart>()).Returns(itemPartMock);
+
+            // Mock ITypeProvider to return null for the item definition
+            _itemProviderMock.Get(123).Returns((IItemDefinition)null!);
+
+            var outputBuffer = Substitute.For<IByteBufferWriter>();
+
+            // Act
+            _writer.WriteItemAppearance(characterMock, outputBuffer);
+
+            // Assert
+            outputBuffer.Received(1).WriteByte(0);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/Store/ItemStoreTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Store/ItemStoreTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hagalaz.Cache.Abstractions.Types;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Services.GameWorld.Store;
+using Hagalaz.Services.GameWorld.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+
+namespace Hagalaz.Services.GameWorld.Tests.Store
+{
+    [TestClass]
+    public class ItemStoreTests
+    {
+        private IServiceProvider _serviceProviderMock;
+        private ITypeProvider<IItemDefinition> _itemProviderMock;
+        private ILogger<ItemStore> _loggerMock;
+        private ItemStore _itemStore;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _serviceProviderMock = Substitute.For<IServiceProvider>();
+            _itemProviderMock = Substitute.For<ITypeProvider<IItemDefinition>>();
+            _loggerMock = Substitute.For<ILogger<ItemStore>>();
+
+            _itemStore = new ItemStore(_serviceProviderMock, _itemProviderMock, _loggerMock);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_ProviderReturnsNullButInDatabase_ReturnsNullAndDoesNotThrow()
+        {
+            // Arrange
+            int itemId = 123;
+            var dbItem = new Hagalaz.Data.Entities.ItemDefinition { Id = (ushort)itemId, Examine = "Test" };
+
+            // Use reflection to populate the private _databaseItems field
+            var databaseItemsField = typeof(ItemStore).GetField("_databaseItems", BindingFlags.NonPublic | BindingFlags.Instance);
+            var databaseItems = new Dictionary<int, Hagalaz.Data.Entities.ItemDefinition>
+            {
+                { itemId, dbItem }
+            };
+            databaseItemsField!.SetValue(_itemStore, databaseItems);
+
+            // Mock provider to return null
+            _itemProviderMock.Get(itemId).Returns((IItemDefinition)null!);
+
+            // Act
+            var result = _itemStore.GetOrAdd(itemId);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld/Network/Protocol/742/CharacterRenderMasksWriter.cs
+++ b/Hagalaz.Services.GameWorld/Network/Protocol/742/CharacterRenderMasksWriter.cs
@@ -95,7 +95,7 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
 
                     var itemID = part - 0x4000; // 16384
                     var definition = _itemStore.GetOrAdd(itemID);
-                    if (definition.TeamId != 0)
+                    if (definition != null && definition.TeamId != 0)
                         teamID = definition.TeamId;
                 }
 
@@ -193,9 +193,18 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
                 var ia = character.Appearance.GetDrawnItemPart(part);
                 if (ia != null)
                 {
+                    var definition = _itemStore.GetOrAdd(ia.ItemId);
+                    if (definition == null)
+                    {
+                        // To prevent protocol desynchronization when an IItemDefinition is missing,
+                        // write a 0 byte for the item flags to signal 'no update' and maintain
+                        // buffer alignment for subsequent data.
+                        output.WriteByte(0);
+                        continue;
+                    }
+
                     output.WriteByte((byte)ia.Flags);
 
-                    var definition = _itemStore.GetOrAdd(ia.ItemId);
                     if (ia.Flags.HasFlag(ItemUpdateFlags.Model))
                     {
                         output.WriteInt32BigEndianSmart(ia.MaleModels[0]); // male worn model1

--- a/Hagalaz.Services.GameWorld/Store/ItemStore.cs
+++ b/Hagalaz.Services.GameWorld/Store/ItemStore.cs
@@ -28,9 +28,14 @@ namespace Hagalaz.Services.GameWorld.Store
             _logger = logger;
         }
 
-        private IItemDefinition LoadItemDefinition(int itemId)
+        private IItemDefinition? LoadItemDefinition(int itemId)
         {
             var definition = _itemProvider.Get(itemId);
+            if (definition == null)
+            {
+                return null;
+            }
+
             if (_databaseItems.TryGetValue(itemId, out var item))
             {
                 definition.Examine = item.Examine;


### PR DESCRIPTION
Fixed a potential `NullReferenceException` in the character rendering protocol when an item definition is missing. Added null guards in `CharacterRenderMasksWriter` and ensured that a placeholder byte is written to maintain network protocol alignment. Added unit tests to verify the fix and ensure no regressions. verified backend and frontend stability.

---
*PR created automatically by Jules for task [123640844608170702](https://jules.google.com/task/123640844608170702) started by @frankvdb7*