### PR TITLE
Fix Item Rendering NRE and Protocol Desynchronization

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/Network/Protocol/742/CharacterRenderMasksWriterTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Network/Protocol/742/CharacterRenderMasksWriterTests.cs
@@ -1,0 +1,95 @@
+using Hagalaz.Cache.Abstractions.Types.Providers;
+using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Game.Abstractions.Providers;
+using Hagalaz.Services.GameWorld.Network.Protocol._742;
+using Hagalaz.Services.GameWorld.Store;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Raido.Common.Buffers;
+using System;
+using Hagalaz.Cache.Abstractions.Types;
+using Hagalaz.Game.Extensions;
+using Hagalaz.Game.Abstractions.Model.Maps;
+
+namespace Hagalaz.Services.GameWorld.Tests.Network.Protocol._742
+{
+    [TestClass]
+    public class CharacterRenderMasksWriterTests
+    {
+        private ItemStore _itemStore;
+        private IHitSplatRenderTypeProvider _hitRenderMasks;
+        private IBodyDataRepository _bodyDataRepository;
+        private IClientMapDefinitionProvider _clientMapDefinitionProvider;
+        private CharacterRenderMasksWriter _writer;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var serviceProviderMock = Substitute.For<IServiceProvider>();
+            var itemProviderMock = Substitute.For<ITypeProvider<IItemDefinition>>();
+            var loggerMock = Substitute.For<Microsoft.Extensions.Logging.ILogger<ItemStore>>();
+            _itemStore = new ItemStore(serviceProviderMock, itemProviderMock, loggerMock);
+
+            _hitRenderMasks = Substitute.For<IHitSplatRenderTypeProvider>();
+            _bodyDataRepository = Substitute.For<IBodyDataRepository>();
+            _clientMapDefinitionProvider = Substitute.For<IClientMapDefinitionProvider>();
+            _writer = new CharacterRenderMasksWriter(_itemStore, _hitRenderMasks, _bodyDataRepository, _clientMapDefinitionProvider);
+
+            itemProviderMock.Get(Arg.Any<int>()).Returns((IItemDefinition)null);
+        }
+
+        [TestMethod]
+        public void WriteAppearance_NpcTransformation_MissingItemDefinition_ShouldNotThrow()
+        {
+            // Arrange
+            var character = Substitute.For<ICharacter>();
+            using var output = MemoryBufferWriter.Get();
+            var appearance = Substitute.For<ICharacterAppearance>();
+            var area = Substitute.For<IArea>();
+            var areaScript = Substitute.For<IAreaScript>();
+
+            character.Appearance.Returns(appearance);
+            character.Area.Returns(area);
+            area.Script.Returns(areaScript);
+            areaScript.ShouldRenderBaseCombatLevel(character).Returns(true);
+
+            appearance.NpcId.Returns(1); // triggers IsTransformedToNpc
+            appearance.Size.Returns(1);
+
+            _bodyDataRepository.BodySlotCount.Returns(1);
+            _bodyDataRepository.IsDisabledSlot(Arg.Any<BodyPart>()).Returns(false);
+
+            // 0x4000 + 1 = 16385, which triggers item definition lookup in transformation block
+            appearance.GetDrawnBodyPart(Arg.Any<BodyPart>()).Returns(16385);
+
+            // Act
+            _writer.WriteAppearance(character, output, false);
+
+            // Assert
+            // If we reached here without exception, it passed.
+        }
+
+        [TestMethod]
+        public void WriteRenderMasks_MissingAnimation_ShouldWritePlaceholders()
+        {
+            // Arrange
+            var character = Substitute.For<ICharacter>();
+            using var output = MemoryBufferWriter.Get();
+            var renderInfo = Substitute.For<ICharacterRenderInformation>();
+
+            character.RenderInformation.Returns(renderInfo);
+            renderInfo.UpdateFlag.Returns(Hagalaz.Game.Abstractions.Model.Creatures.Characters.UpdateFlags.Animation);
+            renderInfo.CurrentAnimation.Returns((IAnimation)null);
+
+            // Act
+            _writer.WriteRenderMasks(character, output, false);
+
+            // Assert
+            // Check that something was written (exact length depends on protocol, but placeholders should be there)
+            Assert.IsTrue(output.Length > 0);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/Store/ItemStoreTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Store/ItemStoreTests.cs
@@ -1,0 +1,43 @@
+using Hagalaz.Cache.Abstractions.Types;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Services.GameWorld.Store;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System;
+
+namespace Hagalaz.Services.GameWorld.Tests.Store
+{
+    [TestClass]
+    public class ItemStoreTests
+    {
+        private IServiceProvider _serviceProviderMock;
+        private ITypeProvider<IItemDefinition> _itemProviderMock;
+        private ILogger<ItemStore> _loggerMock;
+        private ItemStore _itemStore;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _serviceProviderMock = Substitute.For<IServiceProvider>();
+            _itemProviderMock = Substitute.For<ITypeProvider<IItemDefinition>>();
+            _loggerMock = Substitute.For<ILogger<ItemStore>>();
+            _itemStore = new ItemStore(_serviceProviderMock, _itemProviderMock, _loggerMock);
+        }
+
+        [TestMethod]
+        public void GetOrAdd_MissingDefinition_ReturnsEmptyDefinitionWithNullName()
+        {
+            // Arrange
+            int itemId = 1;
+            _itemProviderMock.Get(itemId).Returns((IItemDefinition)null);
+
+            // Act
+            var result = _itemStore.GetOrAdd(itemId);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("null", result.Name);
+        }
+    }
+}

--- a/Hagalaz.Services.GameWorld/Network/Protocol/742/CharacterRenderMasksWriter.cs
+++ b/Hagalaz.Services.GameWorld/Network/Protocol/742/CharacterRenderMasksWriter.cs
@@ -95,7 +95,7 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
 
                     var itemID = part - 0x4000; // 16384
                     var definition = _itemStore.GetOrAdd(itemID);
-                    if (definition.TeamId != 0)
+                    if (definition.Name != "null" && definition.TeamId != 0)
                         teamID = definition.TeamId;
                 }
 
@@ -119,8 +119,15 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
                     else
                         output.WriteInt16BigEndian((short)bodyPart);
 
-                    if (character.Appearance.GetDrawnItemPart(part) != null)
-                        itemAppearanceHash |= 1 << count;
+                    var ia = character.Appearance.GetDrawnItemPart(part);
+                    if (ia != null)
+                    {
+                        var definition = _itemStore.GetOrAdd(ia.ItemId);
+                        if (definition.Name != "null")
+                        {
+                            itemAppearanceHash |= 1 << count;
+                        }
+                    }
 
                     count++;
                 }
@@ -193,9 +200,14 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
                 var ia = character.Appearance.GetDrawnItemPart(part);
                 if (ia != null)
                 {
+                    var definition = _itemStore.GetOrAdd(ia.ItemId);
+                    if (definition.Name == "null")
+                    {
+                        continue;
+                    }
+
                     output.WriteByte((byte)ia.Flags);
 
-                    var definition = _itemStore.GetOrAdd(ia.ItemId);
                     if (ia.Flags.HasFlag(ItemUpdateFlags.Model))
                     {
                         output.WriteInt32BigEndianSmart(ia.MaleModels[0]); // male worn model1
@@ -387,9 +399,18 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
 
             if (updateFlag.HasFlag(Game.Abstractions.Model.Creatures.Characters.UpdateFlags.Animation))
             {
-                for (int i = 0; i < 4; i++)
-                    output.WriteInt32BigEndianSmart(character.RenderInformation.CurrentAnimation.Id);
-                output.WriteByteA((byte)character.RenderInformation.CurrentAnimation.Delay);
+                if (character.RenderInformation.CurrentAnimation != null)
+                {
+                    for (int i = 0; i < 4; i++)
+                        output.WriteInt32BigEndianSmart(character.RenderInformation.CurrentAnimation.Id);
+                    output.WriteByteA((byte)character.RenderInformation.CurrentAnimation.Delay);
+                }
+                else
+                {
+                    for (int i = 0; i < 4; i++)
+                        output.WriteInt32BigEndianSmart(0);
+                    output.WriteByteA(0);
+                }
             }
 
             if (updateFlag.HasFlag(Game.Abstractions.Model.Creatures.Characters.UpdateFlags.MovementType))

--- a/Hagalaz.Services.GameWorld/Network/Protocol/742/NpcRenderMasksWriter.cs
+++ b/Hagalaz.Services.GameWorld/Network/Protocol/742/NpcRenderMasksWriter.cs
@@ -196,9 +196,18 @@ namespace Hagalaz.Services.GameWorld.Network.Protocol._742
 
             if ((updateFlag & UpdateFlags.Animation) != 0)
             {
-                for (int i = 0; i < 4; i++)
-                    output.WriteInt32BigEndianSmart(npc.RenderInformation.CurrentAnimation.Id);
-                output.WriteByteC((byte)npc.RenderInformation.CurrentAnimation.Delay);
+                if (npc.RenderInformation.CurrentAnimation != null)
+                {
+                    for (int i = 0; i < 4; i++)
+                        output.WriteInt32BigEndianSmart(npc.RenderInformation.CurrentAnimation.Id);
+                    output.WriteByteC((byte)npc.RenderInformation.CurrentAnimation.Delay);
+                }
+                else
+                {
+                    for (int i = 0; i < 4; i++)
+                        output.WriteInt32BigEndianSmart(0);
+                    output.WriteByteC(0);
+                }
             }
 
             if ((updateFlag & UpdateFlags.Graphic4) != 0)

--- a/Hagalaz.Services.GameWorld/Store/ItemStore.cs
+++ b/Hagalaz.Services.GameWorld/Store/ItemStore.cs
@@ -31,6 +31,12 @@ namespace Hagalaz.Services.GameWorld.Store
         private IItemDefinition LoadItemDefinition(int itemId)
         {
             var definition = _itemProvider.Get(itemId);
+
+            if (definition == null)
+            {
+                return new Data.Model.ItemDefinition(itemId);
+            }
+
             if (_databaseItems.TryGetValue(itemId, out var item))
             {
                 definition.Examine = item.Examine;


### PR DESCRIPTION
This PR addresses a potential `NullReferenceException` in the item storage and character rendering logic. It also fixes a secondary issue where naive null checks could cause network protocol desynchronization between the server and the client.

Key changes:
- `ItemStore.cs`: Now returns an `ItemDefinition` with `Name = "null"` if a definition is missing from the cache.
- `CharacterRenderMasksWriter.cs`: 
    - The `itemAppearanceHash` now only includes slots where a valid item definition exists.
    - Added safety guards for `UpdateFlags.Animation` to write placeholders (ID 0, delay 0) if `CurrentAnimation` is null, maintaining packet integrity.
- `NpcRenderMasksWriter.cs`: Added similar animation placeholder logic.
- Added unit tests in `Hagalaz.Services.GameWorld.Tests` to verify these fixes.

---
*PR created automatically by Jules for task [1443053767867258861](https://jules.google.com/task/1443053767867258861) started by @frankvdb7*