### PR TITLE
Clean up sessions when world sign-in fails

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/AuthenticationSignInTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/AuthenticationSignInTests.cs
@@ -1,0 +1,269 @@
+using System.Net;
+using System.Reflection;
+using System.Security.Claims;
+using AutoMapper;
+using Hagalaz.Authorization.Messages;
+using Hagalaz.Characters.Messages;
+using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Mediator;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Services.GameWorld.Factories;
+using Hagalaz.Services.GameWorld.Features;
+using Hagalaz.Services.GameWorld.Logic.Characters.Messages;
+using Hagalaz.Services.GameWorld.Services;
+using Hagalaz.Services.GameWorld.Services.Model;
+using MassTransit;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Polly;
+using Raido.Server;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class AuthenticationSignInTests
+{
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task SignInWorldAsync_WhenCharacterHydrationFails_RemovesSession()
+    {
+        var gameSessionService = Substitute.For<IGameSessionService>();
+        var session = Substitute.For<IGameSession>();
+        session.ConnectionId.Returns("connection");
+        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult(session));
+        gameSessionService.RemoveSession("connection").Returns(Task.FromResult(true));
+
+        var characterHydrationService = Substitute.For<ICharacterHydrationService>();
+        characterHydrationService.HydrateAsync(Arg.Any<ICharacter>(), Arg.Any<CharacterModel>())
+            .Returns(Task.FromResult(false));
+
+        var service = CreateAuthenticationService(
+            gameSessionService,
+            characterHydrationService: characterHydrationService);
+
+        var result = await service.SignInWorldAsync(CreateSignInRequest());
+
+        Assert.IsFalse(result.Succeeded);
+        await gameSessionService.Received(1).RemoveSession("connection");
+    }
+
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task SignInWorldAsync_WhenCharacterRegistrationFails_RemovesSession()
+    {
+        var gameSessionService = Substitute.For<IGameSessionService>();
+        var session = Substitute.For<IGameSession>();
+        session.ConnectionId.Returns("connection");
+        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult(session));
+        gameSessionService.RemoveSession("connection").Returns(Task.FromResult(true));
+
+        var characterService = new TestCharacterService(addResult: false);
+
+        var service = CreateAuthenticationService(
+            gameSessionService,
+            characterService: characterService);
+
+        var result = await service.SignInWorldAsync(CreateSignInRequest());
+
+        Assert.IsFalse(result.Succeeded);
+        await gameSessionService.Received(1).RemoveSession("connection");
+    }
+
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task SignInWorldAsync_WhenCharacterRegistrationSucceeds_KeepsSession()
+    {
+        var gameSessionService = Substitute.For<IGameSessionService>();
+        var session = Substitute.For<IGameSession>();
+        session.ConnectionId.Returns("connection");
+        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult(session));
+        var characterService = new TestCharacterService(addResult: true);
+        var characterHydrationService = Substitute.For<ICharacterHydrationService>();
+        characterHydrationService.HydrateAsync(Arg.Any<ICharacter>(), Arg.Any<CharacterModel>()).Returns(Task.FromResult(true));
+
+        var service = CreateAuthenticationService(
+            gameSessionService,
+            characterService,
+            characterHydrationService);
+
+        var result = await service.SignInWorldAsync(CreateSignInRequest());
+
+        Assert.IsTrue(result.Succeeded);
+        await characterHydrationService.Received(1).HydrateAsync(Arg.Any<ICharacter>(), Arg.Any<CharacterModel>());
+        Assert.AreEqual(1, characterService.AddCallCount);
+        await gameSessionService.DidNotReceive().RemoveSession(Arg.Any<string>());
+    }
+
+    private static AuthenticationService CreateAuthenticationService(
+        IGameSessionService gameSessionService,
+        ICharacterService? characterService = null,
+        ICharacterHydrationService? characterHydrationService = null)
+    {
+        var mapper = Substitute.For<IMapper>();
+        mapper.Map<CharacterModel>(Arg.Any<CharacterHydrated>()).Returns(new CharacterModel());
+        mapper.Map<HydratedClaims>(Arg.Any<AuthenticationProperties>()).Returns(new HydratedClaims());
+
+        var signInResponse = CreateResponse(new SignInUserResponseMessage
+        {
+            Succeeded = true,
+            IdToken = "id-token",
+            AccessToken = "access-token",
+            Scope = "openid",
+            ExpireDate = DateTimeOffset.UtcNow.AddMinutes(5),
+            TokenType = "Bearer"
+        });
+        var signInUserRequestClient = Substitute.For<IRequestClient<SignInUserRequestMessage>>();
+        signInUserRequestClient
+            .GetResponse<SignInUserResponseMessage>(
+                Arg.Any<SignInUserRequestMessage>(), Arg.Any<CancellationToken>(), Arg.Any<RequestTimeout>())
+            .ReturnsForAnyArgs(Task.FromResult(signInResponse));
+
+        var userInfoResponse = CreateResponse(new GetUserInfoResponseMessage
+        {
+            Succeeded = true,
+            Claims = new Dictionary<string, object> { [Claims.Subject] = "42" }
+        });
+        var getUserInfoRequestClient = Substitute.For<IRequestClient<GetUserInfoRequestMessage>>();
+        getUserInfoRequestClient
+            .GetResponse<GetUserInfoResponseMessage>(
+                Arg.Any<GetUserInfoRequestMessage>(), Arg.Any<CancellationToken>(), Arg.Any<RequestTimeout>())
+            .ReturnsForAnyArgs(Task.FromResult(userInfoResponse));
+
+        var characterResponse = CreateResponse<CharacterHydrated, CharacterNotFound>(CreateCharacterHydrated());
+        var getCharacterRequestClient = Substitute.For<IRequestClient<HydrateCharacter>>();
+        getCharacterRequestClient
+            .GetResponse<CharacterHydrated, CharacterNotFound>(
+                Arg.Any<HydrateCharacter>(), Arg.Any<CancellationToken>(), Arg.Any<RequestTimeout>())
+            .ReturnsForAnyArgs(Task.FromResult(characterResponse));
+
+        var claimsPrincipalFactory = Substitute.For<IClaimsPrincipalFactory>();
+        claimsPrincipalFactory.Create(Arg.Any<IDictionary<string, object>>())
+            .Returns(new ClaimsPrincipal(new ClaimsIdentity("test")));
+
+        var characterFactory = Substitute.For<ICharacterFactory>();
+        characterFactory.Create(Arg.Any<IGameSession>(), Arg.Any<IGameClient>()).Returns(Substitute.For<ICharacter>());
+
+        var characterServiceSubstitute = characterService ?? new TestCharacterService(addResult: true);
+
+        var characterHydrationServiceSubstitute = characterHydrationService ?? Substitute.For<ICharacterHydrationService>();
+        if (characterHydrationService == null)
+        {
+            characterHydrationServiceSubstitute.HydrateAsync(Arg.Any<ICharacter>(), Arg.Any<CharacterModel>())
+                .Returns(Task.FromResult(true));
+        }
+
+        return new AuthenticationService(
+            NullLogger<AuthenticationService>.Instance,
+            mapper,
+            characterServiceSubstitute,
+            characterFactory,
+            characterHydrationServiceSubstitute,
+            Substitute.For<ICharacterPersistenceService>(),
+            Substitute.For<ICharacterLogoutService>(),
+            gameSessionService,
+            signInUserRequestClient,
+            getUserInfoRequestClient,
+            Substitute.For<IRequestClient<RevokeTokenRequestMessage>>(),
+            getCharacterRequestClient,
+            claimsPrincipalFactory,
+            CreateContextAccessor(),
+            Substitute.For<IGameMediator>(),
+            new ResiliencePipelineBuilder().Build(),
+            new ResiliencePipelineBuilder().Build());
+    }
+
+    private static SignInRequest CreateSignInRequest() => new()
+    {
+        Login = "login",
+        Password = "password",
+        GameClient = Substitute.For<IGameClient>()
+    };
+
+    private static IRaidoCallerContextAccessor CreateContextAccessor()
+    {
+        var context = Substitute.For<RaidoCallerContext>();
+        context.ConnectionId.Returns("connection");
+        context.RemoteIPEndPoint.Returns(new IPEndPoint(IPAddress.Loopback, 43594));
+        context.Features.Returns(new FeatureCollection());
+
+        var accessor = Substitute.For<IRaidoCallerContextAccessor>();
+        accessor.Context.Returns(context);
+        return accessor;
+    }
+
+    private static CharacterHydrated CreateCharacterHydrated() => new()
+    {
+        MasterId = 42,
+        CorrelationId = Guid.NewGuid(),
+        Appearance = null!,
+        Details = null!,
+        Statistics = null!,
+        ItemCollection = null!,
+        Familiar = null!,
+        Music = null!,
+        Farming = null!,
+        Slayer = null!,
+        Notes = null!,
+        Profile = null!,
+        ItemAppearanceCollection = null!,
+        State = null!
+    };
+
+    private static Response<T> CreateResponse<T>(T message) where T : class
+    {
+        var response = Substitute.For<Response<T>>();
+        response.Message.Returns(message);
+        ((Response)response).Message.Returns(message);
+        return response;
+    }
+
+    private sealed class TestCharacterService : ICharacterService
+    {
+        private readonly bool _addResult;
+
+        public TestCharacterService(bool addResult) => _addResult = addResult;
+
+        public int AddCallCount { get; private set; }
+
+        public ValueTask<bool> AddAsync(ICharacter character)
+        {
+            AddCallCount++;
+            return ValueTask.FromResult(_addResult);
+        }
+
+        public ValueTask<bool> RemoveAsync(ICharacter character) => ValueTask.FromResult(false);
+
+        public ValueTask<int> CountAsync() => ValueTask.FromResult(0);
+
+        public ValueTask<ICharacter?> FindByIndex(int index) => ValueTask.FromResult<ICharacter?>(null);
+
+        public ValueTask<ICharacter?> FindByMasterId(uint masterId) => ValueTask.FromResult<ICharacter?>(null);
+
+        public async IAsyncEnumerable<ICharacter> FindAll()
+        {
+            yield break;
+        }
+    }
+
+    private static Response<T1, T2> CreateResponse<T1, T2>(T1 message)
+        where T1 : class
+        where T2 : class
+    {
+        var firstResponse = CreateResponse(message);
+        var secondResponseTask = new TaskCompletionSource<Response<T2>>().Task;
+        var constructor = typeof(Response<T1, T2>)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Single();
+        var response = (Response<T1, T2>)constructor.Invoke(
+            [Task.FromResult(firstResponse), secondResponseTask]);
+        object boxedResponse = response;
+        typeof(Response<T1, T2>)
+            .GetField("_response", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(boxedResponse, firstResponse);
+        response = (Response<T1, T2>)boxedResponse;
+        return response;
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/AuthenticationSignInTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/AuthenticationSignInTests.cs
@@ -13,6 +13,7 @@ using Hagalaz.Services.GameWorld.Features;
 using Hagalaz.Services.GameWorld.Logic.Characters.Messages;
 using Hagalaz.Services.GameWorld.Services;
 using Hagalaz.Services.GameWorld.Services.Model;
+using Hagalaz.Services.GameWorld.Store;
 using MassTransit;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,7 +34,7 @@ public sealed class AuthenticationSignInTests
         var gameSessionService = Substitute.For<IGameSessionService>();
         var session = Substitute.For<IGameSession>();
         session.ConnectionId.Returns("connection");
-        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult(session));
+        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult((session, Created: true)));
         gameSessionService.RemoveSession("connection").Returns(Task.FromResult(true));
 
         var characterHydrationService = Substitute.For<ICharacterHydrationService>();
@@ -57,7 +58,7 @@ public sealed class AuthenticationSignInTests
         var gameSessionService = Substitute.For<IGameSessionService>();
         var session = Substitute.For<IGameSession>();
         session.ConnectionId.Returns("connection");
-        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult(session));
+        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult((session, Created: true)));
         gameSessionService.RemoveSession("connection").Returns(Task.FromResult(true));
 
         var characterService = new TestCharacterService(addResult: false);
@@ -74,12 +75,49 @@ public sealed class AuthenticationSignInTests
 
     [TestMethod]
     [Timeout(5000)]
+    public async Task SignInWorldAsync_WhenCharacterRegistrationFailsForExistingSession_PreservesSession()
+    {
+        var gameSessionService = Substitute.For<IGameSessionService>();
+        var existingSession = Substitute.For<IGameSession>();
+        existingSession.ConnectionId.Returns("connection");
+        gameSessionService.AddSession(42, "connection")
+            .Returns(Task.FromResult((existingSession, Created: false)));
+
+        var service = CreateAuthenticationService(
+            gameSessionService,
+            characterService: new TestCharacterService(addResult: false));
+
+        var result = await service.SignInWorldAsync(CreateSignInRequest());
+
+        Assert.IsFalse(result.Succeeded);
+        await gameSessionService.DidNotReceive().RemoveSession(Arg.Any<string>());
+    }
+
+    [TestMethod]
+    public async Task GameSessionService_AddSession_ReportsOwnershipOnlyForNewSession()
+    {
+        var session = Substitute.For<IGameSession>();
+        var gameSessionFactory = Substitute.For<IGameSessionFactory>();
+        gameSessionFactory.Create(42, "connection").Returns(session);
+        var service = new GameSessionService(new GameSessionStore(), gameSessionFactory);
+
+        var firstRegistration = await service.AddSession(42, "connection");
+        var secondRegistration = await service.AddSession(42, "connection");
+
+        Assert.IsTrue(firstRegistration.Created);
+        Assert.IsFalse(secondRegistration.Created);
+        Assert.AreSame(session, firstRegistration.Session);
+        Assert.AreSame(session, secondRegistration.Session);
+    }
+
+    [TestMethod]
+    [Timeout(5000)]
     public async Task SignInWorldAsync_WhenCharacterRegistrationSucceeds_KeepsSession()
     {
         var gameSessionService = Substitute.For<IGameSessionService>();
         var session = Substitute.For<IGameSession>();
         session.ConnectionId.Returns("connection");
-        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult(session));
+        gameSessionService.AddSession(42, "connection").Returns(Task.FromResult((session, Created: true)));
         var characterService = new TestCharacterService(addResult: true);
         var characterHydrationService = Substitute.For<ICharacterHydrationService>();
         characterHydrationService.HydrateAsync(Arg.Any<ICharacter>(), Arg.Any<CharacterModel>()).Returns(Task.FromResult(true));

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationService.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationService.cs
@@ -115,7 +115,7 @@ namespace Hagalaz.Services.GameWorld.Services
                 }
 
                 var masterId = Convert.ToUInt32(subject);
-                var session = await _gameSessionService.AddSession(masterId, context.ConnectionId);
+                var session = (await _gameSessionService.AddSession(masterId, context.ConnectionId)).Session;
                 context.Features.Set<ISessionFeature>(new SessionFeature
                 {
                     Session = session
@@ -179,7 +179,8 @@ namespace Hagalaz.Services.GameWorld.Services
                     return SignInResult.Fail;
                 }
 
-                var session = await _gameSessionService.AddSession(masterId, context.ConnectionId);
+                var sessionRegistration = await _gameSessionService.AddSession(masterId, context.ConnectionId);
+                var session = sessionRegistration.Session;
                 var signInSucceeded = false;
                 try
                 {
@@ -211,7 +212,7 @@ namespace Hagalaz.Services.GameWorld.Services
                 }
                 finally
                 {
-                    if (!signInSucceeded)
+                    if (!signInSucceeded && sessionRegistration.Created)
                     {
                         try
                         {

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationService.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationService.cs
@@ -180,30 +180,49 @@ namespace Hagalaz.Services.GameWorld.Services
                 }
 
                 var session = await _gameSessionService.AddSession(masterId, context.ConnectionId);
-                var character = _characterFactory.Create(session, signInRequest.GameClient);
-                if (!await _characterHydrationService.HydrateAsync(character, characterModel))
+                var signInSucceeded = false;
+                try
                 {
-                    _logger.LogWarning("Unable to hydrate character '{character}'", character);
-                    return SignInResult.Fail;
-                }
+                    var character = _characterFactory.Create(session, signInRequest.GameClient);
+                    if (!await _characterHydrationService.HydrateAsync(character, characterModel))
+                    {
+                        _logger.LogWarning("Unable to hydrate character '{character}'", character);
+                        return SignInResult.Fail;
+                    }
 
-                if (!await _characterService.AddAsync(character))
-                {
-                    _logger.LogWarning("Unable to add character '{character}'", character);
-                    return SignInResult.Fail;
-                }
+                    if (!await _characterService.AddAsync(character))
+                    {
+                        _logger.LogWarning("Unable to add character '{character}'", character);
+                        return SignInResult.Fail;
+                    }
 
-                context.Features.Set<ICharacterFeature>(new CharacterFeature
+                    context.Features.Set<ICharacterFeature>(new CharacterFeature
+                    {
+                        Character = character
+                    });
+                    context.Features.Set<ISessionFeature>(new SessionFeature
+                    {
+                        Session = session
+                    });
+                    context.Features.Set<IContactsFeature>(new WorldContactsFeature(character));
+                    context.Features.Set<IUserProfileFeature>(new UserProfileFeature()); // TODO
+                    signInSucceeded = true;
+                    return result;
+                }
+                finally
                 {
-                    Character = character
-                });
-                context.Features.Set<ISessionFeature>(new SessionFeature
-                {
-                    Session = session
-                });
-                context.Features.Set<IContactsFeature>(new WorldContactsFeature(character));
-                context.Features.Set<IUserProfileFeature>(new UserProfileFeature()); // TODO
-                return result;
+                    if (!signInSucceeded)
+                    {
+                        try
+                        {
+                            await _gameSessionService.RemoveSession(session.ConnectionId);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Failed to remove game session '{connectionId}' after world sign-in failed", session.ConnectionId);
+                        }
+                    }
+                }
             });
 
         private async ValueTask<SignInResult> SignInAsync(

--- a/Hagalaz.Services.GameWorld/Services/GameSessionService.cs
+++ b/Hagalaz.Services.GameWorld/Services/GameSessionService.cs
@@ -17,11 +17,16 @@ namespace Hagalaz.Services.GameWorld.Services
             _gameSessionFactory = gameSessionFactory;
         }
 
-        public async Task<IGameSession> AddSession(uint masterId, string connectionId)
+        public Task<(IGameSession Session, bool Created)> AddSession(uint masterId, string connectionId)
         {
-            await Task.CompletedTask;
-            var session = _sessions.GetOrAdd(connectionId, _ => _gameSessionFactory.Create(masterId, connectionId));
-            return session;
+            if (_sessions.TryGetValue(connectionId, out var existingSession))
+            {
+                return Task.FromResult((existingSession, Created: false));
+            }
+
+            var createdSession = _gameSessionFactory.Create(masterId, connectionId);
+            var session = _sessions.GetOrAdd(connectionId, _ => createdSession);
+            return Task.FromResult((session, Created: ReferenceEquals(session, createdSession)));
         }
 
         public Task<bool> RemoveSession(string connectionId) => Task.FromResult(_sessions.TryRemove(connectionId));

--- a/Hagalaz.Services.GameWorld/Services/IGameSessionService.cs
+++ b/Hagalaz.Services.GameWorld/Services/IGameSessionService.cs
@@ -6,7 +6,7 @@ namespace Hagalaz.Services.GameWorld.Services
     public interface IGameSessionService
     {
         public Task<IGameSession?> FindByMasterId(uint masterId);
-        public Task<IGameSession> AddSession(uint masterId, string connectionId);
+        public Task<(IGameSession Session, bool Created)> AddSession(uint masterId, string connectionId);
         public Task<bool> RemoveSession(string connectionId);
     }
 }


### PR DESCRIPTION
## Summary

- Remove the game session when character hydration or registration fails during world sign-in.
- Preserve successful sessions and completed sign-in state.
- Add unit tests covering failed hydration, failed registration, and successful sign-in.

## Testing

- Added and ran unit tests for world sign-in session cleanup and success behavior.
Fixes #312