### PR TITLE
Make character persistence durable and observable

### DIFF
--- a/Hagalaz.ServiceDefaults/Extensions.cs
+++ b/Hagalaz.ServiceDefaults/Extensions.cs
@@ -339,7 +339,8 @@ public static class Extensions
         meterProviderBuilder.AddMeter("System.Net.Http",
             "MassTransit",
             "Polly",
-            "Raido.Server");
+            "Raido.Server",
+            "Hagalaz.Services.Characters.Persistence");
 
     public static string? GetServiceConfigurationValue(this IConfiguration configuration, string serviceName, string key, string? fallbackKey = null)
     {

--- a/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
@@ -133,14 +133,16 @@ public sealed class CharacterPersistenceIntegrationTests
             var command = CreateCommand(masterId, 1, noteText: new string('x', 51));
             await harness.Bus.Publish(command);
 
-            var faultMessage = await faultCapture.Received.Task.WaitAsync(TimeSpan.FromSeconds(120));
+            using var faultTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+            var faultMessage = await faultCapture.Received.Task.WaitAsync(faultTimeout.Token);
             Assert.AreEqual(masterId, faultMessage.Message.MasterId);
             var exception = faultMessage.Exceptions.FirstOrDefault();
             Assert.IsNotNull(exception);
             StringAssert.Contains(exception!.ExceptionType, nameof(DbUpdateException));
             StringAssert.Contains(exception.Message, "Could not save changes");
 
-            var errorCommand = await errorQueueCapture.Received.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            using var errorQueueTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var errorCommand = await errorQueueCapture.Received.Task.WaitAsync(errorQueueTimeout.Token);
             Assert.AreEqual(masterId, errorCommand.MasterId);
             Assert.IsFalse(acknowledgementCapture.Received.Task.IsCompleted);
         }

--- a/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
@@ -54,7 +54,7 @@ public sealed class CharacterPersistenceIntegrationTests
         var masterId = await SeedCharacterAsync();
         await using var provider = CreateProvider();
         var harness = provider.GetTestHarness();
-        var acknowledgementProbe = harness.GetConsumerHarness<AcknowledgementProbe>();
+        var acknowledgementCapture = provider.GetRequiredService<AcknowledgementCapture>();
         await harness.Start();
 
         try
@@ -67,10 +67,10 @@ public sealed class CharacterPersistenceIntegrationTests
                 await scope.ServiceProvider.GetRequiredService<HagalazDbContext>().SaveChangesAsync();
             }
 
-            Assert.IsTrue(await harness.Consumed.Any<PersistCharacterCommand>(x =>
-                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 1));
-            Assert.IsTrue(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
-                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 1));
+            using var deliveryTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            var acknowledgement = await acknowledgementCapture.Received.Task.WaitAsync(deliveryTimeout.Token);
+            Assert.AreEqual(masterId, acknowledgement.MasterId);
+            Assert.AreEqual(1L, acknowledgement.SnapshotRevision);
         }
         finally
         {
@@ -123,9 +123,9 @@ public sealed class CharacterPersistenceIntegrationTests
         var masterId = await SeedCharacterAsync();
         await using var provider = CreateProvider();
         var harness = provider.GetTestHarness();
-        var faultConsumer = harness.GetConsumerHarness<CharacterPersistenceFaultConsumer>();
-        var errorQueue = harness.GetConsumerHarness<ErrorQueueProbe>();
-        var acknowledgementProbe = harness.GetConsumerHarness<AcknowledgementProbe>();
+        var faultCapture = provider.GetRequiredService<FaultCapture>();
+        var errorQueueCapture = provider.GetRequiredService<ErrorQueueCapture>();
+        var acknowledgementCapture = provider.GetRequiredService<AcknowledgementCapture>();
         await harness.Start();
 
         try
@@ -133,30 +133,16 @@ public sealed class CharacterPersistenceIntegrationTests
             var command = CreateCommand(masterId, 1, noteText: new string('x', 51));
             await harness.Bus.Publish(command);
 
-            var fault = await harness.Published
-                .SelectAsync<Fault<PersistCharacterCommand>>()
-                .FirstOrDefault();
-            Assert.IsNotNull(fault);
-            var faultMessage = fault!.Context.Message;
+            var faultMessage = await faultCapture.Received.Task.WaitAsync(TimeSpan.FromSeconds(120));
             Assert.AreEqual(masterId, faultMessage.Message.MasterId);
             var exception = faultMessage.Exceptions.FirstOrDefault();
             Assert.IsNotNull(exception);
             StringAssert.Contains(exception!.ExceptionType, nameof(DbUpdateException));
-            StringAssert.Contains(exception.Message, "saving the entity changes");
+            StringAssert.Contains(exception.Message, "Could not save changes");
 
-            using var faultConsumerTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            Assert.IsTrue(await faultConsumer.Consumed.Any<Fault<PersistCharacterCommand>>(x =>
-                x.Context.Message.Message.MasterId == masterId,
-                faultConsumerTimeout.Token));
-
-            using var errorQueueTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            Assert.IsTrue(await errorQueue.Consumed.Any<PersistCharacterCommand>(x =>
-                x.Context.Message.MasterId == masterId,
-                errorQueueTimeout.Token));
-            using var acknowledgementTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            Assert.IsFalse(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
-                x.Context.Message.MasterId == masterId,
-                acknowledgementTimeout.Token));
+            var errorCommand = await errorQueueCapture.Received.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.AreEqual(masterId, errorCommand.MasterId);
+            Assert.IsFalse(acknowledgementCapture.Received.Task.IsCompleted);
         }
         finally
         {
@@ -175,6 +161,9 @@ public sealed class CharacterPersistenceIntegrationTests
         var services = new ServiceCollection()
             .AddLogging()
             .AddSingleton<CharacterPersistenceMetrics>()
+            .AddSingleton<AcknowledgementCapture>()
+            .AddSingleton<FaultCapture>()
+            .AddSingleton<ErrorQueueCapture>()
             .AddDbContext<HagalazDbContext>(options => options.UseMySQL(_database!.GetConnectionString()))
             .AddScoped<ICharacterUnitOfWork>(serviceProvider =>
             {
@@ -195,13 +184,13 @@ public sealed class CharacterPersistenceIntegrationTests
             x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>();
             x.AddConsumer<CharacterPersistenceFaultConsumer>();
             x.AddConsumer<AcknowledgementProbe>();
+            x.AddConsumer<FaultProbe, FaultProbeDefinition>();
             x.AddConsumer<ErrorQueueProbe, ErrorQueueProbeDefinition>();
             x.AddConfigureEndpointsCallback((name, endpoint) =>
             {
                 if (name == "UpdateCharacterRequest")
                 {
                     endpoint.ConcurrentMessageLimit = 2;
-                    endpoint.PublishFaults = true;
                 }
             });
         });
@@ -270,14 +259,66 @@ public sealed class CharacterPersistenceIntegrationTests
             new StateDto { StatesEx = [new StateDto.StateExDto { Id = 50, TicksLeft = 51 }] },
             revision);
 
+    private sealed class AcknowledgementCapture
+    {
+        public TaskCompletionSource<PersistCharacterAcknowledged> Received { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class FaultCapture
+    {
+        public TaskCompletionSource<Fault<PersistCharacterCommand>> Received { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class ErrorQueueCapture
+    {
+        public TaskCompletionSource<PersistCharacterCommand> Received { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
     private sealed class AcknowledgementProbe : IConsumer<PersistCharacterAcknowledged>
     {
-        public Task Consume(ConsumeContext<PersistCharacterAcknowledged> context) => Task.CompletedTask;
+        private readonly AcknowledgementCapture _capture;
+
+        public AcknowledgementProbe(AcknowledgementCapture capture) => _capture = capture;
+
+        public Task Consume(ConsumeContext<PersistCharacterAcknowledged> context)
+        {
+            _capture.Received.TrySetResult(context.Message);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FaultProbe : IConsumer<Fault<PersistCharacterCommand>>
+    {
+        private readonly FaultCapture _capture;
+
+        public FaultProbe(FaultCapture capture) => _capture = capture;
+
+        public Task Consume(ConsumeContext<Fault<PersistCharacterCommand>> context)
+        {
+            _capture.Received.TrySetResult(context.Message);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FaultProbeDefinition : ConsumerDefinition<FaultProbe>
+    {
+        public FaultProbeDefinition() => EndpointName = "FaultProbe";
     }
 
     private sealed class ErrorQueueProbe : IConsumer<PersistCharacterCommand>
     {
-        public Task Consume(ConsumeContext<PersistCharacterCommand> context) => Task.CompletedTask;
+        private readonly ErrorQueueCapture _capture;
+
+        public ErrorQueueProbe(ErrorQueueCapture capture) => _capture = capture;
+
+        public Task Consume(ConsumeContext<PersistCharacterCommand> context)
+        {
+            _capture.Received.TrySetResult(context.Message);
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class ErrorQueueProbeDefinition : ConsumerDefinition<ErrorQueueProbe>

--- a/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
@@ -121,7 +121,7 @@ public sealed class CharacterPersistenceIntegrationTests
     public async Task FailedDatabaseCommit_RollsBackAcknowledgementAndReachesErrorAndFaultPaths()
     {
         var masterId = await SeedCharacterAsync();
-        await using var provider = CreateProvider(fastFailure: true);
+        await using var provider = CreateProvider();
         var harness = provider.GetTestHarness();
         var faultConsumer = harness.GetConsumerHarness<CharacterPersistenceFaultConsumer>();
         var errorQueue = harness.GetConsumerHarness<ErrorQueueProbe>();
@@ -133,25 +133,30 @@ public sealed class CharacterPersistenceIntegrationTests
             var command = CreateCommand(masterId, 1, noteText: new string('x', 51));
             await harness.Bus.Publish(command);
 
-            using var consumedTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            Assert.IsTrue(await harness.Consumed.Any<PersistCharacterCommand>(x =>
-                x.Context.Message.MasterId == masterId,
-                consumedTimeout.Token));
+            var fault = await harness.Published
+                .SelectAsync<Fault<PersistCharacterCommand>>()
+                .FirstOrDefault();
+            Assert.IsNotNull(fault);
+            var faultMessage = fault!.Context.Message;
+            Assert.AreEqual(masterId, faultMessage.Message.MasterId);
+            var exception = faultMessage.Exceptions.FirstOrDefault();
+            Assert.IsNotNull(exception);
+            StringAssert.Contains(exception!.ExceptionType, nameof(DbUpdateException));
+            StringAssert.Contains(exception.Message, "saving the entity changes");
+
+            using var faultConsumerTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            Assert.IsTrue(await faultConsumer.Consumed.Any<Fault<PersistCharacterCommand>>(x =>
+                x.Context.Message.Message.MasterId == masterId,
+                faultConsumerTimeout.Token));
+
+            using var errorQueueTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             Assert.IsTrue(await errorQueue.Consumed.Any<PersistCharacterCommand>(x =>
                 x.Context.Message.MasterId == masterId,
-                consumedTimeout.Token));
+                errorQueueTimeout.Token));
             using var acknowledgementTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             Assert.IsFalse(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
                 x.Context.Message.MasterId == masterId,
                 acknowledgementTimeout.Token));
-            await harness.Bus.Publish<Fault<PersistCharacterCommand>>(new
-            {
-                Message = command
-            });
-            using var faultConsumerTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            Assert.IsTrue(await faultConsumer.Consumed.Any<Fault<PersistCharacterCommand>>(x =>
-                x.Context.Message.Message.MasterId == masterId,
-                faultConsumerTimeout.Token));
         }
         finally
         {
@@ -165,9 +170,7 @@ public sealed class CharacterPersistenceIntegrationTests
         Assert.AreEqual("old note", note.Text);
     }
 
-    private static ServiceProvider CreateProvider(
-        CommitBarrier? barrier = null,
-        bool fastFailure = false)
+    private static ServiceProvider CreateProvider(CommitBarrier? barrier = null)
     {
         var services = new ServiceCollection()
             .AddLogging()
@@ -189,20 +192,10 @@ public sealed class CharacterPersistenceIntegrationTests
                 options.UseMySql();
                 options.UseBusOutbox();
             });
-            if (fastFailure)
-            {
-                x.AddConsumer<UpdateCharacterRequestConsumer, FastCharacterPersistenceConsumerDefinition>();
-            }
-            else
-            {
-                x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>();
-            }
+            x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>();
             x.AddConsumer<CharacterPersistenceFaultConsumer>();
             x.AddConsumer<AcknowledgementProbe>();
-            if (fastFailure)
-            {
-                x.AddConsumer<ErrorQueueProbe, ErrorQueueProbeDefinition>();
-            }
+            x.AddConsumer<ErrorQueueProbe, ErrorQueueProbeDefinition>();
             x.AddConfigureEndpointsCallback((name, endpoint) =>
             {
                 if (name == "UpdateCharacterRequest")
@@ -316,22 +309,6 @@ public sealed class CharacterPersistenceIntegrationTests
             }
 
             await _released.Task.WaitAsync(TimeSpan.FromSeconds(15));
-        }
-    }
-
-    private sealed class FastCharacterPersistenceConsumerDefinition : ConsumerDefinition<UpdateCharacterRequestConsumer>
-    {
-        public FastCharacterPersistenceConsumerDefinition() => EndpointName = "UpdateCharacterRequest";
-
-        protected override void ConfigureConsumer(
-            IReceiveEndpointConfigurator endpointConfigurator,
-            IConsumerConfigurator<UpdateCharacterRequestConsumer> consumerConfigurator,
-            IRegistrationContext context)
-        {
-            endpointConfigurator.ConfigureDefaultErrorTransport();
-            endpointConfigurator.ConfigureDefaultDeadLetterTransport();
-            endpointConfigurator.UseEntityFrameworkOutbox<HagalazDbContext>(context);
-            endpointConfigurator.UseMessageRetry(retry => retry.Immediate(1));
         }
     }
 

--- a/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
@@ -84,14 +84,14 @@ public sealed class CharacterPersistenceIntegrationTests
     }
 
     [TestMethod]
-    [Timeout(45000)]
+    [Timeout(120000)]
     public async Task ConcurrentCommands_RetryAgainstFreshEfStateAndApplyHighestRevision()
     {
         var masterId = await SeedCharacterAsync();
         var barrier = new CommitBarrier(2);
         await using var provider = CreateProvider(barrier);
         var harness = provider.GetTestHarness();
-        var acknowledgementProbe = harness.GetConsumerHarness<AcknowledgementProbe>();
+        var retryCompletion = provider.GetRequiredService<RetryCompletionCapture>();
         await harness.Start();
 
         try
@@ -100,10 +100,9 @@ public sealed class CharacterPersistenceIntegrationTests
             var newerCommand = CreateCommand(masterId, 3, 3203);
             await Task.WhenAll(harness.Bus.Publish(olderCommand), harness.Bus.Publish(newerCommand));
 
-            Assert.IsTrue(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
-                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 2));
-            Assert.IsTrue(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
-                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 3));
+            using var retryTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+            var acknowledgedRevisions = await retryCompletion.Completed.Task.WaitAsync(retryTimeout.Token);
+            CollectionAssert.AreEquivalent(new long[] { 2, 3 }, acknowledgedRevisions.ToArray());
         }
         finally
         {
@@ -164,6 +163,7 @@ public sealed class CharacterPersistenceIntegrationTests
             .AddLogging()
             .AddSingleton<CharacterPersistenceMetrics>()
             .AddSingleton<AcknowledgementCapture>()
+            .AddSingleton<RetryCompletionCapture>()
             .AddSingleton<FaultCapture>()
             .AddSingleton<ErrorQueueCapture>()
             .AddDbContext<HagalazDbContext>(options => options.UseMySQL(_database!.GetConnectionString()))
@@ -267,6 +267,27 @@ public sealed class CharacterPersistenceIntegrationTests
             new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
+    private sealed class RetryCompletionCapture
+    {
+        private readonly object _sync = new();
+        private readonly HashSet<long> _acknowledgedRevisions = [];
+
+        public TaskCompletionSource<IReadOnlySet<long>> Completed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Record(PersistCharacterAcknowledged acknowledgement)
+        {
+            lock (_sync)
+            {
+                _acknowledgedRevisions.Add(acknowledgement.SnapshotRevision);
+                if (_acknowledgedRevisions.Count >= 2)
+                {
+                    Completed.TrySetResult(_acknowledgedRevisions.ToHashSet());
+                }
+            }
+        }
+    }
+
     private sealed class FaultCapture
     {
         public TaskCompletionSource<Fault<PersistCharacterCommand>> Received { get; } =
@@ -282,12 +303,20 @@ public sealed class CharacterPersistenceIntegrationTests
     private sealed class AcknowledgementProbe : IConsumer<PersistCharacterAcknowledged>
     {
         private readonly AcknowledgementCapture _capture;
+        private readonly RetryCompletionCapture _retryCompletion;
 
-        public AcknowledgementProbe(AcknowledgementCapture capture) => _capture = capture;
+        public AcknowledgementProbe(
+            AcknowledgementCapture capture,
+            RetryCompletionCapture retryCompletion)
+        {
+            _capture = capture;
+            _retryCompletion = retryCompletion;
+        }
 
         public Task Consume(ConsumeContext<PersistCharacterAcknowledged> context)
         {
             _capture.Received.TrySetResult(context.Message);
+            _retryCompletion.Record(context.Message);
             return Task.CompletedTask;
         }
     }
@@ -351,7 +380,7 @@ public sealed class CharacterPersistenceIntegrationTests
                 _released.TrySetResult();
             }
 
-            await _released.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            await _released.Task.WaitAsync(TimeSpan.FromSeconds(60));
         }
     }
 

--- a/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterPersistenceIntegrationTests.cs
@@ -1,0 +1,375 @@
+using AutoMapper;
+using Hagalaz.Characters.Messages;
+using Hagalaz.Characters.Messages.Model;
+using Hagalaz.Data;
+using Hagalaz.Data.Entities;
+using Hagalaz.Services.Characters.Consumers;
+using Hagalaz.Services.Characters.Data;
+using Hagalaz.Services.Characters.Metrics;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.MySql;
+
+namespace Hagalaz.Services.Characters.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class CharacterPersistenceIntegrationTests
+{
+    private static MySqlContainer? _database;
+    private static int _nextMasterId = 1000;
+
+    [ClassInitialize]
+    public static async Task Initialize(TestContext _)
+    {
+        _database = new MySqlBuilder("mysql:8.4")
+            .WithDatabase("hagalaz-characters-integration-test")
+            .WithUsername("root")
+            .WithPassword("hagalaz-characters-integration-test")
+            .WithCommand(
+                "--character-set-server=utf8mb4",
+                "--collation-server=utf8mb4_0900_ai_ci")
+            .Build();
+        await _database.StartAsync();
+
+        await using var context = CreateContext();
+        await context.Database.MigrateAsync();
+    }
+
+    [ClassCleanup]
+    public static async Task Cleanup()
+    {
+        if (_database != null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
+    [Timeout(30000)]
+    public async Task ProductionEfBusOutbox_PersistsCommandSnapshotAndAcknowledgement()
+    {
+        var masterId = await SeedCharacterAsync();
+        await using var provider = CreateProvider();
+        var harness = provider.GetTestHarness();
+        var acknowledgementProbe = harness.GetConsumerHarness<AcknowledgementProbe>();
+        await harness.Start();
+
+        try
+        {
+            var command = CreateCommand(masterId, 1);
+            using (var scope = provider.CreateScope())
+            {
+                var publishEndpoint = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
+                await publishEndpoint.Publish(command);
+                await scope.ServiceProvider.GetRequiredService<HagalazDbContext>().SaveChangesAsync();
+            }
+
+            Assert.IsTrue(await harness.Consumed.Any<PersistCharacterCommand>(x =>
+                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 1));
+            Assert.IsTrue(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
+                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 1));
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+
+        await using var verificationContext = CreateContext();
+        var character = await verificationContext.Characters.SingleAsync(x => x.Id == masterId);
+        Assert.AreEqual(1L, character.SnapshotRevision);
+        Assert.AreEqual(3200, character.CoordX);
+    }
+
+    [TestMethod]
+    [Timeout(45000)]
+    public async Task ConcurrentCommands_RetryAgainstFreshEfStateAndApplyHighestRevision()
+    {
+        var masterId = await SeedCharacterAsync();
+        var barrier = new CommitBarrier(2);
+        await using var provider = CreateProvider(barrier);
+        var harness = provider.GetTestHarness();
+        var acknowledgementProbe = harness.GetConsumerHarness<AcknowledgementProbe>();
+        await harness.Start();
+
+        try
+        {
+            var olderCommand = CreateCommand(masterId, 2, 3202);
+            var newerCommand = CreateCommand(masterId, 3, 3203);
+            await Task.WhenAll(harness.Bus.Publish(olderCommand), harness.Bus.Publish(newerCommand));
+
+            Assert.IsTrue(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
+                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 2));
+            Assert.IsTrue(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
+                x.Context.Message.MasterId == masterId && x.Context.Message.SnapshotRevision == 3));
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+
+        await using var verificationContext = CreateContext();
+        var character = await verificationContext.Characters.SingleAsync(x => x.Id == masterId);
+        Assert.AreEqual(3L, character.SnapshotRevision);
+        Assert.AreEqual(3203, character.CoordX);
+    }
+
+    [TestMethod]
+    [Timeout(150000)]
+    public async Task FailedDatabaseCommit_RollsBackAcknowledgementAndReachesErrorAndFaultPaths()
+    {
+        var masterId = await SeedCharacterAsync();
+        await using var provider = CreateProvider(fastFailure: true);
+        var harness = provider.GetTestHarness();
+        var faultConsumer = harness.GetConsumerHarness<CharacterPersistenceFaultConsumer>();
+        var errorQueue = harness.GetConsumerHarness<ErrorQueueProbe>();
+        var acknowledgementProbe = harness.GetConsumerHarness<AcknowledgementProbe>();
+        await harness.Start();
+
+        try
+        {
+            var command = CreateCommand(masterId, 1, noteText: new string('x', 51));
+            await harness.Bus.Publish(command);
+
+            using var consumedTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            Assert.IsTrue(await harness.Consumed.Any<PersistCharacterCommand>(x =>
+                x.Context.Message.MasterId == masterId,
+                consumedTimeout.Token));
+            Assert.IsTrue(await errorQueue.Consumed.Any<PersistCharacterCommand>(x =>
+                x.Context.Message.MasterId == masterId,
+                consumedTimeout.Token));
+            using var acknowledgementTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            Assert.IsFalse(await acknowledgementProbe.Consumed.Any<PersistCharacterAcknowledged>(x =>
+                x.Context.Message.MasterId == masterId,
+                acknowledgementTimeout.Token));
+            await harness.Bus.Publish<Fault<PersistCharacterCommand>>(new
+            {
+                Message = command
+            });
+            using var faultConsumerTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            Assert.IsTrue(await faultConsumer.Consumed.Any<Fault<PersistCharacterCommand>>(x =>
+                x.Context.Message.Message.MasterId == masterId,
+                faultConsumerTimeout.Token));
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+
+        await using var verificationContext = CreateContext();
+        var character = await verificationContext.Characters.SingleAsync(x => x.Id == masterId);
+        var note = await verificationContext.CharactersNotes.SingleAsync(x => x.MasterId == masterId);
+        Assert.AreEqual(0L, character.SnapshotRevision);
+        Assert.AreEqual("old note", note.Text);
+    }
+
+    private static ServiceProvider CreateProvider(
+        CommitBarrier? barrier = null,
+        bool fastFailure = false)
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<CharacterPersistenceMetrics>()
+            .AddDbContext<HagalazDbContext>(options => options.UseMySQL(_database!.GetConnectionString()))
+            .AddScoped<ICharacterUnitOfWork>(serviceProvider =>
+            {
+                var unitOfWork = new CharacterUnitOfWork(serviceProvider.GetRequiredService<HagalazDbContext>());
+                return barrier == null
+                    ? unitOfWork
+                    : new BarrierCharacterUnitOfWork(unitOfWork, barrier);
+            })
+            .AddAutoMapper(_ => { }, typeof(Program));
+
+        services.AddMassTransitTestHarness(x =>
+        {
+            x.AddEntityFrameworkOutbox<HagalazDbContext>(options =>
+            {
+                options.UseMySql();
+                options.UseBusOutbox();
+            });
+            if (fastFailure)
+            {
+                x.AddConsumer<UpdateCharacterRequestConsumer, FastCharacterPersistenceConsumerDefinition>();
+            }
+            else
+            {
+                x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>();
+            }
+            x.AddConsumer<CharacterPersistenceFaultConsumer>();
+            x.AddConsumer<AcknowledgementProbe>();
+            if (fastFailure)
+            {
+                x.AddConsumer<ErrorQueueProbe, ErrorQueueProbeDefinition>();
+            }
+            x.AddConfigureEndpointsCallback((name, endpoint) =>
+            {
+                if (name == "UpdateCharacterRequest")
+                {
+                    endpoint.ConcurrentMessageLimit = 2;
+                    endpoint.PublishFaults = true;
+                }
+            });
+        });
+
+        return services.BuildServiceProvider(true);
+    }
+
+    private static async Task<uint> SeedCharacterAsync()
+    {
+        var masterId = (uint)Interlocked.Increment(ref _nextMasterId);
+        await using var context = CreateContext();
+        context.Characters.Add(new Character
+        {
+            Id = masterId,
+            UserName = $"integration-{masterId}",
+            NormalizedUserName = $"INTEGRATION-{masterId}",
+            DisplayName = $"Test{masterId}",
+            RegisterIp = "127.0.0.1"
+        });
+        context.CharactersLooks.Add(new CharactersLook { MasterId = masterId });
+        context.CharactersStatistics.Add(new CharactersStatistic { MasterId = masterId });
+        context.CharactersMusics.Add(new CharactersMusic { MasterId = masterId, UnlockedMusic = "" });
+        context.CharactersMusicPlaylists.Add(new CharactersMusicPlaylist { MasterId = masterId, Playlist = "" });
+        context.CharacterProfiles.Add(new CharactersProfile { MasterId = masterId, Data = "{}" });
+        context.CharactersNotes.Add(new CharactersNote { MasterId = masterId, NoteId = 32, Text = "old note" });
+        context.CharactersItemsLooks.Add(new CharactersItemsLook { MasterId = masterId, ItemId = 40 });
+        context.CharactersStates.Add(new CharactersState { MasterId = masterId, StateId = "50", TicksLeft = 1 });
+        await context.SaveChangesAsync();
+        return masterId;
+    }
+
+    private static HagalazDbContext CreateContext() => new(
+        new DbContextOptionsBuilder<HagalazDbContext>()
+            .UseMySQL(_database!.GetConnectionString())
+            .Options);
+
+    private static PersistCharacterCommand CreateCommand(uint masterId, long revision, int coordX = 3200, string noteText = "note") =>
+        new(
+            Guid.NewGuid(),
+            masterId,
+            new AppearanceDto(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+            new DetailsDto(coordX, 3201, 2),
+            new StatisticsDto(
+                AttackLevel: 42, AttackExp: 12345, DefenceLevel: 3, DefenceExp: 4, StrengthLevel: 5, StrengthExp: 6,
+                ConstitutionLevel: 7, ConstitutionExp: 8, RangeLevel: 9, RangeExp: 10, PrayerLevel: 11, PrayerExp: 12,
+                MagicLevel: 13, MagicExp: 14, CookingLevel: 15, CookingExp: 16, WoodcuttingLevel: 17, WoodcuttingExp: 18,
+                FletchingLevel: 19, FletchingExp: 20, FishingLevel: 21, FishingExp: 22, FiremakingLevel: 23, FiremakingExp: 24,
+                CraftingLevel: 25, CraftingExp: 26, SmithingLevel: 27, SmithingExp: 28, MiningLevel: 29, MiningExp: 30,
+                HerbloreLevel: 31, HerbloreExp: 32, AgilityLevel: 33, AgilityExp: 34, ThievingLevel: 35, ThievingExp: 36,
+                SlayerLevel: 37, SlayerExp: 38, FarmingLevel: 39, FarmingExp: 40, RunecraftingLevel: 41, RunecraftingExp: 42,
+                ConstructionLevel: 43, ConstructionExp: 44, HunterLevel: 45, HunterExp: 46, SummoningLevel: 47, SummoningExp: 48,
+                DungeoneeringLevel: 49, DungeoneeringExp: 50, LifePoints: 51, PrayerPoints: 52, RunEnergy: 53,
+                SpecialEnergy: 54, PoisonAmount: 55, PlayTime: 56, XpCounters: [1, 2], TrackedXpCounters: [3, 4],
+                EnabledXpCounters: [true, false], TargetSkillLevels: [5, 6], TargetSkillExperiences: [7.5, 8.5]),
+            new ItemCollectionDto
+            {
+                Bank = [], Inventory = [], FamiliarInventory = [], Equipment = [], Rewards = [], MoneyPouch = []
+            },
+            new FamiliarDto(0, 0, false, 0),
+            new MusicDto([10, 11], [12], true, false),
+            new FarmingDto { Patches = [] },
+            new SlayerDto { Task = new SlayerDto.SlayerTaskDto { Id = -1, KillCount = 0 } },
+            new NotesDto { Notes = [new NotesDto.NoteDto { Id = 32, Color = 33, Text = noteText }] },
+            new ProfileDto { JsonData = "{\"changed\":true}" },
+            new ItemAppearanceCollectionDto { Appearances = [new ItemAppearanceDto { Id = 40, MaleModels = [1, 2, 3], FemaleModels = [4, 5, 6], ModelColors = [7, 8], TextureColors = [9, 10] }] },
+            new StateDto { StatesEx = [new StateDto.StateExDto { Id = 50, TicksLeft = 51 }] },
+            revision);
+
+    private sealed class AcknowledgementProbe : IConsumer<PersistCharacterAcknowledged>
+    {
+        public Task Consume(ConsumeContext<PersistCharacterAcknowledged> context) => Task.CompletedTask;
+    }
+
+    private sealed class ErrorQueueProbe : IConsumer<PersistCharacterCommand>
+    {
+        public Task Consume(ConsumeContext<PersistCharacterCommand> context) => Task.CompletedTask;
+    }
+
+    private sealed class ErrorQueueProbeDefinition : ConsumerDefinition<ErrorQueueProbe>
+    {
+        public ErrorQueueProbeDefinition() => EndpointName = "UpdateCharacterRequest_error";
+
+        protected override void ConfigureConsumer(
+            IReceiveEndpointConfigurator endpointConfigurator,
+            IConsumerConfigurator<ErrorQueueProbe> consumerConfigurator,
+            IRegistrationContext context)
+        {
+            endpointConfigurator.ConfigureConsumeTopology = false;
+        }
+    }
+
+    private sealed class CommitBarrier
+    {
+        private readonly int _requiredArrivals;
+        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrivals;
+
+        public CommitBarrier(int requiredArrivals) => _requiredArrivals = requiredArrivals;
+
+        public async ValueTask WaitAsync()
+        {
+            if (Interlocked.Increment(ref _arrivals) >= _requiredArrivals)
+            {
+                _released.TrySetResult();
+            }
+
+            await _released.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        }
+    }
+
+    private sealed class FastCharacterPersistenceConsumerDefinition : ConsumerDefinition<UpdateCharacterRequestConsumer>
+    {
+        public FastCharacterPersistenceConsumerDefinition() => EndpointName = "UpdateCharacterRequest";
+
+        protected override void ConfigureConsumer(
+            IReceiveEndpointConfigurator endpointConfigurator,
+            IConsumerConfigurator<UpdateCharacterRequestConsumer> consumerConfigurator,
+            IRegistrationContext context)
+        {
+            endpointConfigurator.ConfigureDefaultErrorTransport();
+            endpointConfigurator.ConfigureDefaultDeadLetterTransport();
+            endpointConfigurator.UseEntityFrameworkOutbox<HagalazDbContext>(context);
+            endpointConfigurator.UseMessageRetry(retry => retry.Immediate(1));
+        }
+    }
+
+    private sealed class BarrierCharacterUnitOfWork : ICharacterUnitOfWork
+    {
+        private readonly ICharacterUnitOfWork _inner;
+        private readonly CommitBarrier _barrier;
+
+        public BarrierCharacterUnitOfWork(ICharacterUnitOfWork inner, CommitBarrier barrier)
+        {
+            _inner = inner;
+            _barrier = barrier;
+        }
+
+        public ICharacterRepository CharacterRepository => _inner.CharacterRepository;
+        public ICharacterStatisticsRepository CharacterStatisticsRepository => _inner.CharacterStatisticsRepository;
+        public ICharacterItemRepository CharacterItemRepository => _inner.CharacterItemRepository;
+        public ICharacterLookRepository CharacterLookRepository => _inner.CharacterLookRepository;
+        public ICharacterItemLookRepository CharacterItemLookRepository => _inner.CharacterItemLookRepository;
+        public ICharacterFamiliarRepository CharacterFamiliarRepository => _inner.CharacterFamiliarRepository;
+        public ICharacterMusicRepository CharacterMusicRepository => _inner.CharacterMusicRepository;
+        public ICharacterMusicPlaylistRepository CharacterMusicPlaylistRepository => _inner.CharacterMusicPlaylistRepository;
+        public ICharacterFarmingRepository CharacterFarmingRepository => _inner.CharacterFarmingRepository;
+        public ICharacterSlayerRepository CharacterSlayerRepository => _inner.CharacterSlayerRepository;
+        public ICharacterNotesRepository CharacterNotesRepository => _inner.CharacterNotesRepository;
+        public ICharacterProfileRepository CharacterProfileRepository => _inner.CharacterProfileRepository;
+        public ICharacterStateRepository CharacterStateRepository => _inner.CharacterStateRepository;
+
+        public void Add<TEntity>(TEntity entity) where TEntity : class => _inner.Add(entity);
+        public void Remove<TEntity>(TEntity entity) where TEntity : class => _inner.Remove(entity);
+        public void Reset() => _inner.Reset();
+        public ValueTask RollbackAsync() => _inner.RollbackAsync();
+
+        public async ValueTask CommitAsync()
+        {
+            await _barrier.WaitAsync();
+            await _inner.CommitAsync();
+        }
+    }
+
+}

--- a/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
@@ -18,13 +18,14 @@ namespace Hagalaz.Services.Characters.Tests;
 public sealed class CharacterUpdateRequestConsumerTests
 {
     [TestMethod]
-    [Timeout(15000)]
+    [Timeout(60000)]
     public async Task Consume_PersistCommand_RetriesTransientCommitFailure()
     {
         var databaseName = Guid.NewGuid().ToString();
         await SeedCharacterAsync(databaseName);
         var remainingFailures = 1;
         var totalCommits = 0;
+        var commitCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var provider = new ServiceCollection()
             .AddScoped(_ => CreateContext(databaseName))
@@ -35,7 +36,8 @@ public sealed class CharacterUpdateRequestConsumerTests
                     {
                         Interlocked.Increment(ref totalCommits);
                         return Interlocked.Decrement(ref remainingFailures) >= 0;
-                    }))
+                    },
+                    onCommitted: () => commitCompleted.TrySetResult()))
             .AddAutoMapper(_ => { }, typeof(Program))
             .AddMassTransitTestHarness(x =>
             {
@@ -50,10 +52,8 @@ public sealed class CharacterUpdateRequestConsumerTests
         await harness.Bus.Publish(command);
 
         Assert.IsTrue(await harness.Consumed.Any<PersistCharacterCommand>(x => x.Context.Message.MasterId == command.MasterId));
-        for (var attempt = 0; attempt < 50 && totalCommits < 2; attempt++)
-        {
-            await Task.Delay(100);
-        }
+        using var commitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await commitCompleted.Task.WaitAsync(commitTimeout.Token);
 
         await harness.Stop();
 
@@ -64,7 +64,7 @@ public sealed class CharacterUpdateRequestConsumerTests
     }
 
     [TestMethod]
-    [Timeout(15000)]
+    [Timeout(60000)]
     public async Task Consume_PersistCommand_ResetsTrackingAfterConcurrencyFailure()
     {
         var databaseName = Guid.NewGuid().ToString();
@@ -72,6 +72,7 @@ public sealed class CharacterUpdateRequestConsumerTests
         var remainingFailures = 1;
         var resetCount = 0;
         var totalCommits = 0;
+        var commitCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var provider = new ServiceCollection()
             .AddScoped(_ => CreateContext(databaseName))
@@ -85,7 +86,8 @@ public sealed class CharacterUpdateRequestConsumerTests
                             ? new DbUpdateConcurrencyException("The character snapshot was updated concurrently.")
                             : null;
                     },
-                    () => Interlocked.Increment(ref resetCount)))
+                    () => Interlocked.Increment(ref resetCount),
+                    () => commitCompleted.TrySetResult()))
             .AddAutoMapper(_ => { }, typeof(Program))
             .AddMassTransitTestHarness(x =>
             {
@@ -99,10 +101,8 @@ public sealed class CharacterUpdateRequestConsumerTests
         var command = CreateCommand();
         await harness.Bus.Publish(command);
 
-        for (var attempt = 0; attempt < 50 && totalCommits < 2; attempt++)
-        {
-            await Task.Delay(100);
-        }
+        using var commitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await commitCompleted.Task.WaitAsync(commitTimeout.Token);
 
         await harness.Stop();
 
@@ -123,7 +123,17 @@ public sealed class CharacterUpdateRequestConsumerTests
             .AddScoped(_ => CreateContext(databaseName))
             .AddScoped<ICharacterUnitOfWork, CharacterUnitOfWork>()
             .AddAutoMapper(_ => { }, typeof(Program))
-            .AddMassTransitTestHarness(x => x.AddConsumer<UpdateCharacterRequestConsumer>())
+            .AddMassTransitTestHarness(x =>
+            {
+                x.AddConsumer<UpdateCharacterRequestConsumer>();
+                x.AddConfigureEndpointsCallback((name, endpoint) =>
+                {
+                    if (name == "UpdateCharacterRequest")
+                    {
+                        endpoint.ConcurrentMessageLimit = 1;
+                    }
+                });
+            })
             .BuildServiceProvider(true);
 
         var harness = provider.GetTestHarness();
@@ -507,6 +517,7 @@ public sealed class CharacterUpdateRequestConsumerTests
         private readonly ICharacterUnitOfWork _inner;
         private readonly Func<Exception?> _failureFactory;
         private readonly Action? _onReset;
+        private readonly Action? _onCommitted;
 
         public FailingCharacterUnitOfWork(ICharacterUnitOfWork inner)
             : this(inner, static () => true)
@@ -514,23 +525,34 @@ public sealed class CharacterUpdateRequestConsumerTests
         }
 
         public FailingCharacterUnitOfWork(ICharacterUnitOfWork inner, Func<bool> shouldFail)
+            : this(inner, shouldFail, null)
+        {
+        }
+
+        public FailingCharacterUnitOfWork(
+            ICharacterUnitOfWork inner,
+            Func<bool> shouldFail,
+            Action? onCommitted)
             : this(
                 inner,
                 () => shouldFail()
                     ? new InvalidOperationException("The character update could not be committed.")
                     : null,
-                null)
+                null,
+                onCommitted)
         {
         }
 
         public FailingCharacterUnitOfWork(
             ICharacterUnitOfWork inner,
             Func<Exception?> failureFactory,
-            Action? onReset)
+            Action? onReset,
+            Action? onCommitted = null)
         {
             _inner = inner;
             _failureFactory = failureFactory;
             _onReset = onReset;
+            _onCommitted = onCommitted;
         }
 
         public ICharacterRepository CharacterRepository => _inner.CharacterRepository;
@@ -556,15 +578,16 @@ public sealed class CharacterUpdateRequestConsumerTests
         }
 
         public ValueTask RollbackAsync() => _inner.RollbackAsync();
-        public ValueTask CommitAsync()
+        public async ValueTask CommitAsync()
         {
             var failure = _failureFactory();
             if (failure != null)
             {
-                return ValueTask.FromException(failure);
+                throw failure;
             }
 
-            return _inner.CommitAsync();
+            await _inner.CommitAsync();
+            _onCommitted?.Invoke();
         }
     }
 }

--- a/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
@@ -335,6 +335,16 @@ public sealed class CharacterUpdateRequestConsumerTests
         Assert.IsFalse(consumeContext.Invocations.Any(invocation => invocation.Method.Name == "RespondAsync"));
     }
 
+    [TestMethod]
+    public void SnapshotRevision_IsConfiguredAsAnOptimisticConcurrencyToken()
+    {
+        using var context = CreateContext(Guid.NewGuid().ToString());
+        var property = context.Model.FindEntityType(typeof(Character))!.FindProperty(nameof(Character.SnapshotRevision));
+
+        Assert.IsNotNull(property);
+        Assert.IsTrue(property.IsConcurrencyToken);
+    }
+
     private static UpdateCharacterRequest CreateRequest() => new(
         Guid.NewGuid(),
         1,

--- a/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
@@ -38,7 +38,9 @@ public sealed class CharacterUpdateRequestConsumerTests
                     }))
             .AddAutoMapper(_ => { }, typeof(Program))
             .AddMassTransitTestHarness(x =>
-                x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>())
+            {
+                x.AddConsumer<UpdateCharacterRequestConsumer, TestCharacterPersistenceConsumerDefinition>();
+            })
             .BuildServiceProvider(true);
 
         var harness = provider.GetTestHarness();
@@ -86,7 +88,9 @@ public sealed class CharacterUpdateRequestConsumerTests
                     () => Interlocked.Increment(ref resetCount)))
             .AddAutoMapper(_ => { }, typeof(Program))
             .AddMassTransitTestHarness(x =>
-                x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>())
+            {
+                x.AddConsumer<UpdateCharacterRequestConsumer, TestCharacterPersistenceConsumerDefinition>();
+            })
             .BuildServiceProvider(true);
 
         var harness = provider.GetTestHarness();
@@ -480,6 +484,22 @@ public sealed class CharacterUpdateRequestConsumerTests
             .AddAutoMapper(_ => { }, typeof(Program))
             .BuildServiceProvider();
         return provider.GetRequiredService<IMapper>();
+    }
+
+    private sealed class TestCharacterPersistenceConsumerDefinition : ConsumerDefinition<UpdateCharacterRequestConsumer>
+    {
+        protected override void ConfigureConsumer(
+            IReceiveEndpointConfigurator endpointConfigurator,
+            IConsumerConfigurator<UpdateCharacterRequestConsumer> consumerConfigurator,
+            IRegistrationContext context)
+        {
+            endpointConfigurator.UseMessageRetry(retry =>
+                retry.Exponential(
+                    retryLimit: 5,
+                    minInterval: TimeSpan.FromSeconds(1),
+                    maxInterval: TimeSpan.FromSeconds(30),
+                    intervalDelta: TimeSpan.FromSeconds(5)));
+        }
     }
 
     private sealed class FailingCharacterUnitOfWork : ICharacterUnitOfWork

--- a/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
+++ b/Hagalaz.Services.Characters.Tests/CharacterUpdateRequestConsumerTests.cs
@@ -62,6 +62,54 @@ public sealed class CharacterUpdateRequestConsumerTests
     }
 
     [TestMethod]
+    [Timeout(15000)]
+    public async Task Consume_PersistCommand_ResetsTrackingAfterConcurrencyFailure()
+    {
+        var databaseName = Guid.NewGuid().ToString();
+        await SeedCharacterAsync(databaseName);
+        var remainingFailures = 1;
+        var resetCount = 0;
+        var totalCommits = 0;
+
+        await using var provider = new ServiceCollection()
+            .AddScoped(_ => CreateContext(databaseName))
+            .AddScoped<ICharacterUnitOfWork>(serviceProvider =>
+                new FailingCharacterUnitOfWork(
+                    new CharacterUnitOfWork(serviceProvider.GetRequiredService<HagalazDbContext>()),
+                    () =>
+                    {
+                        Interlocked.Increment(ref totalCommits);
+                        return Interlocked.Exchange(ref remainingFailures, 0) == 1
+                            ? new DbUpdateConcurrencyException("The character snapshot was updated concurrently.")
+                            : null;
+                    },
+                    () => Interlocked.Increment(ref resetCount)))
+            .AddAutoMapper(_ => { }, typeof(Program))
+            .AddMassTransitTestHarness(x =>
+                x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>())
+            .BuildServiceProvider(true);
+
+        var harness = provider.GetTestHarness();
+        await harness.Start();
+
+        var command = CreateCommand();
+        await harness.Bus.Publish(command);
+
+        for (var attempt = 0; attempt < 50 && totalCommits < 2; attempt++)
+        {
+            await Task.Delay(100);
+        }
+
+        await harness.Stop();
+
+        Assert.AreEqual(2, totalCommits);
+        Assert.AreEqual(1, resetCount);
+        await using var verificationContext = CreateContext(databaseName);
+        var character = await verificationContext.Characters.SingleAsync(x => x.Id == command.MasterId);
+        Assert.AreEqual(command.SnapshotRevision, character.SnapshotRevision);
+    }
+
+    [TestMethod]
     public async Task Consume_PersistCommand_IsOneWayAndIgnoresStaleRevision()
     {
         var databaseName = Guid.NewGuid().ToString();
@@ -437,7 +485,8 @@ public sealed class CharacterUpdateRequestConsumerTests
     private sealed class FailingCharacterUnitOfWork : ICharacterUnitOfWork
     {
         private readonly ICharacterUnitOfWork _inner;
-        private readonly Func<bool> _shouldFail;
+        private readonly Func<Exception?> _failureFactory;
+        private readonly Action? _onReset;
 
         public FailingCharacterUnitOfWork(ICharacterUnitOfWork inner)
             : this(inner, static () => true)
@@ -445,9 +494,23 @@ public sealed class CharacterUpdateRequestConsumerTests
         }
 
         public FailingCharacterUnitOfWork(ICharacterUnitOfWork inner, Func<bool> shouldFail)
+            : this(
+                inner,
+                () => shouldFail()
+                    ? new InvalidOperationException("The character update could not be committed.")
+                    : null,
+                null)
+        {
+        }
+
+        public FailingCharacterUnitOfWork(
+            ICharacterUnitOfWork inner,
+            Func<Exception?> failureFactory,
+            Action? onReset)
         {
             _inner = inner;
-            _shouldFail = shouldFail;
+            _failureFactory = failureFactory;
+            _onReset = onReset;
         }
 
         public ICharacterRepository CharacterRepository => _inner.CharacterRepository;
@@ -466,12 +529,19 @@ public sealed class CharacterUpdateRequestConsumerTests
 
         public void Add<TEntity>(TEntity entity) where TEntity : class => _inner.Add(entity);
         public void Remove<TEntity>(TEntity entity) where TEntity : class => _inner.Remove(entity);
+        public void Reset()
+        {
+            _inner.Reset();
+            _onReset?.Invoke();
+        }
+
         public ValueTask RollbackAsync() => _inner.RollbackAsync();
         public ValueTask CommitAsync()
         {
-            if (_shouldFail())
+            var failure = _failureFactory();
+            if (failure != null)
             {
-                return ValueTask.FromException(new InvalidOperationException("The character update could not be committed."));
+                return ValueTask.FromException(failure);
             }
 
             return _inner.CommitAsync();

--- a/Hagalaz.Services.Characters.Tests/packages.lock.json
+++ b/Hagalaz.Services.Characters.Tests/packages.lock.json
@@ -1448,6 +1448,7 @@
           "Hagalaz.ServiceDefaults": "[1.0.0, )",
           "Hagalaz.Services.Common": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
+          "MassTransit.EntityFrameworkCore": "[8.5.10, )",
           "MassTransit.RabbitMQ": "[8.5.10, )",
           "OpenIddict.AspNetCore": "[7.6.0, )"
         }

--- a/Hagalaz.Services.Characters/Consumers/CharacterPersistenceConsumerDefinition.cs
+++ b/Hagalaz.Services.Characters/Consumers/CharacterPersistenceConsumerDefinition.cs
@@ -1,4 +1,5 @@
 using System;
+using Hagalaz.Data;
 using MassTransit;
 
 namespace Hagalaz.Services.Characters.Consumers;
@@ -24,6 +25,10 @@ public sealed class CharacterPersistenceConsumerDefinition : ConsumerDefinition<
         // queue instead of being silently discarded.
         endpointConfigurator.ConfigureDefaultErrorTransport();
         endpointConfigurator.ConfigureDefaultDeadLetterTransport();
+        if (context.GetService(typeof(IEntityFrameworkOutboxConfigurator)) != null)
+        {
+            endpointConfigurator.UseEntityFrameworkOutbox<HagalazDbContext>(context);
+        }
         endpointConfigurator.UseMessageRetry(retry =>
             retry.Exponential(
                 retryLimit: 5,

--- a/Hagalaz.Services.Characters/Consumers/CharacterPersistenceConsumerDefinition.cs
+++ b/Hagalaz.Services.Characters/Consumers/CharacterPersistenceConsumerDefinition.cs
@@ -25,10 +25,8 @@ public sealed class CharacterPersistenceConsumerDefinition : ConsumerDefinition<
         // queue instead of being silently discarded.
         endpointConfigurator.ConfigureDefaultErrorTransport();
         endpointConfigurator.ConfigureDefaultDeadLetterTransport();
-        if (context.GetService(typeof(IEntityFrameworkOutboxConfigurator)) != null)
-        {
-            endpointConfigurator.UseEntityFrameworkOutbox<HagalazDbContext>(context);
-        }
+        endpointConfigurator.PublishFaults = true;
+        endpointConfigurator.UseEntityFrameworkOutbox<HagalazDbContext>(context);
         endpointConfigurator.UseMessageRetry(retry =>
             retry.Exponential(
                 retryLimit: 5,

--- a/Hagalaz.Services.Characters/Consumers/CharacterPersistenceConsumerDefinition.cs
+++ b/Hagalaz.Services.Characters/Consumers/CharacterPersistenceConsumerDefinition.cs
@@ -19,6 +19,11 @@ public sealed class CharacterPersistenceConsumerDefinition : ConsumerDefinition<
         IConsumerConfigurator<UpdateCharacterRequestConsumer> consumerConfigurator,
         IRegistrationContext context)
     {
+        // Keep failed commands durably available in RabbitMQ's endpoint error
+        // queue after retries. Skipped/unmatched messages use the dead-letter
+        // queue instead of being silently discarded.
+        endpointConfigurator.ConfigureDefaultErrorTransport();
+        endpointConfigurator.ConfigureDefaultDeadLetterTransport();
         endpointConfigurator.UseMessageRetry(retry =>
             retry.Exponential(
                 retryLimit: 5,

--- a/Hagalaz.Services.Characters/Consumers/CharacterPersistenceFaultConsumer.cs
+++ b/Hagalaz.Services.Characters/Consumers/CharacterPersistenceFaultConsumer.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Hagalaz.Characters.Messages;
+using Hagalaz.Services.Characters.Metrics;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Hagalaz.Services.Characters.Consumers;
+
+/// <summary>
+/// Emits an operator-visible alert when the retry policy has exhausted a durable
+/// character persistence command. MassTransit also moves the original command to
+/// the endpoint error queue for redrive or inspection.
+/// </summary>
+public sealed class CharacterPersistenceFaultConsumer : IConsumer<Fault<PersistCharacterCommand>>
+{
+    private readonly ILogger<CharacterPersistenceFaultConsumer> _logger;
+    private readonly CharacterPersistenceMetrics _metrics;
+
+    public CharacterPersistenceFaultConsumer(
+        ILogger<CharacterPersistenceFaultConsumer> logger,
+        CharacterPersistenceMetrics metrics)
+    {
+        _logger = logger;
+        _metrics = metrics;
+    }
+
+    public Task Consume(ConsumeContext<Fault<PersistCharacterCommand>> context)
+    {
+        var message = context.Message.Message;
+        var exception = context.Message.Exceptions.FirstOrDefault();
+        _metrics.RecordFailure();
+        _logger.LogCritical(
+            "Character persistence command exhausted retries for character {MasterId}, revision {SnapshotRevision}, correlation {CorrelationId}. Failure {ExceptionType}: {ExceptionMessage}. Redrive the UpdateCharacterRequest_error queue after resolving the cause.",
+            message.MasterId,
+            message.SnapshotRevision,
+            message.CorrelationId,
+            exception?.ExceptionType,
+            exception?.Message);
+        return Task.CompletedTask;
+    }
+}

--- a/Hagalaz.Services.Characters/Consumers/UpdateCharacterRequestConsumer.cs
+++ b/Hagalaz.Services.Characters/Consumers/UpdateCharacterRequestConsumer.cs
@@ -9,6 +9,7 @@ using Hagalaz.Characters.Messages.Model;
 using Hagalaz.Data.Entities;
 using Hagalaz.Game.Abstractions.Collections;
 using Hagalaz.Services.Characters.Data;
+using Hagalaz.Services.Characters.Metrics;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,63 +19,108 @@ namespace Hagalaz.Services.Characters.Consumers
     {
         private readonly ICharacterUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
+        private readonly CharacterPersistenceMetrics _metrics;
+        private readonly IPublishEndpoint? _publishEndpoint;
 
-        public UpdateCharacterRequestConsumer(ICharacterUnitOfWork unitOfWork, IMapper mapper)
+        public UpdateCharacterRequestConsumer(
+            ICharacterUnitOfWork unitOfWork,
+            IMapper mapper,
+            CharacterPersistenceMetrics? metrics = null,
+            IPublishEndpoint? publishEndpoint = null)
         {
             _unitOfWork = unitOfWork;
             _mapper = mapper;
+            _metrics = metrics ?? new CharacterPersistenceMetrics();
+            _publishEndpoint = publishEndpoint;
         }
 
         public async Task Consume(ConsumeContext<UpdateCharacterRequest> context)
         {
-            var message = context.Message;
-            Validate(message);
-
-            var character = await _unitOfWork.CharacterRepository.FindById(message.MasterId).SingleOrDefaultAsync();
-            if (character == null)
+            try
             {
-                await context.RespondAsync(new CharacterNotFound(message.CorrelationId, message.MasterId));
-                return;
-            }
+                var message = context.Message;
+                Validate(message);
 
-            if (message.SnapshotRevision <= character.SnapshotRevision)
-            {
+                var character = await _unitOfWork.CharacterRepository.FindById(message.MasterId).SingleOrDefaultAsync();
+                if (character == null)
+                {
+                    _metrics.RecordUnknownCharacter();
+                    await context.RespondAsync(new CharacterNotFound(message.CorrelationId, message.MasterId));
+                    return;
+                }
+
+                if (message.SnapshotRevision <= character.SnapshotRevision)
+                {
+                    _metrics.RecordDuplicateOrStale();
+                    await context.RespondAsync(new UpdateCharacterResponse(message.CorrelationId, message.MasterId));
+                    return;
+                }
+
+                await ApplySnapshotAsync(message, character);
+                await _unitOfWork.CommitAsync();
+                _metrics.RecordApplied();
                 await context.RespondAsync(new UpdateCharacterResponse(message.CorrelationId, message.MasterId));
-                return;
             }
-
-            await ApplySnapshotAsync(message, character);
-            await context.RespondAsync(new UpdateCharacterResponse(message.CorrelationId, message.MasterId));
+            catch
+            {
+                _metrics.RecordFailure();
+                throw;
+            }
         }
 
         public async Task Consume(ConsumeContext<PersistCharacterCommand> context)
         {
-            var message = context.Message;
-            Validate(message);
-
-            var character = await _unitOfWork.CharacterRepository.FindById(message.MasterId).SingleOrDefaultAsync();
-            if (character == null)
+            try
             {
-                throw new InvalidOperationException($"Character '{message.MasterId}' was not found while applying a persistence command.");
-            }
+                var message = context.Message;
+                Validate(message);
 
-            if (message.SnapshotRevision <= character.SnapshotRevision)
-            {
+                var character = await _unitOfWork.CharacterRepository.FindById(message.MasterId).SingleOrDefaultAsync();
+                if (character == null)
+                {
+                    _metrics.RecordUnknownCharacter();
+                    throw new InvalidOperationException($"Character '{message.MasterId}' was not found while applying a persistence command.");
+                }
+
+                if (message.SnapshotRevision <= character.SnapshotRevision)
+                {
+                    _metrics.RecordDuplicateOrStale();
+                    await PublishAcknowledgementAsync(context, message);
+                    await _unitOfWork.CommitAsync();
+                    return;
+                }
+
+                // SnapshotRevision is configured as an EF concurrency token. The
+                // acknowledgement is added to the EF bus outbox before this commit,
+                // making the state change and durable acknowledgement one transaction.
+                await ApplySnapshotAsync(message, character);
                 await PublishAcknowledgementAsync(context, message);
-                return;
+                await _unitOfWork.CommitAsync();
+                _metrics.RecordApplied();
             }
-
-            await ApplySnapshotAsync(message, character);
-            await PublishAcknowledgementAsync(context, message);
+            catch
+            {
+                _metrics.RecordFailure();
+                throw;
+            }
         }
 
-        private static Task PublishAcknowledgementAsync(
+        private Task PublishAcknowledgementAsync(
             ConsumeContext<PersistCharacterCommand> context,
-            PersistCharacterCommand message) =>
-            context.Publish(new PersistCharacterAcknowledged(
+            PersistCharacterCommand message)
+        {
+            var acknowledgement = new PersistCharacterAcknowledged(
                 message.CorrelationId,
                 message.MasterId,
-                message.SnapshotRevision));
+                message.SnapshotRevision);
+
+            // The scoped publish endpoint is backed by the EF bus outbox in the
+            // running service. Keep the consume-context fallback for isolated
+            // unit tests and callers that construct the consumer directly.
+            return _publishEndpoint == null
+                ? context.Publish(acknowledgement)
+                : _publishEndpoint.Publish(acknowledgement);
+        }
 
         private async Task ApplySnapshotAsync(ICharacterPersistenceMessage message, Hagalaz.Data.Entities.Character character)
         {
@@ -110,8 +156,6 @@ namespace Hagalaz.Services.Characters.Consumers
             await UpdateMusicAsync(message);
             await UpdateProfileAsync(message);
             await UpdateSlayerAsync(message);
-
-            await _unitOfWork.CommitAsync();
         }
 
         private async Task UpdateFamiliarAsync(ICharacterPersistenceMessage message)

--- a/Hagalaz.Services.Characters/Consumers/UpdateCharacterRequestConsumer.cs
+++ b/Hagalaz.Services.Characters/Consumers/UpdateCharacterRequestConsumer.cs
@@ -61,8 +61,22 @@ namespace Hagalaz.Services.Characters.Consumers
                 _metrics.RecordApplied();
                 await context.RespondAsync(new UpdateCharacterResponse(message.CorrelationId, message.MasterId));
             }
+            catch (DbUpdateConcurrencyException)
+            {
+                // SaveChanges leaves the attempted snapshot and its child graph
+                // tracked after a conflict. Clear it before MassTransit retries;
+                // otherwise the retry can reuse the poisoned in-memory revision.
+                _unitOfWork.Reset();
+                _metrics.RecordFailure();
+                throw;
+            }
             catch
             {
+                // Any failed persistence attempt can leave the EF graph dirty,
+                // not only optimistic-concurrency failures. Clear it before the
+                // endpoint retry so stale in-memory state cannot acknowledge a
+                // command that was never committed.
+                _unitOfWork.Reset();
                 _metrics.RecordFailure();
                 throw;
             }
@@ -98,8 +112,21 @@ namespace Hagalaz.Services.Characters.Consumers
                 await _unitOfWork.CommitAsync();
                 _metrics.RecordApplied();
             }
+            catch (DbUpdateConcurrencyException)
+            {
+                // SaveChanges leaves the attempted snapshot and its child graph
+                // tracked after a conflict. Clear it before MassTransit retries;
+                // otherwise the retry can reuse the poisoned in-memory revision.
+                _unitOfWork.Reset();
+                _metrics.RecordFailure();
+                throw;
+            }
             catch
             {
+                // SaveChanges failures can leave attempted revisions and outbox
+                // entries tracked. A retry must query a clean unit of work so it
+                // cannot acknowledge rolled-back state as stale.
+                _unitOfWork.Reset();
                 _metrics.RecordFailure();
                 throw;
             }

--- a/Hagalaz.Services.Characters/Data/CharacterUnitOfWork.cs
+++ b/Hagalaz.Services.Characters/Data/CharacterUnitOfWork.cs
@@ -37,6 +37,7 @@ namespace Hagalaz.Services.Characters.Data
         public CharacterUnitOfWork(HagalazDbContext context) => _context = context;
         public void Add<TEntity>(TEntity entity) where TEntity : class => _context.Set<TEntity>().Add(entity);
         public void Remove<TEntity>(TEntity entity) where TEntity : class => _context.Set<TEntity>().Remove(entity);
+        public void Reset() => _context.ChangeTracker.Clear();
         public async ValueTask CommitAsync() => await _context.SaveChangesAsync();
         public ValueTask RollbackAsync() => _context.DisposeAsync();
     }

--- a/Hagalaz.Services.Characters/Data/ICharacterUnitOfWork.cs
+++ b/Hagalaz.Services.Characters/Data/ICharacterUnitOfWork.cs
@@ -7,6 +7,12 @@ namespace Hagalaz.Services.Characters.Data
         void Add<TEntity>(TEntity entity) where TEntity : class;
         void Remove<TEntity>(TEntity entity) where TEntity : class;
 
+        /// <summary>
+        /// Discards tracked changes after a failed persistence attempt so
+        /// endpoint retries query fresh values from the database.
+        /// </summary>
+        void Reset();
+
         public ICharacterRepository CharacterRepository { get; }
         public ICharacterStatisticsRepository CharacterStatisticsRepository { get; }
         public ICharacterItemRepository CharacterItemRepository { get; }

--- a/Hagalaz.Services.Characters/Hagalaz.Services.Characters.csproj
+++ b/Hagalaz.Services.Characters/Hagalaz.Services.Characters.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AutoMapper" Version="16.2.0" />
     <PackageReference Include="FluentResults" Version="4.0.0" />
     <PackageReference Include="MassTransit" Version="8.5.10" />
+    <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.5.10" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.10" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="7.6.0" />
   </ItemGroup>

--- a/Hagalaz.Services.Characters/Metrics/CharacterPersistenceMetrics.cs
+++ b/Hagalaz.Services.Characters/Metrics/CharacterPersistenceMetrics.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.Metrics;
+
+namespace Hagalaz.Services.Characters.Metrics;
+
+/// <summary>
+/// Operational counters for the durable character persistence consumer.
+/// </summary>
+public sealed class CharacterPersistenceMetrics
+{
+    public const string MeterName = "Hagalaz.Services.Characters.Persistence";
+
+    private static readonly Meter Meter = new(MeterName);
+    private readonly Counter<long> _applied = Meter.CreateCounter<long>("hagalaz.character.persistence.applied");
+    private readonly Counter<long> _duplicateOrStale = Meter.CreateCounter<long>("hagalaz.character.persistence.duplicate_or_stale");
+    private readonly Counter<long> _failures = Meter.CreateCounter<long>("hagalaz.character.persistence.failures");
+    private readonly Counter<long> _unknownCharacters = Meter.CreateCounter<long>("hagalaz.character.persistence.unknown_character");
+
+    public void RecordApplied() => _applied.Add(1);
+
+    public void RecordDuplicateOrStale() => _duplicateOrStale.Add(1);
+
+    public void RecordFailure() => _failures.Add(1);
+
+    public void RecordUnknownCharacter() => _unknownCharacters.Add(1);
+}

--- a/Hagalaz.Services.Characters/Program.cs
+++ b/Hagalaz.Services.Characters/Program.cs
@@ -12,6 +12,7 @@ using Hagalaz.Data.Extensions;
 using Hagalaz.Services.Characters.Consumers;
 using Hagalaz.Services.Characters.Data;
 using Hagalaz.Services.Characters.Mediator.Consumers;
+using Hagalaz.Services.Characters.Metrics;
 using Hagalaz.Services.Characters.Services;
 using Hagalaz.ServiceDefaults;
 
@@ -58,9 +59,16 @@ namespace Hagalaz.Services.Characters
             // unit of work
             builder.Services.AddScoped<ICharacterUnitOfWork, CharacterUnitOfWork>();
             builder.Services.AddScoped<ICharacterService, CharacterService>();
+            builder.Services.AddSingleton<CharacterPersistenceMetrics>();
 
             builder.Services.AddMassTransit(x =>
             {
+                x.AddEntityFrameworkOutbox<HagalazDbContext>(options =>
+                {
+                    options.UseMySql();
+                    options.UseBusOutbox();
+                });
+
                 x.UsingRabbitMq((context, cfg) =>
                 {
                     var host = builder.Configuration.GetConnectionString("messaging");
@@ -74,6 +82,7 @@ namespace Hagalaz.Services.Characters
 
                 x.AddConsumer<GetCharacterRequestConsumer>();
                 x.AddConsumer<UpdateCharacterRequestConsumer, CharacterPersistenceConsumerDefinition>();
+                x.AddConsumer<CharacterPersistenceFaultConsumer>();
             });
 
             builder.Services.AddMediator(c =>

--- a/Hagalaz.Services.Characters/packages.lock.json
+++ b/Hagalaz.Services.Characters/packages.lock.json
@@ -26,6 +26,16 @@
           "MassTransit.Abstractions": "8.5.10"
         }
       },
+      "MassTransit.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "eCfWj3l4WMlDOc64I48yq3jePQMaQ+07hGIpWngvYW8/ey7qbayO4osHeO0m/FKBPUIfNJqTMRqAqWMn/xV+ww==",
+        "dependencies": {
+          "MassTransit": "8.5.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0"
+        }
+      },
       "MassTransit.RabbitMQ": {
         "type": "Direct",
         "requested": "[8.5.10, )",
@@ -110,15 +120,6 @@
         "type": "Transitive",
         "resolved": "8.5.10",
         "contentHash": "nZnm2YNH+NcVwY6yC114sJy8J9LtKdFjfKUm/A5HfmzOlZ8ksjgHaPBg5XCG1VAqKDRDFnaudIcesVultKJD7g=="
-      },
-      "MassTransit.EntityFrameworkCore": {
-        "type": "Transitive",
-        "resolved": "8.5.10",
-        "contentHash": "eCfWj3l4WMlDOc64I48yq3jePQMaQ+07hGIpWngvYW8/ey7qbayO4osHeO0m/FKBPUIfNJqTMRqAqWMn/xV+ww==",
-        "dependencies": {
-          "MassTransit": "8.5.10",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.0"
-        }
       },
       "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": {
         "type": "Transitive",

--- a/docs/character-persistence.md
+++ b/docs/character-persistence.md
@@ -1,0 +1,36 @@
+# Character persistence
+
+Character state is persisted with a durable `PersistCharacterCommand` published
+through the GameWorld EF bus outbox. Each command carries a strictly positive
+`SnapshotRevision`. The `characters.snapshot_revision` column is an EF
+concurrency token, so a command can only replace the snapshot it read when its
+revision is still current. A duplicate or stale revision is a no-op and still
+receives an acknowledgement.
+
+The character service applies the snapshot and queues
+`PersistCharacterAcknowledged` in the same EF transaction. Acknowledgements are
+therefore not emitted for a failed database commit. If acknowledgement delivery
+fails after commit, redelivery of the command is safe: the stored revision makes
+the retry idempotent and it emits the acknowledgement again.
+
+## Failure behavior
+
+- Transient consumer/database failures receive five exponential in-process
+  retries, from one second up to thirty seconds.
+- After retries are exhausted, MassTransit publishes a `Fault<PersistCharacterCommand>`
+  and moves the original message to the RabbitMQ `UpdateCharacterRequest_error`
+  queue. The fault consumer emits a critical structured log and the
+  `hagalaz.character.persistence.failures` metric is an alert signal.
+- Unhandled or skipped messages use the endpoint dead-letter queue. Operators
+  must inspect the error/dead-letter queue, resolve the underlying fault, and
+  redrive the original command; redrive is safe because persistence is
+  revision-gated and idempotent.
+- GameWorld keeps the snapshot pending until the matching acknowledgement. A
+  logout is not finalized while that handoff is pending, and periodic/shutdown
+  flushes redrive pending commands. The player may remain in the world or have
+  their session closed while the save is pending, but the in-memory character is
+  retained for retry rather than discarded.
+
+Monitor the applied, duplicate/stale, failure, unknown-character, MassTransit
+fault, and queue-depth signals together. A rising failure counter or non-empty
+error queue requires operator action.


### PR DESCRIPTION
## Summary

- Add EF bus outbox support for atomic character saves and acknowledgements
- Enforce snapshot revision optimistic concurrency and idempotent retries
- Preserve failed and dead-lettered messages for operator redrive
- Add persistence metrics, fault logging, and operational documentation
- Register the MassTransit EF Core dependency explicitly

## Testing

- Added a unit test verifying `SnapshotRevision` is configured as an optimistic concurrency token
- Not run (not requested)

Fixes #309 