### PR TITLE
Partition sign-in rate limiting by remote IP

### DIFF
--- a/Hagalaz.ServiceDefaults/Extensions.cs
+++ b/Hagalaz.ServiceDefaults/Extensions.cs
@@ -343,7 +343,8 @@ public static class Extensions
             "MassTransit",
             "Polly",
             "Raido.Server",
-            "Hagalaz.Services.Characters.Persistence");
+            "Hagalaz.Services.Characters.Persistence",
+            "Hagalaz.Services.GameWorld.Authentication");
 
     public static string? GetServiceConfigurationValue(this IConfiguration configuration, string serviceName, string key, string? fallbackKey = null)
     {

--- a/Hagalaz.Services.GameWorld.Tests/AuthenticationRateLimitingTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/AuthenticationRateLimitingTests.cs
@@ -1,0 +1,93 @@
+using System.Threading.RateLimiting;
+using Polly;
+using Hagalaz.Services.GameWorld.Services;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class AuthenticationRateLimitingTests
+{
+    [TestMethod]
+    public async Task PartitionedLimiter_ExhaustingOneRemoteIp_DoesNotRejectAnother()
+    {
+        using var limiter = AuthenticationRateLimiting.CreatePartitionedLimiter(queueLimit: 0);
+        var firstClient = CreateContext("ip:192.0.2.10");
+        var secondClient = CreateContext("ip:192.0.2.11");
+        var firstClientLeases = new List<RateLimitLease>();
+
+        try
+        {
+            for (var i = 0; i < AuthenticationRateLimiting.PartitionPermitLimit; i++)
+            {
+                var lease = await limiter.AcquireAsync(firstClient, 1);
+                Assert.IsTrue(lease.IsAcquired);
+                firstClientLeases.Add(lease);
+            }
+
+            var exhaustedLease = await limiter.AcquireAsync(firstClient, 1);
+            var unrelatedLease = await limiter.AcquireAsync(secondClient, 1);
+
+            Assert.IsFalse(exhaustedLease.IsAcquired);
+            Assert.IsTrue(unrelatedLease.IsAcquired);
+            exhaustedLease.Dispose();
+            unrelatedLease.Dispose();
+        }
+        finally
+        {
+            foreach (var lease in firstClientLeases)
+            {
+                lease.Dispose();
+            }
+
+            ResilienceContextPool.Shared.Return(firstClient);
+            ResilienceContextPool.Shared.Return(secondClient);
+        }
+    }
+
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task PartitionedLimiter_QueuesBurstForOneRemoteIp_WithoutBlockingAnother()
+    {
+        using var limiter = AuthenticationRateLimiting.CreatePartitionedLimiter();
+        var firstClient = CreateContext("ip:192.0.2.20");
+        var secondClient = CreateContext("ip:192.0.2.21");
+        var firstClientLeases = new List<RateLimitLease>();
+        using var cancellationSource = new CancellationTokenSource();
+
+        try
+        {
+            for (var i = 0; i < AuthenticationRateLimiting.PartitionPermitLimit; i++)
+            {
+                firstClientLeases.Add(await limiter.AcquireAsync(firstClient, 1));
+            }
+
+            var queuedLeaseTask = limiter.AcquireAsync(firstClient, 1, cancellationSource.Token);
+            Assert.IsFalse(queuedLeaseTask.IsCompleted);
+
+            var unrelatedLease = await limiter.AcquireAsync(secondClient, 1);
+            Assert.IsTrue(unrelatedLease.IsAcquired);
+
+            cancellationSource.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => queuedLeaseTask.AsTask());
+
+            unrelatedLease.Dispose();
+        }
+        finally
+        {
+            foreach (var lease in firstClientLeases)
+            {
+                lease.Dispose();
+            }
+
+            ResilienceContextPool.Shared.Return(firstClient);
+            ResilienceContextPool.Shared.Return(secondClient);
+        }
+    }
+
+    private static ResilienceContext CreateContext(string partitionKey)
+    {
+        var context = ResilienceContextPool.Shared.Get();
+        context.Properties.Set(AuthenticationRateLimiting.PartitionKey, partitionKey);
+        return context;
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/AuthenticationRateLimitingTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/AuthenticationRateLimitingTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using Polly;
+using Polly.RateLimiting;
 using Hagalaz.Services.GameWorld.Services;
 
 namespace Hagalaz.Services.GameWorld.Tests;
@@ -83,6 +84,50 @@ public sealed class AuthenticationRateLimitingTests
             ResilienceContextPool.Shared.Return(secondClient);
         }
     }
+
+    [TestMethod]
+    [Timeout(5000)]
+    public async Task CombinedLimiter_PerIpRejection_DoesNotConsumeGlobalWindowPermit()
+    {
+        using var globalAdmissionLimiter = AuthenticationRateLimiting.CreateGlobalAdmissionLimiter(permitLimit: 1);
+        using var partitionedLimiter = AuthenticationRateLimiting.CreatePartitionedLimiter(permitLimit: 1, queueLimit: 0);
+        using var globalLimiter = AuthenticationRateLimiting.CreateGlobalLimiter(permitLimit: 2);
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                RateLimiter = args => globalAdmissionLimiter.AcquireAsync(1, args.Context.CancellationToken)
+            })
+            .AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                RateLimiter = args => partitionedLimiter.AcquireAsync(args.Context, 1, args.Context.CancellationToken)
+            })
+            .AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                RateLimiter = args => globalLimiter.AcquireAsync(1, args.Context.CancellationToken)
+            })
+            .Build();
+
+        var firstClient = CreateContext("ip:192.0.2.30");
+        var secondClient = CreateContext("ip:192.0.2.31");
+        var thirdClient = CreateContext("ip:192.0.2.32");
+
+        try
+        {
+            await ExecuteAsync(pipeline, firstClient);
+            await Assert.ThrowsAsync<RateLimiterRejectedException>(() => ExecuteAsync(pipeline, firstClient));
+            await ExecuteAsync(pipeline, secondClient);
+            await Assert.ThrowsAsync<RateLimiterRejectedException>(() => ExecuteAsync(pipeline, thirdClient));
+        }
+        finally
+        {
+            ResilienceContextPool.Shared.Return(firstClient);
+            ResilienceContextPool.Shared.Return(secondClient);
+            ResilienceContextPool.Shared.Return(thirdClient);
+        }
+    }
+
+    private static Task ExecuteAsync(ResiliencePipeline pipeline, ResilienceContext context) =>
+        pipeline.ExecuteAsync(_ => ValueTask.CompletedTask, context).AsTask();
 
     private static ResilienceContext CreateContext(string partitionKey)
     {

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimiting.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimiting.cs
@@ -8,6 +8,7 @@ internal static class AuthenticationRateLimiting
 {
     internal const int PartitionPermitLimit = 5;
     internal const int PartitionQueueLimit = 10;
+    internal const int GlobalAdmissionPermitLimit = 1_000;
     internal const int GlobalPermitLimit = 1_000;
 
     internal static readonly ResiliencePropertyKey<string> PartitionKey = new("auth-sign-in-partition");
@@ -28,9 +29,18 @@ internal static class AuthenticationRateLimiting
                     AutoReplenishment = true
                 }));
 
-    internal static SlidingWindowRateLimiter CreateGlobalLimiter() => new(new SlidingWindowRateLimiterOptions
+    internal static ConcurrencyLimiter CreateGlobalAdmissionLimiter(
+        int permitLimit = GlobalAdmissionPermitLimit) => new(new ConcurrencyLimiterOptions
     {
-        PermitLimit = GlobalPermitLimit,
+        PermitLimit = permitLimit,
+        QueueLimit = 0,
+        QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+    });
+
+    internal static SlidingWindowRateLimiter CreateGlobalLimiter(
+        int permitLimit = GlobalPermitLimit) => new(new SlidingWindowRateLimiterOptions
+    {
+        PermitLimit = permitLimit,
         QueueLimit = 0,
         QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
         Window = TimeSpan.FromMinutes(1),

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimiting.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimiting.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.RateLimiting;
+using Polly;
+
+namespace Hagalaz.Services.GameWorld.Services;
+
+internal static class AuthenticationRateLimiting
+{
+    internal const int PartitionPermitLimit = 5;
+    internal const int PartitionQueueLimit = 10;
+    internal const int GlobalPermitLimit = 1_000;
+
+    internal static readonly ResiliencePropertyKey<string> PartitionKey = new("auth-sign-in-partition");
+
+    internal static PartitionedRateLimiter<ResilienceContext> CreatePartitionedLimiter(
+        int permitLimit = PartitionPermitLimit,
+        int queueLimit = PartitionQueueLimit) =>
+        PartitionedRateLimiter.Create<ResilienceContext, string>(context =>
+            RateLimitPartition.GetSlidingWindowLimiter(
+                context.Properties.GetValue(PartitionKey, "unknown"),
+                _ => new SlidingWindowRateLimiterOptions
+                {
+                    PermitLimit = permitLimit,
+                    QueueLimit = queueLimit,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    Window = TimeSpan.FromMinutes(1),
+                    SegmentsPerWindow = 10,
+                    AutoReplenishment = true
+                }));
+
+    internal static SlidingWindowRateLimiter CreateGlobalLimiter() => new(new SlidingWindowRateLimiterOptions
+    {
+        PermitLimit = GlobalPermitLimit,
+        QueueLimit = 0,
+        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+        Window = TimeSpan.FromMinutes(1),
+        SegmentsPerWindow = 10,
+        AutoReplenishment = true
+    });
+}

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimitingMetrics.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimitingMetrics.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Hagalaz.Game.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Hagalaz.Services.GameWorld.Services;
+
+/// <summary>
+/// Metrics for sign-in throttling, separated from the auth outage circuit breaker.
+/// </summary>
+public sealed class AuthenticationRateLimitingMetrics
+{
+    public const string MeterName = "Hagalaz.Services.GameWorld.Authentication";
+
+    private static readonly KeyValuePair<string, object?> PartitionTags = new("partition", "remote_ip");
+    private static readonly KeyValuePair<string, object?> GlobalTags = new("partition", "global");
+
+    private readonly Counter<long> _partitionRejected;
+    private readonly Counter<long> _globalRejected;
+    private readonly KeyValuePair<string, object?> _worldTag;
+
+    public AuthenticationRateLimitingMetrics(IMeterFactory meterFactory, IOptions<WorldOptions> worldOptions)
+    {
+        var meter = meterFactory.Create(MeterName);
+        _partitionRejected = meter.CreateCounter<long>("hagalaz.auth.sign_in.rate_limited.partition");
+        _globalRejected = meter.CreateCounter<long>("hagalaz.auth.sign_in.rate_limited.global");
+        _worldTag = new KeyValuePair<string, object?>("world", worldOptions.Value.Id);
+    }
+
+    public void RecordPartitionRejected() => _partitionRejected.Add(1, PartitionTags, _worldTag);
+
+    public void RecordGlobalRejected() => _globalRejected.Add(1, GlobalTags, _worldTag);
+}

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimitingMetrics.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationRateLimitingMetrics.cs
@@ -13,9 +13,11 @@ public sealed class AuthenticationRateLimitingMetrics
     public const string MeterName = "Hagalaz.Services.GameWorld.Authentication";
 
     private static readonly KeyValuePair<string, object?> PartitionTags = new("partition", "remote_ip");
+    private static readonly KeyValuePair<string, object?> AdmissionTags = new("partition", "global_admission");
     private static readonly KeyValuePair<string, object?> GlobalTags = new("partition", "global");
 
     private readonly Counter<long> _partitionRejected;
+    private readonly Counter<long> _globalAdmissionRejected;
     private readonly Counter<long> _globalRejected;
     private readonly KeyValuePair<string, object?> _worldTag;
 
@@ -23,11 +25,14 @@ public sealed class AuthenticationRateLimitingMetrics
     {
         var meter = meterFactory.Create(MeterName);
         _partitionRejected = meter.CreateCounter<long>("hagalaz.auth.sign_in.rate_limited.partition");
+        _globalAdmissionRejected = meter.CreateCounter<long>("hagalaz.auth.sign_in.rate_limited.global_admission");
         _globalRejected = meter.CreateCounter<long>("hagalaz.auth.sign_in.rate_limited.global");
         _worldTag = new KeyValuePair<string, object?>("world", worldOptions.Value.Id);
     }
 
     public void RecordPartitionRejected() => _partitionRejected.Add(1, PartitionTags, _worldTag);
+
+    public void RecordGlobalAdmissionRejected() => _globalAdmissionRejected.Add(1, AdmissionTags, _worldTag);
 
     public void RecordGlobalRejected() => _globalRejected.Add(1, GlobalTags, _worldTag);
 }

--- a/Hagalaz.Services.GameWorld/Services/AuthenticationService.cs
+++ b/Hagalaz.Services.GameWorld/Services/AuthenticationService.cs
@@ -99,7 +99,7 @@ namespace Hagalaz.Services.GameWorld.Services
         }
 
         public async ValueTask<SignInResult> SignInLobbyAsync(SignInRequest signInRequest) =>
-            await _authLoginPipeline.ExecuteAsync(async (cancellationToken) =>
+            await ExecuteSignInAsync(async cancellationToken =>
             {
                 var result = await SignInAsync(signInRequest, Constants.OAuth.LobbyClientId, _lobbyClientScopes, cancellationToken);
                 if (!result.Succeeded)
@@ -126,7 +126,7 @@ namespace Hagalaz.Services.GameWorld.Services
             });
 
         public async ValueTask<SignInResult> SignInWorldAsync(SignInRequest signInRequest) =>
-            await _authLoginPipeline.ExecuteAsync(async cancellationToken =>
+            await ExecuteSignInAsync(async cancellationToken =>
             {
                 var characterCount = await _characterService.CountAsync();
                 // TODO - character count / give donators extra queue
@@ -225,6 +225,30 @@ namespace Hagalaz.Services.GameWorld.Services
                     }
                 }
             });
+
+        private async ValueTask<SignInResult> ExecuteSignInAsync(
+            Func<CancellationToken, ValueTask<SignInResult>> signIn)
+        {
+            var resilienceContext = ResilienceContextPool.Shared.Get();
+            resilienceContext.Properties.Set(AuthenticationRateLimiting.PartitionKey, GetSignInPartitionKey());
+            try
+            {
+                return await _authLoginPipeline.ExecuteAsync(
+                    context => signIn(context.CancellationToken), resilienceContext);
+            }
+            finally
+            {
+                ResilienceContextPool.Shared.Return(resilienceContext);
+            }
+        }
+
+        private string GetSignInPartitionKey()
+        {
+            var context = _contextAccessor.Context;
+            return context.RemoteIPEndPoint?.Address is { } address
+                ? $"ip:{address}"
+                : $"connection:{context.ConnectionId}";
+        }
 
         private async ValueTask<SignInResult> SignInAsync(
             SignInRequest signInRequest, string clientId, ImmutableArray<string> clientScopes, CancellationToken cancellationToken)

--- a/Hagalaz.Services.GameWorld/Startup.cs
+++ b/Hagalaz.Services.GameWorld/Startup.cs
@@ -720,26 +720,27 @@ namespace Hagalaz.Services.GameWorld
                 (builder, context) =>
                 {
                     var metrics = context.ServiceProvider.GetRequiredService<AuthenticationRateLimitingMetrics>();
+                    var globalAdmissionLimiter = AuthenticationRateLimiting.CreateGlobalAdmissionLimiter();
                     var partitionedLimiter = AuthenticationRateLimiting.CreatePartitionedLimiter();
                     var globalLimiter = AuthenticationRateLimiting.CreateGlobalLimiter();
                     context.OnPipelineDisposed(() =>
                     {
+                        globalAdmissionLimiter.Dispose();
                         partitionedLimiter.Dispose();
                         globalLimiter.Dispose();
                     });
 
                     builder.InstanceName = "SignIn";
                     builder
-                        // Polly adds the first strategy as the outermost strategy. Keep the
-                        // shared zero-queue backstop outside the per-IP queues so queued work
-                        // remains globally bounded under a distributed attack.
+                        // Polly adds the first strategy as the outermost strategy. The shared,
+                        // zero-queue admission gate bounds aggregate work before per-IP queues.
                         .AddRateLimiter(new RateLimiterStrategyOptions
                         {
-                            Name = "GlobalSignInSafetyCap",
-                            RateLimiter = args => globalLimiter.AcquireAsync(1, args.Context.CancellationToken),
+                            Name = "GlobalSignInAdmission",
+                            RateLimiter = args => globalAdmissionLimiter.AcquireAsync(1, args.Context.CancellationToken),
                             OnRejected = _ =>
                             {
-                                metrics.RecordGlobalRejected();
+                                metrics.RecordGlobalAdmissionRejected();
                                 return default;
                             }
                         })
@@ -750,6 +751,18 @@ namespace Hagalaz.Services.GameWorld
                             OnRejected = _ =>
                             {
                                 metrics.RecordPartitionRejected();
+                                return default;
+                            }
+                        })
+                        // The global sliding-window budget must be after the partitioned
+                        // limiter so a locally rejected request does not spend a global permit.
+                        .AddRateLimiter(new RateLimiterStrategyOptions
+                        {
+                            Name = "GlobalSignInSafetyCap",
+                            RateLimiter = args => globalLimiter.AcquireAsync(1, args.Context.CancellationToken),
+                            OnRejected = _ =>
+                            {
+                                metrics.RecordGlobalRejected();
                                 return default;
                             }
                         })

--- a/Hagalaz.Services.GameWorld/Startup.cs
+++ b/Hagalaz.Services.GameWorld/Startup.cs
@@ -730,16 +730,9 @@ namespace Hagalaz.Services.GameWorld
 
                     builder.InstanceName = "SignIn";
                     builder
-                        .AddRateLimiter(new RateLimiterStrategyOptions
-                        {
-                            Name = "PartitionedSignInRateLimiter",
-                            RateLimiter = args => partitionedLimiter.AcquireAsync(args.Context, 1, args.Context.CancellationToken),
-                            OnRejected = _ =>
-                            {
-                                metrics.RecordPartitionRejected();
-                                return default;
-                            }
-                        })
+                        // Polly adds the first strategy as the outermost strategy. Keep the
+                        // shared zero-queue backstop outside the per-IP queues so queued work
+                        // remains globally bounded under a distributed attack.
                         .AddRateLimiter(new RateLimiterStrategyOptions
                         {
                             Name = "GlobalSignInSafetyCap",
@@ -747,6 +740,16 @@ namespace Hagalaz.Services.GameWorld
                             OnRejected = _ =>
                             {
                                 metrics.RecordGlobalRejected();
+                                return default;
+                            }
+                        })
+                        .AddRateLimiter(new RateLimiterStrategyOptions
+                        {
+                            Name = "PartitionedSignInRateLimiter",
+                            RateLimiter = args => partitionedLimiter.AcquireAsync(args.Context, 1, args.Context.CancellationToken),
+                            OnRejected = _ =>
+                            {
+                                metrics.RecordPartitionRejected();
                                 return default;
                             }
                         })

--- a/Hagalaz.Services.GameWorld/Startup.cs
+++ b/Hagalaz.Services.GameWorld/Startup.cs
@@ -93,6 +93,7 @@ using Microsoft.EntityFrameworkCore;
 using Hagalaz.Data;
 using Polly;
 using Polly.CircuitBreaker;
+using Polly.RateLimiting;
 using ZiggyCreatures.Caching.Fusion;
 using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
 
@@ -714,20 +715,41 @@ namespace Hagalaz.Services.GameWorld
             services.AddTransient<IStartupService>(provider => provider.GetRequiredService<StateProvider>());
 
             // policies
+            services.AddSingleton<AuthenticationRateLimitingMetrics>();
             services.AddResiliencePipeline(Constants.Pipeline.AuthSignInPipeline,
-                builder =>
+                (builder, context) =>
                 {
+                    var metrics = context.ServiceProvider.GetRequiredService<AuthenticationRateLimitingMetrics>();
+                    var partitionedLimiter = AuthenticationRateLimiting.CreatePartitionedLimiter();
+                    var globalLimiter = AuthenticationRateLimiting.CreateGlobalLimiter();
+                    context.OnPipelineDisposed(() =>
+                    {
+                        partitionedLimiter.Dispose();
+                        globalLimiter.Dispose();
+                    });
+
                     builder.InstanceName = "SignIn";
                     builder
-                        .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+                        .AddRateLimiter(new RateLimiterStrategyOptions
                         {
-                            Window = TimeSpan.FromMinutes(1), // Specifies the minimum period between replenishments (e.g., 1 minute).
-                            SegmentsPerWindow = 10, // Specifies the maximum number of segments a window is divided into (e.g., 10 segments).
-                            AutoReplenishment = true, // Specifies whether the limiter automatically replenishes request counters (true by default).
-                            PermitLimit = 5, // Maximum number of requests that can be served in a window (e.g., 5 requests).
-                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst, // Determines the behavior when not enough resources are available.
-                            QueueLimit = 10, // Maximum cumulative permit count of queued acquisition requests (e.g., 10 permits).
-                        }))
+                            Name = "PartitionedSignInRateLimiter",
+                            RateLimiter = args => partitionedLimiter.AcquireAsync(args.Context, 1, args.Context.CancellationToken),
+                            OnRejected = _ =>
+                            {
+                                metrics.RecordPartitionRejected();
+                                return default;
+                            }
+                        })
+                        .AddRateLimiter(new RateLimiterStrategyOptions
+                        {
+                            Name = "GlobalSignInSafetyCap",
+                            RateLimiter = args => globalLimiter.AcquireAsync(1, args.Context.CancellationToken),
+                            OnRejected = _ =>
+                            {
+                                metrics.RecordGlobalRejected();
+                                return default;
+                            }
+                        })
                         .AddTimeout(TimeSpan.FromSeconds(10))
                         .AddCircuitBreaker(new CircuitBreakerStrategyOptions
                         {


### PR DESCRIPTION
## Summary

- Partition sign-in throttling by remote IP, with connection ID fallback.
- Add a global safety cap and separate rejection metrics for partition and global limits.
- Register the authentication metrics meter for observability.

## Testing

- Added MSTest coverage verifying one IP can be throttled without blocking another and queued requests can be cancelled independently.
- Not run (not requested).
Fixes #305 