### PR TITLE
Enforce hub-level authorization for Raido message handlers

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/AdminHubAuthorizationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/AdminHubAuthorizationTests.cs
@@ -1,0 +1,96 @@
+using System.Security.Claims;
+using Hagalaz.Authorization.Constants;
+using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Events;
+using Hagalaz.Game.Common.Events.Character.Packet;
+using Hagalaz.Game.Messages.Protocol;
+using Hagalaz.Services.GameWorld.Features;
+using Hagalaz.Services.GameWorld.Hubs;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Raido.Server;
+using Raido.Server.Extensions;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class AdminHubAuthorizationTests
+{
+    [TestMethod]
+    public async Task AdminHub_OnCommand_RejectsAuthenticatedNonAdmin()
+    {
+        using var provider = CreateProvider();
+        var eventManager = Substitute.For<IEventManager>();
+        var connection = CreateConnection(eventManager, Roles.Donator);
+
+        await provider.GetRequiredService<IRaidoDispatcher>().DispatchMessageAsync(
+            connection,
+            new ConsoleCommandMessage { Command = "::dangerous-command" });
+
+        eventManager.DidNotReceive().SendEvent(Arg.Any<IEvent>());
+    }
+
+    [TestMethod]
+    public async Task AdminHub_OnCommand_AllowsModeratorAndPublishesCommandEvent()
+    {
+        using var provider = CreateProvider();
+        var eventManager = Substitute.For<IEventManager>();
+        var sentEvent = default(IEvent);
+        eventManager.SendEvent(Arg.Do<IEvent>(e => sentEvent = e)).Returns(true);
+        var connection = CreateConnection(eventManager, Roles.GameModerator);
+
+        await provider.GetRequiredService<IRaidoDispatcher>().DispatchMessageAsync(
+            connection,
+            new ConsoleCommandMessage { Command = "::safe-command" });
+
+        eventManager.Received(1).SendEvent(Arg.Any<IEvent>());
+        var commandEvent = Assert.IsInstanceOfType<ConsoleCommandEvent>(sentEvent);
+        Assert.AreEqual("::safe-command", commandEvent.Command);
+    }
+
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRaidoServer().AddHub<AdminHub>();
+        return services.BuildServiceProvider();
+    }
+
+    private static RaidoConnectionContext CreateConnection(IEventManager eventManager, string role)
+    {
+        var features = new FeatureCollection();
+        features.Set<IConnectionUserFeature>(new ConnectionUserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, role) }, "test"))
+        });
+        features.Set<ICharacterFeature>(new CharacterFeature
+        {
+            Character = CreateCharacter(eventManager)
+        });
+
+        var rawConnection = Substitute.For<ConnectionContext>();
+        rawConnection.ConnectionId.Returns("admin-hub-test");
+        rawConnection.Features.Returns(features);
+        rawConnection.ConnectionClosed.Returns(CancellationToken.None);
+
+        return new RaidoConnectionContext(rawConnection, new RaidoConnectionContextOptions(), NullLoggerFactory.Instance);
+    }
+
+    private static ICharacter CreateCharacter(IEventManager eventManager)
+    {
+        var character = Substitute.For<ICharacter>();
+        character.EventManager.Returns(eventManager);
+        return character;
+    }
+
+    private sealed class ConnectionUserFeature : IConnectionUserFeature
+    {
+        public ClaimsPrincipal? User { get; set; }
+    }
+}

--- a/Raido.Server.Tests/RaidoHubDispatcherTests.cs
+++ b/Raido.Server.Tests/RaidoHubDispatcherTests.cs
@@ -157,6 +157,11 @@ public sealed class RaidoHubDispatcherTests
     {
     }
 
+    [AllowAnonymous]
+    private sealed class ClassAllowAnonymousOverrideHub : BaseAuthorizedHub
+    {
+    }
+
     [Authorize(Roles = "admin")]
     [Authorize(Policy = "trusted")]
     private sealed class MultiplePolicyHub : RaidoHub
@@ -526,6 +531,17 @@ public sealed class RaidoHubDispatcherTests
         });
 
         await dispatcher.DispatchMessageAsync(authenticatedConnection, new InheritedAuthorizationMessage());
+
+        Assert.AreEqual(1, BaseAuthorizedHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_AllowsClassLevelAllowAnonymousToOverrideInheritedAuthorization()
+    {
+        using var provider = CreateProvider<ClassAllowAnonymousOverrideHub>().Provider;
+        var dispatcher = CreateDispatcher<ClassAllowAnonymousOverrideHub>(provider);
+
+        await dispatcher.DispatchMessageAsync(CreateConnection(), new InheritedAuthorizationMessage());
 
         Assert.AreEqual(1, BaseAuthorizedHub.Invoked);
     }

--- a/Raido.Server.Tests/RaidoHubDispatcherTests.cs
+++ b/Raido.Server.Tests/RaidoHubDispatcherTests.cs
@@ -26,6 +26,14 @@ public sealed class RaidoHubDispatcherTests
     private sealed class OtherMessage : RaidoMessage { }
     private sealed class TaskMessage : RaidoMessage { }
     private sealed class ValueTaskMessage : RaidoMessage { }
+    private sealed class ClassAuthorizedMessage : RaidoMessage { }
+    private sealed class SecondClassAuthorizedMessage : RaidoMessage { }
+    private sealed class RoleProtectedMessage : RaidoMessage { }
+    private sealed class MethodRoleProtectedMessage : RaidoMessage { }
+    private sealed class CombinedAuthorizationMessage : RaidoMessage { }
+    private sealed class InheritedAuthorizationMessage : RaidoMessage { }
+    private sealed class MultiplePolicyMessage : RaidoMessage { }
+    private sealed class AllowAnonymousMessage : RaidoMessage { }
 
     private sealed class DispatchHub : RaidoHub
     {
@@ -96,21 +104,99 @@ public sealed class RaidoHubDispatcherTests
         public Task OnDisconnectedAsync(RaidoHubLifetimeContext context, Exception? exception, Func<RaidoHubLifetimeContext, Exception?, Task> next) => next(context, exception);
     }
 
+    [Authorize]
+    private sealed class ClassAuthorizedHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [RaidoMessageHandler(typeof(ClassAuthorizedMessage))]
+        public void Handle(ClassAuthorizedMessage message) => Invoked++;
+
+        [RaidoMessageHandler(typeof(SecondClassAuthorizedMessage))]
+        public void HandleSecond(SecondClassAuthorizedMessage message) => Invoked++;
+    }
+
+    [Authorize(Roles = "admin")]
+    private sealed class RoleProtectedHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [RaidoMessageHandler(typeof(RoleProtectedMessage))]
+        public void Handle(RoleProtectedMessage message) => Invoked++;
+    }
+
+    private sealed class MethodRoleProtectedHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [Authorize(Roles = "admin")]
+        [RaidoMessageHandler(typeof(MethodRoleProtectedMessage))]
+        public void Handle(MethodRoleProtectedMessage message) => Invoked++;
+    }
+
+    [Authorize]
+    private sealed class CombinedAuthorizationHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [Authorize(Roles = "admin")]
+        [RaidoMessageHandler(typeof(CombinedAuthorizationMessage))]
+        public void Handle(CombinedAuthorizationMessage message) => Invoked++;
+    }
+
+    [Authorize]
+    private abstract class BaseAuthorizedHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [RaidoMessageHandler(typeof(InheritedAuthorizationMessage))]
+        public void Handle(InheritedAuthorizationMessage message) => Invoked++;
+    }
+
+    private sealed class InheritedAuthorizationHub : BaseAuthorizedHub
+    {
+    }
+
+    [Authorize(Roles = "admin")]
+    [Authorize(Policy = "trusted")]
+    private sealed class MultiplePolicyHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [RaidoMessageHandler(typeof(MultiplePolicyMessage))]
+        public void Handle(MultiplePolicyMessage message) => Invoked++;
+    }
+
+    [Authorize]
+    private sealed class AllowAnonymousOverrideHub : RaidoHub
+    {
+        public static int Invoked;
+
+        [AllowAnonymous]
+        [RaidoMessageHandler(typeof(AllowAnonymousMessage))]
+        public void Handle(AllowAnonymousMessage message) => Invoked++;
+    }
+
     private static (ServiceProvider Provider, IRaidoContext Context) CreateProvider(bool withFilter = false)
+        => CreateProvider<DispatchHub>(withFilter);
+
+    private static (ServiceProvider Provider, IRaidoContext Context) CreateProvider<THub>(
+        bool withFilter = false,
+        Action<AuthorizationOptions>? configureAuthorization = null) where THub : RaidoHub
     {
         var services = new ServiceCollection();
         var context = Substitute.For<IRaidoContext>();
         context.Clients.Returns(Substitute.For<IRaidoClients>());
         services.AddSingleton(context);
         services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Trace));
-        services.AddAuthorization();
+        services.AddAuthorization(configureAuthorization ?? (_ => { }));
         services.AddSingleton(new RaidoServerActivitySource());
         services.AddScoped<IRaidoCallerContextAccessor, DefaultRaidoCallerContextAccessor>();
-        services.AddScoped<IRaidoHubActivator<DispatchHub>, DefaultRaidoHubActivator<DispatchHub>>();
-        services.AddOptions<RaidoHubOptions<DispatchHub>>();
+        services.AddScoped<IRaidoHubActivator<THub>, DefaultRaidoHubActivator<THub>>();
+        services.AddOptions<RaidoHubOptions<THub>>();
         if (withFilter)
         {
-            services.Configure<RaidoHubOptions<DispatchHub>>(options => options.AddFilter(new DispatchFilter()));
+            services.Configure<RaidoHubOptions<THub>>(options => options.AddFilter(new DispatchFilter()));
         }
         return (services.BuildServiceProvider(), context);
     }
@@ -134,12 +220,15 @@ public sealed class RaidoHubDispatcherTests
     }
 
     private static DefaultRaidoHubDispatcher<DispatchHub> CreateDispatcher(ServiceProvider provider)
+        => CreateDispatcher<DispatchHub>(provider);
+
+    private static DefaultRaidoHubDispatcher<THub> CreateDispatcher<THub>(ServiceProvider provider) where THub : RaidoHub
     {
-        var options = provider.GetRequiredService<IOptions<RaidoHubOptions<DispatchHub>>>();
-        return new DefaultRaidoHubDispatcher<DispatchHub>(
+        var options = provider.GetRequiredService<IOptions<RaidoHubOptions<THub>>>();
+        return new DefaultRaidoHubDispatcher<THub>(
             provider.GetRequiredService<IServiceScopeFactory>(),
             provider.GetRequiredService<IRaidoContext>(),
-            provider.GetRequiredService<ILogger<DefaultRaidoHubDispatcher<DispatchHub>>>(),
+            provider.GetRequiredService<ILogger<DefaultRaidoHubDispatcher<THub>>>(),
             options);
     }
 
@@ -154,6 +243,13 @@ public sealed class RaidoHubDispatcherTests
         DispatchHub.TaskInvoked = 0;
         DispatchHub.ValueTaskInvoked = 0;
         DispatchHub.ThrowFromHandler = false;
+        ClassAuthorizedHub.Invoked = 0;
+        RoleProtectedHub.Invoked = 0;
+        MethodRoleProtectedHub.Invoked = 0;
+        CombinedAuthorizationHub.Invoked = 0;
+        BaseAuthorizedHub.Invoked = 0;
+        MultiplePolicyHub.Invoked = 0;
+        AllowAnonymousOverrideHub.Invoked = 0;
     }
 
     [TestMethod]
@@ -298,6 +394,198 @@ public sealed class RaidoHubDispatcherTests
         await dispatcher.DispatchMessageAsync(connection, new OtherMessage());
 
         Assert.AreEqual(1, DispatchHub.AuthorizedInvoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_EnforcesClassLevelAuthorizeAttributeForAllHandlers()
+    {
+        using var provider = CreateProvider<ClassAuthorizedHub>().Provider;
+        var dispatcher = CreateDispatcher<ClassAuthorizedHub>(provider);
+
+        var anonymousConnection = CreateConnection();
+        await dispatcher.DispatchMessageAsync(anonymousConnection, new ClassAuthorizedMessage());
+        await dispatcher.DispatchMessageAsync(anonymousConnection, new SecondClassAuthorizedMessage());
+
+        Assert.AreEqual(0, ClassAuthorizedHub.Invoked);
+
+        var authenticatedConnection = CreateConnection();
+        authenticatedConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(authenticatedConnection, new ClassAuthorizedMessage());
+        await dispatcher.DispatchMessageAsync(authenticatedConnection, new SecondClassAuthorizedMessage());
+
+        Assert.AreEqual(2, ClassAuthorizedHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_EnforcesClassLevelRoleAuthorizeAttribute()
+    {
+        using var provider = CreateProvider<RoleProtectedHub>().Provider;
+        var dispatcher = CreateDispatcher<RoleProtectedHub>(provider);
+
+        var nonAdminConnection = CreateConnection();
+        nonAdminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "user") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(nonAdminConnection, new RoleProtectedMessage());
+
+        Assert.AreEqual(0, RoleProtectedHub.Invoked);
+
+        var adminConnection = CreateConnection();
+        adminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "admin") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(adminConnection, new RoleProtectedMessage());
+
+        Assert.AreEqual(1, RoleProtectedHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_EnforcesMethodLevelRoleAuthorizeAttribute()
+    {
+        using var provider = CreateProvider<MethodRoleProtectedHub>().Provider;
+        var dispatcher = CreateDispatcher<MethodRoleProtectedHub>(provider);
+
+        var nonAdminConnection = CreateConnection();
+        nonAdminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "user") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(nonAdminConnection, new MethodRoleProtectedMessage());
+
+        Assert.AreEqual(0, MethodRoleProtectedHub.Invoked);
+
+        var adminConnection = CreateConnection();
+        adminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "admin") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(adminConnection, new MethodRoleProtectedMessage());
+
+        Assert.AreEqual(1, MethodRoleProtectedHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_CombinesClassAndMethodAuthorizeAttributes()
+    {
+        using var provider = CreateProvider<CombinedAuthorizationHub>().Provider;
+        var dispatcher = CreateDispatcher<CombinedAuthorizationHub>(provider);
+
+        await dispatcher.DispatchMessageAsync(CreateConnection(), new CombinedAuthorizationMessage());
+
+        var nonAdminConnection = CreateConnection();
+        nonAdminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "user") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(nonAdminConnection, new CombinedAuthorizationMessage());
+
+        Assert.AreEqual(0, CombinedAuthorizationHub.Invoked);
+
+        var adminConnection = CreateConnection();
+        adminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "admin") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(adminConnection, new CombinedAuthorizationMessage());
+
+        Assert.AreEqual(1, CombinedAuthorizationHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_EnforcesInheritedClassLevelAuthorizeAttribute()
+    {
+        using var provider = CreateProvider<InheritedAuthorizationHub>().Provider;
+        var dispatcher = CreateDispatcher<InheritedAuthorizationHub>(provider);
+
+        await dispatcher.DispatchMessageAsync(CreateConnection(), new InheritedAuthorizationMessage());
+
+        Assert.AreEqual(0, BaseAuthorizedHub.Invoked);
+
+        var authenticatedConnection = CreateConnection();
+        authenticatedConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(authenticatedConnection, new InheritedAuthorizationMessage());
+
+        Assert.AreEqual(1, BaseAuthorizedHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_CombinesMultipleClassLevelAuthorizePolicies()
+    {
+        using var provider = CreateProvider<MultiplePolicyHub>(configureAuthorization: options =>
+            options.AddPolicy("trusted", policy => policy.RequireClaim("trusted", "yes"))).Provider;
+        var dispatcher = CreateDispatcher<MultiplePolicyHub>(provider);
+
+        var trustedNonAdminConnection = CreateConnection();
+        trustedNonAdminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.Role, "user"),
+                    new Claim("trusted", "yes")
+                }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(trustedNonAdminConnection, new MultiplePolicyMessage());
+
+        var untrustedAdminConnection = CreateConnection();
+        untrustedAdminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Role, "admin") }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(untrustedAdminConnection, new MultiplePolicyMessage());
+
+        Assert.AreEqual(0, MultiplePolicyHub.Invoked);
+
+        var trustedAdminConnection = CreateConnection();
+        trustedAdminConnection.Features.Set<IConnectionUserFeature>(new UserFeature
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.Role, "admin"),
+                    new Claim("trusted", "yes")
+                }, "test"))
+        });
+
+        await dispatcher.DispatchMessageAsync(trustedAdminConnection, new MultiplePolicyMessage());
+
+        Assert.AreEqual(1, MultiplePolicyHub.Invoked);
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_AllowsMethodLevelAllowAnonymousToOverrideHubAuthorization()
+    {
+        using var provider = CreateProvider<AllowAnonymousOverrideHub>().Provider;
+        var dispatcher = CreateDispatcher<AllowAnonymousOverrideHub>(provider);
+
+        await dispatcher.DispatchMessageAsync(CreateConnection(), new AllowAnonymousMessage());
+
+        Assert.AreEqual(1, AllowAnonymousOverrideHub.Invoked);
     }
 
     [TestMethod]

--- a/Raido.Server/Internal/DefaultRaidoHubDispatcher.cs
+++ b/Raido.Server/Internal/DefaultRaidoHubDispatcher.cs
@@ -374,7 +374,9 @@ namespace Raido.Server.Internal
                 }
 
                 var executor = ObjectMethodExecutor.Create(methodInfo, hubTypeInfo);
-                var authorizeAttributes = methodInfo.GetCustomAttribute<AllowAnonymousAttribute>(inherit: true) is not null
+                var allowAnonymous = hubTypeInfo.GetCustomAttribute<AllowAnonymousAttribute>(inherit: true) is not null
+                    || methodInfo.GetCustomAttribute<AllowAnonymousAttribute>(inherit: true) is not null;
+                var authorizeAttributes = allowAnonymous
                     ? Array.Empty<AuthorizeAttribute>()
                     : hubTypeInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true)
                         .Concat(methodInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true));

--- a/Raido.Server/Internal/DefaultRaidoHubDispatcher.cs
+++ b/Raido.Server/Internal/DefaultRaidoHubDispatcher.cs
@@ -374,7 +374,10 @@ namespace Raido.Server.Internal
                 }
 
                 var executor = ObjectMethodExecutor.Create(methodInfo, hubTypeInfo);
-                var authorizeAttributes = methodInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true);
+                var authorizeAttributes = methodInfo.GetCustomAttribute<AllowAnonymousAttribute>(inherit: true) is not null
+                    ? Array.Empty<AuthorizeAttribute>()
+                    : hubTypeInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true)
+                        .Concat(methodInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true));
                 _messageHandlers[messageType] = new RaidoHubMethodDescriptor(executor, serviceProviderIsService, authorizeAttributes);
 
                 Log.HubMethodBound(_logger, hubName, methodInfo.Name);


### PR DESCRIPTION
## Summary
- Apply hub-level, inherited, and method-level authorization attributes during message dispatch
- Combine authorization policies and honor method-level `AllowAnonymous`
- Add dispatcher and admin hub authorization unit tests

## Testing
- Not run (not requested)
Fixes #310 