### PR TITLE
Fix NullReferenceException in character item rendering

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/Network/Protocol/742/CharacterRenderMasksWriterTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Network/Protocol/742/CharacterRenderMasksWriterTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Providers;
+using Hagalaz.Services.GameWorld.Network.Protocol._742;
+using Hagalaz.Services.GameWorld.Store;
+using Raido.Common.Buffers;
+using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Cache.Abstractions.Types.Providers;
+using Hagalaz.Cache.Abstractions.Types;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Game.Abstractions.Model;
+using System;
+using System.Collections.Generic;
+
+namespace Hagalaz.Services.GameWorld.Tests.Network.Protocol._742
+{
+    [TestClass]
+    public class CharacterRenderMasksWriterTests
+    {
+        private ItemStore _itemStore;
+        private ITypeProvider<IItemDefinition> _itemProviderMock;
+        private IHitSplatRenderTypeProvider _hitRenderMasksMock;
+        private IBodyDataRepository _bodyDataRepositoryMock;
+        private IClientMapDefinitionProvider _clientMapDefinitionProviderMock;
+        private CharacterRenderMasksWriter _writer;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _itemProviderMock = Substitute.For<ITypeProvider<IItemDefinition>>();
+            _itemStore = new ItemStore(Substitute.For<IServiceProvider>(), _itemProviderMock, Substitute.For<Microsoft.Extensions.Logging.ILogger<ItemStore>>());
+            _hitRenderMasksMock = Substitute.For<IHitSplatRenderTypeProvider>();
+            _bodyDataRepositoryMock = Substitute.For<IBodyDataRepository>();
+            _clientMapDefinitionProviderMock = Substitute.For<IClientMapDefinitionProvider>();
+            _writer = new CharacterRenderMasksWriter(_itemStore, _hitRenderMasksMock, _bodyDataRepositoryMock, _clientMapDefinitionProviderMock);
+        }
+
+        [TestMethod]
+        public void WriteItemAppearance_MissingDefinition_WritesZeroFlagsAndDoesNotThrow()
+        {
+            // Arrange
+            var characterMock = Substitute.For<ICharacter>();
+            var appearanceMock = Substitute.For<ICharacterAppearance>();
+            characterMock.Appearance.Returns(appearanceMock);
+
+            _bodyDataRepositoryMock.BodySlotCount.Returns(1);
+            _bodyDataRepositoryMock.IsDisabledSlot(Arg.Any<BodyPart>()).Returns(false);
+
+            var itemAppearanceMock = Substitute.For<IItemPart>();
+            itemAppearanceMock.ItemId.Returns(999);
+            itemAppearanceMock.Flags.Returns(ItemUpdateFlags.Model);
+            itemAppearanceMock.MaleModels.Returns(new[] { 1 });
+            itemAppearanceMock.FemaleModels.Returns(new[] { 1 });
+
+            appearanceMock.GetDrawnItemPart((BodyPart)0).Returns(itemAppearanceMock);
+            _itemProviderMock.Get(999).Returns((IItemDefinition)null!);
+
+            var outputBuffer = Substitute.For<IByteBufferWriter>();
+            var writtenBytes = new List<byte>();
+            outputBuffer.WriteByte(Arg.Do<byte>(b => writtenBytes.Add(b)));
+
+            // Act
+            _writer.WriteItemAppearance(characterMock, outputBuffer);
+
+            // Assert
+            Assert.AreEqual(1, writtenBytes.Count);
+            Assert.AreEqual(0, writtenBytes[0]);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/Network/Protocol/742/Encoders/DrawFrameComponentMessageEncoderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Network/Protocol/742/Encoders/DrawFrameComponentMessageEncoderTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Hagalaz.Game.Messages.Protocol;
+using Hagalaz.Services.GameWorld.Network.Protocol._742.Encoders;
+using Raido.Common.Protocol;
+using Hagalaz.Services.GameWorld.Extensions;
+using Raido.Server.Extensions;
+using Raido.Common.Buffers;
+
+namespace Hagalaz.Services.GameWorld.Tests.Network.Protocol._742.Encoders
+{
+    [TestClass]
+    public class DrawFrameComponentMessageEncoderTests
+    {
+        private DrawFrameComponentMessageEncoder _encoder;
+        private IRaidoMessageBinaryWriter _outputMock;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _encoder = new DrawFrameComponentMessageEncoder();
+            _outputMock = Substitute.For<IRaidoMessageBinaryWriter>();
+
+            _outputMock.SetOpcode(Arg.Any<int>()).Returns(_outputMock);
+            _outputMock.SetSize(Arg.Any<RaidoMessageSize>()).Returns(_outputMock);
+            _outputMock.WriteByte(Arg.Any<byte>()).Returns(_outputMock);
+        }
+
+        [TestMethod]
+        public void EncodeMessage_ForceRedrawTrue_WritesTwo()
+        {
+            // Arrange
+            var message = new DrawFrameComponentMessage { Id = 1, ForceRedraw = true };
+
+            // Act
+            _encoder.EncodeMessage(message, _outputMock);
+
+            // Assert
+            // WriteByteS(2) calls WriteByte(128 - 2) = WriteByte(126)
+            _outputMock.Received(1).WriteByte(126);
+        }
+
+        [TestMethod]
+        public void EncodeMessage_ForceRedrawFalse_WritesZero()
+        {
+            // Arrange
+            var message = new DrawFrameComponentMessage { Id = 1, ForceRedraw = false };
+
+            // Act
+            _encoder.EncodeMessage(message, _outputMock);
+
+            // Assert
+            // WriteByteS(0) calls WriteByte(128 - 0) = WriteByte(128)
+            _outputMock.Received(1).WriteByte(128);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/Store/ItemStoreTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Store/ItemStoreTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Hagalaz.Cache.Abstractions.Types;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Services.GameWorld.Store;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Hagalaz.Services.GameWorld.Tests.Store
+{
+    [TestClass]
+    public class ItemStoreTests
+    {
+        private IServiceProvider _serviceProviderMock;
+        private ITypeProvider<IItemDefinition> _itemProviderMock;
+        private ILogger<ItemStore> _loggerMock;
+        private ItemStore _itemStore;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _serviceProviderMock = Substitute.For<IServiceProvider>();
+            _itemProviderMock = Substitute.For<ITypeProvider<IItemDefinition>>();
+            _loggerMock = Substitute.For<ILogger<ItemStore>>();
+            _itemStore = new ItemStore(_serviceProviderMock, _itemProviderMock, _loggerMock);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_MissingDefinition_ReturnsNull()
+        {
+            // Arrange
+            int itemId = 999;
+            _itemProviderMock.Get(itemId).Returns((IItemDefinition)null!);
+
+            // Act
+            var result = _itemStore.GetOrAdd(itemId);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_ExistingDefinition_ReturnsDefinition()
+        {
+            // Arrange
+            int itemId = 1;
+            var definitionMock = Substitute.For<IItemDefinition>();
+            _itemProviderMock.Get(itemId).Returns(definitionMock);
+
+            // Act
+            var result = _itemStore.GetOrAdd(itemId);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(definitionMock, result);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld/Network/Protocol/742/CharacterRenderMasksWriter.cs
+++ b/Hagalaz.Services.GameWorld/Network/Protocol/742/CharacterRenderMasksWriter.cs
@@ -193,9 +193,15 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
                 var ia = character.Appearance.GetDrawnItemPart(part);
                 if (ia != null)
                 {
+                    var definition = _itemStore.GetOrAdd(ia.ItemId);
+                    if (definition == null)
+                    {
+                        output.WriteByte(0); // write 0 byte for flags to maintain buffer alignment
+                        continue;
+                    }
+
                     output.WriteByte((byte)ia.Flags);
 
-                    var definition = _itemStore.GetOrAdd(ia.ItemId);
                     if (ia.Flags.HasFlag(ItemUpdateFlags.Model))
                     {
                         output.WriteInt32BigEndianSmart(ia.MaleModels[0]); // male worn model1


### PR DESCRIPTION
I have identified and fixed a critical bug in the backend where missing item definitions were causing `NullReferenceException` crashes during character rendering. 

The fix involved:
1.  **ItemStore**: Adding null guards in `LoadItemDefinition` and updating `GetOrAdd` to safely handle missing definitions from the provider.
2.  **CharacterRenderMasksWriter**: Adding null checks for item definitions in `WriteAppearance` and `WriteItemAppearance`. In `WriteItemAppearance`, I implemented a protocol-safe fallback by writing a `0` byte for flags when a definition is missing, which prevents protocol desynchronization and downstream client crashes.
3.  **Unit Tests**: Added new test files to verify the fixes and prevent regressions:
    *   `ItemStoreTests.cs`
    *   `CharacterRenderMasksWriterTests.cs`
    *   `DrawFrameComponentMessageEncoderTests.cs`

All backend tests pass, and both the backend and frontend projects build successfully.

---
*PR created automatically by Jules for task [7350517241427262556](https://jules.google.com/task/7350517241427262556) started by @frankvdb7*