### PR TITLE
Fix character statistics experience calculation and improve string utility robustness

### DIFF
--- a/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
+++ b/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Hagalaz.Services.Characters.Model;
+
+namespace Hagalaz.Services.Characters.Tests.Model
+{
+    [TestClass]
+    public class CharactersStatisticsDtoTests
+    {
+        [TestMethod]
+        public void OverallExperience_ShouldSumAllExperienceCorrectly()
+        {
+            // Arrange
+            var stats = new CharactersStatisticsDto
+            {
+                DisplayName = "TestPlayer",
+                AgilityExp = 10,
+                AttackExp = 10,
+                ConstitutionExp = 10,
+                ConstructionExp = 10,
+                CookingExp = 10,
+                CraftingExp = 10,
+                DefenceExp = 10, // Only once here
+                DungeoneeringExp = 10,
+                FarmingExp = 10,
+                FiremakingExp = 10,
+                FishingExp = 10,
+                FletchingExp = 10,
+                HerbloreExp = 10,
+                HunterExp = 10,
+                MagicExp = 10,
+                MiningExp = 10,
+                PrayerExp = 10,
+                RangeExp = 10,
+                RunecraftingExp = 10,
+                SlayerExp = 10,
+                SmithingExp = 10,
+                StrengthExp = 10,
+                SummoningExp = 10,
+                ThievingExp = 10,
+                WoodcuttingExp = 10
+            };
+
+            // There are 25 skills in total.
+            // 25 * 10 = 250
+            double expected = 250;
+
+            // Act
+            double actual = stats.OverallExperience;
+
+            // Assert
+            Assert.AreEqual(expected, actual, "OverallExperience calculation is incorrect. It might be double-counting a skill (e.g., DefenceExp).");
+        }
+    }
+}

--- a/Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs
+++ b/Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs
@@ -66,7 +66,7 @@ namespace Hagalaz.Services.Characters.Mediator.Consumers
             {
                 CharacterStatisticType.Overall => _mapper.ProjectTo<CharactersStatisticsDto>(statsQuery)
                     .OrderByDescending(dto => dto.AgilityExp + dto.AttackExp + dto.ConstitutionExp + dto.ConstructionExp + dto.CookingExp + dto.CraftingExp +
-                                              dto.DefenceExp + dto.DefenceExp + dto.DungeoneeringExp + dto.FarmingExp + dto.FiremakingExp + dto.FishingExp +
+                                              dto.DefenceExp + dto.DungeoneeringExp + dto.FarmingExp + dto.FiremakingExp + dto.FishingExp +
                                               dto.FletchingExp + dto.HerbloreExp + dto.HunterExp + dto.MagicExp + dto.MiningExp + dto.PrayerExp + dto.RangeExp +
                                               dto.RunecraftingExp + dto.SlayerExp + dto.SmithingExp + dto.StrengthExp + dto.SummoningExp + dto.ThievingExp +
                                               dto.WoodcuttingExp)

--- a/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
+++ b/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
@@ -61,7 +61,7 @@ namespace Hagalaz.Services.Characters.Model
             RunecraftingLevel + SlayerLevel + SmithingLevel + StrengthLevel + SummoningLevel + ThievingLevel + WoodcuttingLevel;
 
         public double OverallExperience =>
-            AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DefenceExp + DungeoneeringExp + FarmingExp +
+            AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DungeoneeringExp + FarmingExp +
             FiremakingExp + FishingExp + FletchingExp + HerbloreExp + HunterExp + MagicExp + MiningExp + PrayerExp + RangeExp + RunecraftingExp + SlayerExp +
             SmithingExp + StrengthExp + SummoningExp + ThievingExp + WoodcuttingExp;
     }

--- a/Hagalaz.Utilities.Tests/StringUtilitiesTests.cs
+++ b/Hagalaz.Utilities.Tests/StringUtilitiesTests.cs
@@ -250,6 +250,19 @@ namespace Hagalaz.Utilities.Tests
         }
 
         [TestMethod]
+        public void SelectIntFromString_WhitespaceInput_ReturnsEmpty()
+        {
+            // Arrange
+            var input = " ";
+
+            // Act
+            var actual = StringUtilities.SelectIntFromString(input).ToArray();
+
+            // Assert
+            Assert.IsEmpty(actual);
+        }
+
+        [TestMethod]
         public void SelectIntFromString_ValidInput_ReturnsCorrectInts()
         {
             // Arrange
@@ -319,6 +332,19 @@ namespace Hagalaz.Utilities.Tests
         }
 
         [TestMethod]
+        public void SelectDoubleFromString_WhitespaceInput_ReturnsEmpty()
+        {
+            // Arrange
+            var input = " ";
+
+            // Act
+            var actual = StringUtilities.SelectDoubleFromString(input).ToArray();
+
+            // Assert
+            Assert.IsEmpty(actual);
+        }
+
+        [TestMethod]
         public void DecodeValues_Bool_DecodesCorrectly()
         {
             // Arrange
@@ -375,6 +401,19 @@ namespace Hagalaz.Utilities.Tests
 
             // Act
             var actual = StringUtilities.SelectIntFromString(input).ToArray();
+
+            // Assert
+            Assert.IsEmpty(actual);
+        }
+
+        [TestMethod]
+        public void SelectBoolFromString_WhitespaceInput_ReturnsEmpty()
+        {
+            // Arrange
+            var input = " ";
+
+            // Act
+            var actual = StringUtilities.SelectBoolFromString(input).ToArray();
 
             // Assert
             Assert.IsEmpty(actual);

--- a/Hagalaz.Utilities/StringUtilities.cs
+++ b/Hagalaz.Utilities/StringUtilities.cs
@@ -177,7 +177,7 @@ namespace Hagalaz.Utilities
         /// <returns>An <see cref="IEnumerable{T}"/> of doubles.</returns>
         public static IEnumerable<double> SelectDoubleFromString(string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (string.IsNullOrWhiteSpace(input))
             {
                 yield break;
             }
@@ -207,7 +207,7 @@ namespace Hagalaz.Utilities
         /// <returns>An <see cref="IEnumerable{T}"/> of integers.</returns>
         public static IEnumerable<int> SelectIntFromString(string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (string.IsNullOrWhiteSpace(input))
             {
                 yield break;
             }
@@ -237,7 +237,7 @@ namespace Hagalaz.Utilities
         /// <returns>An <see cref="IEnumerable{T}"/> of booleans.</returns>
         public static IEnumerable<bool> SelectBoolFromString(string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (string.IsNullOrWhiteSpace(input))
             {
                 yield break; // Return an empty enumerable for an empty or null input.
             }


### PR DESCRIPTION
This PR addresses a logic error in the character statistics calculation where the defense experience was being counted twice, leading to inflated overall experience totals and incorrect highscore rankings. 

Additionally, it improves the robustness of `StringUtilities` by ensuring that whitespace-only strings are correctly identified as empty inputs in numeric and boolean parsing methods, preventing them from being parsed as default values (e.g., 0).

Changes:
- Modified `Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs` to fix `OverallExperience`.
- Modified `Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs` to fix highscore sorting.
- Updated `Hagalaz.Utilities/StringUtilities.cs` to use `string.IsNullOrWhiteSpace`.
- Created `Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs` for verification.
- Updated `Hagalaz.Utilities.Tests/StringUtilitiesTests.cs` with additional test cases.

---
*PR created automatically by Jules for task [3597408477956980384](https://jules.google.com/task/3597408477956980384) started by @frankvdb7*