### PR TITLE
Fix highscore sorting and overall experience calculation

### DIFF
--- a/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
+++ b/Hagalaz.Services.Characters.Tests/Model/CharactersStatisticsDtoTests.cs
@@ -19,7 +19,7 @@ namespace Hagalaz.Services.Characters.Tests.Model
                 ConstructionExp = 10,
                 CookingExp = 10,
                 CraftingExp = 10,
-                DefenceExp = 10, // Only once here
+                DefenceExp = 10,
                 DungeoneeringExp = 10,
                 FarmingExp = 10,
                 FiremakingExp = 10,
@@ -49,6 +49,51 @@ namespace Hagalaz.Services.Characters.Tests.Model
 
             // Assert
             Assert.AreEqual(expected, actual, "OverallExperience calculation is incorrect. It might be double-counting a skill (e.g., DefenceExp).");
+        }
+
+        [TestMethod]
+        public void OverallLevel_ShouldSumAllLevelsCorrectly()
+        {
+            // Arrange
+            var stats = new CharactersStatisticsDto
+            {
+                DisplayName = "TestPlayer",
+                AgilityLevel = 1,
+                AttackLevel = 1,
+                ConstitutionLevel = 1,
+                ConstructionLevel = 1,
+                CookingLevel = 1,
+                CraftingLevel = 1,
+                DefenceLevel = 1,
+                DungeoneeringLevel = 1,
+                FarmingLevel = 1,
+                FiremakingLevel = 1,
+                FishingLevel = 1,
+                FletchingLevel = 1,
+                HerbloreLevel = 1,
+                HunterLevel = 1,
+                MagicLevel = 1,
+                MiningLevel = 1,
+                PrayerLevel = 1,
+                RangeLevel = 1,
+                RunecraftingLevel = 1,
+                SlayerLevel = 1,
+                SmithingLevel = 1,
+                StrengthLevel = 1,
+                SummoningLevel = 1,
+                ThievingLevel = 1,
+                WoodcuttingLevel = 1
+            };
+
+            // There are 25 skills in total.
+            // 25 * 1 = 25
+            int expected = 25;
+
+            // Act
+            int actual = stats.OverallLevel;
+
+            // Assert
+            Assert.AreEqual(expected, actual, "OverallLevel calculation is incorrect.");
         }
     }
 }

--- a/Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs
+++ b/Hagalaz.Services.Characters/Mediator/Consumers/GetAllCharacterStatisticsQueryConsumer.cs
@@ -44,7 +44,9 @@ namespace Hagalaz.Services.Characters.Mediator.Consumers
 
             if (sort?.Experience != null)
             {
-                //dtoQuery = sort.Experience.Value == SortType.Asc ? dtoQuery.OrderBy(s => s.Statistics.Count) : query.OrderByDescending(s => s.AgilityExp);
+                dtoQuery = sort.Experience.Value == SortType.Asc
+                    ? dtoQuery.OrderBy(s => s.Statistics.First().Experience)
+                    : dtoQuery.OrderByDescending(s => s.Statistics.First().Experience);
             }
 
             if (paging != null)
@@ -64,18 +66,26 @@ namespace Hagalaz.Services.Characters.Mediator.Consumers
         private IQueryable<CharacterStatisticCollectionDto> FilterByType(IQueryable<CharactersStatistic> statsQuery, CharacterStatisticType type) =>
             type switch
             {
-                CharacterStatisticType.Overall => _mapper.ProjectTo<CharactersStatisticsDto>(statsQuery)
-                    .OrderByDescending(dto => dto.AgilityExp + dto.AttackExp + dto.ConstitutionExp + dto.ConstructionExp + dto.CookingExp + dto.CraftingExp +
-                                              dto.DefenceExp + dto.DungeoneeringExp + dto.FarmingExp + dto.FiremakingExp + dto.FishingExp +
-                                              dto.FletchingExp + dto.HerbloreExp + dto.HunterExp + dto.MagicExp + dto.MiningExp + dto.PrayerExp + dto.RangeExp +
-                                              dto.RunecraftingExp + dto.SlayerExp + dto.SmithingExp + dto.StrengthExp + dto.SummoningExp + dto.ThievingExp +
-                                              dto.WoodcuttingExp)
-                    .Select(dto => new CharacterStatisticCollectionDto
+                CharacterStatisticType.Overall => statsQuery.OrderByDescending(stats => (long)stats.AgilityExp + stats.AttackExp + stats.ConstitutionExp + stats.ConstructionExp + stats.CookingExp + stats.CraftingExp +
+                                              stats.DefenceExp + stats.DungeoneeringExp + stats.FarmingExp + stats.FiremakingExp + stats.FishingExp +
+                                              stats.FletchingExp + stats.HerbloreExp + stats.HunterExp + stats.MagicExp + stats.MiningExp + stats.PrayerExp + stats.RangeExp +
+                                              stats.RunecraftingExp + stats.SlayerExp + stats.SmithingExp + stats.StrengthExp + stats.SummoningExp + stats.ThievingExp +
+                                              stats.WoodcuttingExp)
+                    .Select(stats => new CharacterStatisticCollectionDto
                     {
-                        DisplayName = dto.DisplayName,
+                        DisplayName = stats.Master.DisplayName,
                         Statistics = new[]
                         {
-                                new CharacterStatisticDetailDto { Type = CharacterStatisticType.Overall, Level = dto.OverallLevel, Experience = dto.OverallExperience }
+                                new CharacterStatisticDetailDto
+                                {
+                                    Type = CharacterStatisticType.Overall,
+                                    Level = stats.AgilityLevel + stats.AttackLevel + stats.ConstitutionLevel + stats.ConstructionLevel + stats.CookingLevel + stats.CraftingLevel + stats.DefenceLevel + stats.DungeoneeringLevel +
+                                            stats.FarmingLevel + stats.FiremakingLevel + stats.FishingLevel + stats.FletchingLevel + stats.HerbloreLevel + stats.HunterLevel + stats.MagicLevel + stats.MiningLevel + stats.PrayerLevel + stats.RangeLevel +
+                                            stats.RunecraftingLevel + stats.SlayerLevel + stats.SmithingLevel + stats.StrengthLevel + stats.SummoningLevel + stats.ThievingLevel + stats.WoodcuttingLevel,
+                                    Experience = (double)stats.AgilityExp + stats.AttackExp + stats.ConstitutionExp + stats.ConstructionExp + stats.CookingExp + stats.CraftingExp + stats.DefenceExp + stats.DungeoneeringExp + stats.FarmingExp +
+                                                 stats.FiremakingExp + stats.FishingExp + stats.FletchingExp + stats.HerbloreExp + stats.HunterExp + stats.MagicExp + stats.MiningExp + stats.PrayerExp + stats.RangeExp + stats.RunecraftingExp + stats.SlayerExp +
+                                                 stats.SmithingExp + stats.StrengthExp + stats.SummoningExp + stats.ThievingExp + stats.WoodcuttingExp
+                                }
                         }
                     }),
                 CharacterStatisticType.Agility => statsQuery.OrderByDescending(stats => stats.AgilityExp)

--- a/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
+++ b/Hagalaz.Services.Characters/Model/CharactersStatisticsDto.cs
@@ -61,7 +61,7 @@ namespace Hagalaz.Services.Characters.Model
             RunecraftingLevel + SlayerLevel + SmithingLevel + StrengthLevel + SummoningLevel + ThievingLevel + WoodcuttingLevel;
 
         public double OverallExperience =>
-            AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DungeoneeringExp + FarmingExp +
+            (double)AgilityExp + AttackExp + ConstitutionExp + ConstructionExp + CookingExp + CraftingExp + DefenceExp + DungeoneeringExp + FarmingExp +
             FiremakingExp + FishingExp + FletchingExp + HerbloreExp + HunterExp + MagicExp + MiningExp + PrayerExp + RangeExp + RunecraftingExp + SlayerExp +
             SmithingExp + StrengthExp + SummoningExp + ThievingExp + WoodcuttingExp;
     }


### PR DESCRIPTION
This PR fixes issues related to highscore sorting and the calculation of overall character statistics. 

Key changes:
- In `CharactersStatisticsDto`, `OverallExperience` now uses an explicit `double` cast during summation of the 25 skill experiences to prevent integer overflow if the total exceeds ~2.1 billion.
- In `GetAllCharacterStatisticsQueryConsumer`, the previously commented-out sorting logic for experience has been enabled and corrected.
- The `FilterByType` method was updated to handle the `Overall` statistic type correctly by performing the summation and sorting directly on the queryable, ensuring correct SQL translation and overflow prevention using `long` casts.
- New unit tests were added to `CharactersStatisticsDtoTests` to verify that both `OverallExperience` and `OverallLevel` correctly sum all 25 skills exactly once.

---
*PR created automatically by Jules for task [4190377821988662756](https://jules.google.com/task/4190377821988662756) started by @frankvdb7*