### PR TITLE
Replace entity region access with IMapRegionService

### DIFF
--- a/Hagalaz.Game.Abstractions/Model/IEntity.cs
+++ b/Hagalaz.Game.Abstractions/Model/IEntity.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using Hagalaz.Game.Abstractions.Model.Maps;
-
 namespace Hagalaz.Game.Abstractions.Model
 {
     /// <summary>
@@ -13,12 +10,6 @@ namespace Hagalaz.Game.Abstractions.Model
         /// Gets the current location of the entity in the game world.
         /// </summary>
         ILocation Location { get; }
-
-        /// <summary>
-        /// Gets the map region that the entity is currently in.
-        /// </summary>
-        [Obsolete("Use the IMapRegionService instead.")]
-        IMapRegion Region { get; }
 
         /// <summary>
         /// Gets a value indicating whether the entity has been destroyed and removed from the game.

--- a/Hagalaz.Game.Scripts.Tests/Commands/GfxCommandTests.cs
+++ b/Hagalaz.Game.Scripts.Tests/Commands/GfxCommandTests.cs
@@ -5,6 +5,7 @@ using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Model.Maps.Updates;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Scripts.Commands;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -19,6 +20,8 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
         private Mock<IRegionUpdateOptional> _regionUpdateOptionalMock = null!;
         private Mock<IRegionUpdateBuild> _regionUpdateBuildMock = null!;
         private Mock<IRegionPartUpdate> _regionPartUpdateMock = null!;
+        private Mock<IMapRegionService> _mapRegionServiceMock = null!;
+        private Mock<IServiceProvider> _serviceProviderMock = null!;
         private GfxCommand _gfxCommand = null!;
 
         [TestInitialize]
@@ -29,6 +32,11 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
             _regionUpdateOptionalMock = new Mock<IRegionUpdateOptional>();
             _regionUpdateBuildMock = new Mock<IRegionUpdateBuild>();
             _regionPartUpdateMock = new Mock<IRegionPartUpdate>();
+            _mapRegionServiceMock = new Mock<IMapRegionService>();
+            _serviceProviderMock = new Mock<IServiceProvider>();
+            _serviceProviderMock
+                .Setup(p => p.GetService(typeof(IMapRegionService)))
+                .Returns(_mapRegionServiceMock.Object);
 
             _gfxCommand = new GfxCommand(_regionUpdateBuilderMock.Object);
 
@@ -60,7 +68,10 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
             var regionMock = new Mock<IMapRegion>();
             var location = new Location(10, 20, 0, 0);
             characterMock.Setup(c => c.Location).Returns(location);
-            characterMock.Setup(c => c.Region).Returns(regionMock.Object);
+            characterMock.Setup(c => c.ServiceProvider).Returns(_serviceProviderMock.Object);
+            _mapRegionServiceMock
+                .Setup(s => s.GetOrCreateMapRegion(location.RegionId, location.Dimension, false))
+                .Returns(regionMock.Object);
 
             var args = new GameCommandArgs(characterMock.Object, new[] { "gfx", "123" });
 
@@ -80,7 +91,10 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
             var regionMock = new Mock<IMapRegion>();
             var location = new Location(10, 20, 0, 0);
             characterMock.Setup(c => c.Location).Returns(location);
-            characterMock.Setup(c => c.Region).Returns(regionMock.Object);
+            characterMock.Setup(c => c.ServiceProvider).Returns(_serviceProviderMock.Object);
+            _mapRegionServiceMock
+                .Setup(s => s.GetOrCreateMapRegion(location.RegionId, location.Dimension, false))
+                .Returns(regionMock.Object);
 
             var args = new GameCommandArgs(characterMock.Object, new[] { "gfx", "123", "50" });
 
@@ -100,7 +114,10 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
             var regionMock = new Mock<IMapRegion>();
             var location = new Location(10, 20, 0, 0);
             characterMock.Setup(c => c.Location).Returns(location);
-            characterMock.Setup(c => c.Region).Returns(regionMock.Object);
+            characterMock.Setup(c => c.ServiceProvider).Returns(_serviceProviderMock.Object);
+            _mapRegionServiceMock
+                .Setup(s => s.GetOrCreateMapRegion(location.RegionId, location.Dimension, false))
+                .Returns(regionMock.Object);
 
             var args = new GameCommandArgs(characterMock.Object, new[] { "gfx", "123", "50", "2" });
 

--- a/Hagalaz.Game.Scripts.Tests/Commands/SpawnObjectCommandTests.cs
+++ b/Hagalaz.Game.Scripts.Tests/Commands/SpawnObjectCommandTests.cs
@@ -5,6 +5,7 @@ using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.GameObjects;
 using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Scripts.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -25,6 +26,8 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
             var gameObjectOptionalMock = Substitute.For<IGameObjectOptional>();
             var gameObjectMock = Substitute.For<IGameObject>();
             var regionMock = Substitute.For<IMapRegion>();
+            var mapRegionServiceMock = Substitute.For<IMapRegionService>();
+            var location = new Location(10, 20, 0, 0);
 
             gameObjectBuilderMock.Create().Returns(gameObjectIdMock);
             gameObjectIdMock.WithId(Arg.Any<int>()).Returns(gameObjectLocationMock);
@@ -35,10 +38,12 @@ namespace Hagalaz.Game.Scripts.Tests.Commands
 
             var serviceProviderMock = Substitute.For<IServiceProvider>();
             serviceProviderMock.GetService(typeof(IGameObjectBuilder)).Returns(gameObjectBuilderMock);
+            serviceProviderMock.GetService(typeof(IMapRegionService)).Returns(mapRegionServiceMock);
+            mapRegionServiceMock.GetOrCreateMapRegion(location.RegionId, location.Dimension, false).Returns(regionMock);
 
             var characterMock = Substitute.For<ICharacter>();
             characterMock.ServiceProvider.Returns(serviceProviderMock);
-            characterMock.Region.Returns(regionMock);
+            characterMock.Location.Returns(location);
 
             var command = new SpawnObjectCommand();
             var args = new GameCommandArgs(characterMock, new[] { "123", "10", "1" });

--- a/Hagalaz.Game.Scripts.Tests/Skills/Woodcutting/WoodcuttingSkillServiceTests.cs
+++ b/Hagalaz.Game.Scripts.Tests/Skills/Woodcutting/WoodcuttingSkillServiceTests.cs
@@ -23,6 +23,7 @@ using Hagalaz.Game.Extensions;
 using Hagalaz.Game.Abstractions.Builders.GroundItem;
 using Hagalaz.Game.Abstractions.Builders.GameObject;
 using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.Maps;
 
 namespace Hagalaz.Game.Scripts.Tests.Skills.Woodcutting
 {
@@ -43,6 +44,7 @@ namespace Hagalaz.Game.Scripts.Tests.Skills.Woodcutting
         private IGameObjectId _gameObjectId = null!;
         private IGameObjectLocation _gameObjectLocation = null!;
         private IGameObjectOptional _gameObjectOptional = null!;
+        private IMapRegionService _mapRegionService = null!;
 
 
         [TestInitialize]
@@ -61,6 +63,7 @@ namespace Hagalaz.Game.Scripts.Tests.Skills.Woodcutting
             _gameObjectId = Substitute.For<IGameObjectId>();
             _gameObjectLocation = Substitute.For<IGameObjectLocation>();
             _gameObjectOptional = Substitute.For<IGameObjectOptional>();
+            _mapRegionService = Substitute.For<IMapRegionService>();
 
             var scopeFactory = Substitute.For<IServiceScopeFactory>();
             var scope = Substitute.For<IServiceScope>();
@@ -75,6 +78,9 @@ namespace Hagalaz.Game.Scripts.Tests.Skills.Woodcutting
             _serviceProvider.GetService(typeof(IGroundItemBuilder)).Returns(_groundItemBuilder);
             _serviceProvider.GetService(typeof(IGameObjectService)).Returns(_gameObjectService);
             _serviceProvider.GetService(typeof(IGameObjectBuilder)).Returns(_gameObjectBuilder);
+            _serviceProvider.GetService(typeof(IMapRegionService)).Returns(_mapRegionService);
+            _mapRegionService.GetOrCreateMapRegion(Arg.Any<int>(), Arg.Any<int>(), false)
+                .Returns(Substitute.For<IMapRegion>());
 
             _gameObjectBuilder.Create().Returns(_gameObjectId);
             _gameObjectId.WithId(Arg.Any<int>()).Returns(_gameObjectLocation);

--- a/Hagalaz.Game.Scripts/Areas/Wilderness/GameObjects/Web.rsobj.cs
+++ b/Hagalaz.Game.Scripts/Areas/Wilderness/GameObjects/Web.rsobj.cs
@@ -14,8 +14,13 @@ namespace Hagalaz.Game.Scripts.Areas.Wilderness.GameObjects
     public class Web : GameObjectScript
     {
         private readonly IGameObjectService _gameObjectService;
+        private readonly IMapRegionService _mapRegionService;
 
-        public Web(IGameObjectService gameObjectService) => _gameObjectService = gameObjectService;
+        public Web(IGameObjectService gameObjectService, IMapRegionService mapRegionService)
+        {
+            _gameObjectService = gameObjectService;
+            _mapRegionService = mapRegionService;
+        }
 
         /// <summary>
         ///     Happens when character click's this object and then walks to it
@@ -59,7 +64,7 @@ namespace Hagalaz.Game.Scripts.Areas.Wilderness.GameObjects
                     Instance = Owner,
                     Id = Owner.Id + 1
                 });
-                Owner.Region.UnFlagCollision(Owner);
+                _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).UnFlagCollision(Owner);
                 clicker.QueueTask(new RsTask(() =>
                     {
                         _gameObjectService.UpdateGameObject(new GameObjectUpdate
@@ -67,7 +72,7 @@ namespace Hagalaz.Game.Scripts.Areas.Wilderness.GameObjects
                             Instance = Owner,
                             Id = Owner.Id - 1
                         });
-                        Owner.Region.FlagCollision(Owner);
+                        _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).FlagCollision(Owner);
                     },
                     100));
                 return;

--- a/Hagalaz.Game.Scripts/Commands/GameCommandPrompt.cs
+++ b/Hagalaz.Game.Scripts/Commands/GameCommandPrompt.cs
@@ -47,7 +47,9 @@ namespace Hagalaz.Game.Scripts.Commands
                     Name = "currentregion",
                     CommandFunc = async (character, arguments) =>
                     {
-                        character.SendChatMessage("Current Region Id: " + character.Region.Id, ChatMessageType.ConsoleText);
+                        var regionService = character.ServiceProvider.GetRequiredService<IMapRegionService>();
+                        var region = regionService.GetOrCreateMapRegion(character.Location.RegionId, character.Location.Dimension, false);
+                        character.SendChatMessage("Current Region Id: " + region.Id, ChatMessageType.ConsoleText);
                         return true;
                     },
                     Permission = Permission.SystemAdministrator

--- a/Hagalaz.Game.Scripts/Commands/GfxCommand.cs
+++ b/Hagalaz.Game.Scripts/Commands/GfxCommand.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 using Hagalaz.Game.Abstractions.Authorization;
 using Hagalaz.Game.Abstractions.Builders.Region;
 using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Game.Scripts.Commands
 {
@@ -25,7 +27,8 @@ namespace Hagalaz.Game.Scripts.Commands
                 rotation = int.Parse(cmd[3]);
             var gfx = Graphic.Create(gfxID, 0, height, rotation);
             var update = _regionUpdateBuilder.Create().WithLocation(args.Character.Location).WithGraphic(gfx).Build();
-            args.Character.Region.QueueUpdate(update);
+            var regionService = args.Character.ServiceProvider.GetRequiredService<IMapRegionService>();
+            regionService.GetOrCreateMapRegion(args.Character.Location.RegionId, args.Character.Location.Dimension, false).QueueUpdate(update);
             return Task.CompletedTask;
         }
     }

--- a/Hagalaz.Game.Scripts/Commands/SpawnObjectCommand.cs
+++ b/Hagalaz.Game.Scripts/Commands/SpawnObjectCommand.cs
@@ -3,6 +3,7 @@ using Hagalaz.Game.Abstractions.Authorization;
 using Hagalaz.Game.Abstractions.Builders.GameObject;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.GameObjects;
+using Hagalaz.Game.Abstractions.Services;
 
 namespace Hagalaz.Game.Scripts.Commands
 {
@@ -25,7 +26,8 @@ namespace Hagalaz.Game.Scripts.Commands
                     .WithShape((ShapeType)shape)
                     .WithRotation(rotation)
                     .Build();
-                args.Character.Region.Add(gameObject);
+                var regionService = args.Character.ServiceProvider.GetRequiredService<IMapRegionService>();
+                regionService.GetOrCreateMapRegion(args.Character.Location.RegionId, args.Character.Location.Dimension, false).Add(gameObject);
             }
             return Task.CompletedTask;
         }

--- a/Hagalaz.Game.Scripts/GameObjects/Cabbage.rsobj.cs
+++ b/Hagalaz.Game.Scripts/GameObjects/Cabbage.rsobj.cs
@@ -14,11 +14,13 @@ namespace Hagalaz.Game.Scripts.GameObjects
     {
         private readonly IRsTaskService _rsTaskService;
         private readonly IItemBuilder _itemBuilder;
+        private readonly IMapRegionService _mapRegionService;
 
-        public Cabbage(IRsTaskService rsTaskService, IItemBuilder itemBuilder)
+        public Cabbage(IRsTaskService rsTaskService, IItemBuilder itemBuilder, IMapRegionService mapRegionService)
         {
             _rsTaskService = rsTaskService;
             _itemBuilder = itemBuilder;
+            _mapRegionService = mapRegionService;
         }
 
         /// <summary>
@@ -42,8 +44,9 @@ namespace Hagalaz.Game.Scripts.GameObjects
                         if (clicker.Inventory.Add(_itemBuilder.Create().WithId(1965).Build()))
                         {
                             // delete the cabbage object.
-                            Owner.Region.Remove(Owner);
-                            _rsTaskService.Schedule(new RsTask(() => Owner.Region.Add(Owner), 100));
+                            _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).Remove(Owner);
+                            _rsTaskService.Schedule(new RsTask(() =>
+                                _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).Add(Owner), 100));
                             clicker.SendChatMessage("You pulled the cabbage out of the ground.");
                         }
                         else

--- a/Hagalaz.Game.Scripts/GameObjects/Cannon/DwarfMultiCannonGameObjectScript.cs
+++ b/Hagalaz.Game.Scripts/GameObjects/Cannon/DwarfMultiCannonGameObjectScript.cs
@@ -78,10 +78,11 @@ namespace Hagalaz.Game.Scripts.GameObjects.Cannon
         private readonly IProjectileBuilder _projectileBuilder;
         private readonly IItemBuilder _itemBuilder;
         private readonly IGameObjectService _gameObjectService;
+        private readonly IMapRegionService _mapRegionService;
 
         public DwarfMultiCannonGameObjectScript(
             IProjectilePathFinder projectilePathFinder, IRsTaskService rsTaskService, IHitSplatBuilder hitSplatBuilder, IProjectileBuilder projectileBuilder,
-            IItemBuilder itemBuilder, IGameObjectService gameObjectService)
+            IItemBuilder itemBuilder, IGameObjectService gameObjectService, IMapRegionService mapRegionService)
         {
             _projectilePathFinder = projectilePathFinder;
             _rsTaskService = rsTaskService;
@@ -89,6 +90,7 @@ namespace Hagalaz.Game.Scripts.GameObjects.Cannon
             _projectileBuilder = projectileBuilder;
             _itemBuilder = itemBuilder;
             _gameObjectService = gameObjectService;
+            _mapRegionService = mapRegionService;
         }
 
         /// <summary>
@@ -297,7 +299,7 @@ namespace Hagalaz.Game.Scripts.GameObjects.Cannon
 
                 if (_cannonOwner.IsDestroyed || !_cannonOwner.HasState<CannonPlacedState>())
                 {
-                    Owner.Region.Remove(Owner);
+                    _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).Remove(Owner);
                     task.Cancel();
                     return;
                 }
@@ -361,7 +363,7 @@ namespace Hagalaz.Game.Scripts.GameObjects.Cannon
 
                     character.Inventory.Add(cannonBalls);
 
-                    character.Region.Remove(cannon);
+                    _mapRegionService.GetOrCreateMapRegion(character.Location.RegionId, character.Location.Dimension, false).Remove(cannon);
 
                     character.RemoveState<CannonPlacedState>();
 

--- a/Hagalaz.Game.Scripts/GameObjects/Cannon/DwarfMultiCannonItemScript.cs
+++ b/Hagalaz.Game.Scripts/GameObjects/Cannon/DwarfMultiCannonItemScript.cs
@@ -96,7 +96,9 @@ namespace Hagalaz.Game.Scripts.GameObjects.Cannon
                 {
                     if (tick == 0)
                     {
-                        character.Region.Add(cannon);
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(character.Location.RegionId, character.Location.Dimension, false)
+                            .Add(cannon);
 
                         character.SendChatMessage("You place the cannon base on the ground...");
                         character.Inventory.Remove(_itemBuilder.Create().WithId(CannonItemIds[0 + cannonId]).Build());

--- a/Hagalaz.Game.Scripts/GameObjects/Flax.rsobj.cs
+++ b/Hagalaz.Game.Scripts/GameObjects/Flax.rsobj.cs
@@ -15,11 +15,13 @@ namespace Hagalaz.Game.Scripts.GameObjects
     {
         private readonly IRsTaskService _taskService;
         private readonly IItemBuilder _itemBuilder;
+        private readonly IMapRegionService _mapRegionService;
 
-        public Flax(IRsTaskService taskService, IItemBuilder itemBuilder)
+        public Flax(IRsTaskService taskService, IItemBuilder itemBuilder, IMapRegionService mapRegionService)
         {
             _taskService = taskService;
             _itemBuilder = itemBuilder;
+            _mapRegionService = mapRegionService;
         }
 
         /// <summary>
@@ -47,8 +49,9 @@ namespace Hagalaz.Game.Scripts.GameObjects
                             if (0.40 >= RandomStatic.Generator.NextDouble())
                             {
                                 // delete the flax object.
-                                Owner.Region.Remove(Owner);
-                                _taskService.Schedule(new RsTask(() => Owner.Region.Add(Owner), 8));
+                                _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).Remove(Owner);
+                                _taskService.Schedule(new RsTask(() =>
+                                    _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).Add(Owner), 8));
                             }
 
                             clicker.SendChatMessage("You picked up the flax from the ground.");

--- a/Hagalaz.Game.Scripts/GameObjects/Lodestone.rsobj.cs
+++ b/Hagalaz.Game.Scripts/GameObjects/Lodestone.rsobj.cs
@@ -16,11 +16,13 @@ namespace Hagalaz.Game.Scripts.GameObjects
     {
         private readonly ILodestoneService _lodestoneService;
         private readonly IRegionUpdateBuilder _regionUpdateBuilder;
+        private readonly IMapRegionService _mapRegionService;
 
-        public Lodestone(ILodestoneService lodestoneService, IRegionUpdateBuilder regionUpdateBuilder)
+        public Lodestone(ILodestoneService lodestoneService, IRegionUpdateBuilder regionUpdateBuilder, IMapRegionService mapRegionService)
         {
             _lodestoneService = lodestoneService;
             _regionUpdateBuilder = regionUpdateBuilder;
+            _mapRegionService = mapRegionService;
         }
         
         /// <summary>
@@ -56,7 +58,7 @@ namespace Hagalaz.Game.Scripts.GameObjects
             }
             character.AddState(new TeleportingState { TicksLeft = int.MaxValue });
             var update = _regionUpdateBuilder.Create().WithLocation(Owner.Location).WithGraphic(Graphic.Create(3019)).Build();
-            Owner.Region.QueueUpdate(update);
+            _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).QueueUpdate(update);
             // TODO - Show cutscene
         }
     }

--- a/Hagalaz.Game.Scripts/GameObjects/RemovedObject.rsobj.cs
+++ b/Hagalaz.Game.Scripts/GameObjects/RemovedObject.rsobj.cs
@@ -1,15 +1,22 @@
 ﻿using Hagalaz.Game.Abstractions.Model.GameObjects;
 using Hagalaz.Game.Scripts.Model.GameObjects;
+using Hagalaz.Game.Abstractions.Services;
 
 namespace Hagalaz.Game.Scripts.GameObjects
 {
     [GameObjectScriptMetaData([1596, 1597, 31825, 31827, 31841, 31844, 38453, 38447, 55349, 77085, 77086, 77098])]
     public class RemovedObject : GameObjectScript
     {
+        private readonly IMapRegionService _mapRegionService;
+
+        public RemovedObject(IMapRegionService mapRegionService) => _mapRegionService = mapRegionService;
+
         /// <summary>
         ///     Happens when object is spawned.
         /// </summary>
-        public override void OnSpawn() => Owner.Region.Remove(Owner);
+        public override void OnSpawn() => _mapRegionService
+            .GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false)
+            .Remove(Owner);
 
         /// <summary>
         ///     Get's called when owner is found.

--- a/Hagalaz.Game.Scripts/Minigames/Godwars/GameObjects/Armadyl/Pillar.rsobj.cs
+++ b/Hagalaz.Game.Scripts/Minigames/Godwars/GameObjects/Armadyl/Pillar.rsobj.cs
@@ -6,6 +6,7 @@ using Hagalaz.Game.Abstractions.Features.States.Effects;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.GameObjects;
 using Hagalaz.Game.Abstractions.Tasks;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Scripts.Model.GameObjects;
 
 namespace Hagalaz.Game.Scripts.Minigames.Godwars.GameObjects.Armadyl
@@ -17,11 +18,13 @@ namespace Hagalaz.Game.Scripts.Minigames.Godwars.GameObjects.Armadyl
     {
         private readonly IRegionUpdateBuilder _regionUpdateBuilder;
         private readonly IMovementBuilder _movementBuilder;
+        private readonly IMapRegionService _mapRegionService;
 
-        public Pillar(IRegionUpdateBuilder regionUpdateBuilder, IMovementBuilder movementBuilder)
+        public Pillar(IRegionUpdateBuilder regionUpdateBuilder, IMovementBuilder movementBuilder, IMapRegionService mapRegionService)
         {
             _regionUpdateBuilder = regionUpdateBuilder;
             _movementBuilder = movementBuilder;
+            _mapRegionService = mapRegionService;
         }
 
         /// <summary>
@@ -61,7 +64,7 @@ namespace Hagalaz.Game.Scripts.Minigames.Godwars.GameObjects.Armadyl
                             .WithLocation(Location.Create(2872, 5274, 2, 0))
                             .WithGraphic(Graphic.Create(2103))
                             .Build();
-                        Owner.Region.QueueUpdate(update);
+                        _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).QueueUpdate(update);
                         clicker.FaceLocation(Owner.Location);
 
                         clicker.QueueTask(new RsTask(() =>

--- a/Hagalaz.Game.Scripts/Skills/Mining/MiningRocks.rsobj.cs
+++ b/Hagalaz.Game.Scripts/Skills/Mining/MiningRocks.rsobj.cs
@@ -147,17 +147,24 @@ namespace Hagalaz.Game.Scripts.Skills.Mining
                             .WithRotation(rocks.Rotation)
                             .WithShape(rocks.ShapeType)
                             .Build();
-                        rocks.Region.Add(exhaustedRock);
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(rocks.Location.RegionId, rocks.Location.Dimension, false)
+                            .Add(exhaustedRock);
                     }
                     else // delete the rocks
                     {
-                        rocks.Region.Remove(rocks);
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(rocks.Location.RegionId, rocks.Location.Dimension, false)
+                            .Remove(rocks);
                     }
 
                     var characterCount = await _characterStore.CountAsync();
                     var respawnTick = (int)(respawnTime * (1.0 + characterCount * -0.00025) * 100.0);
 
-                    _taskService.Schedule(new RsTask(() => rocks.Region.Add(rocks), respawnTick));
+                    _taskService.Schedule(new RsTask(() =>
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(rocks.Location.RegionId, rocks.Location.Dimension, false)
+                            .Add(rocks), respawnTick));
                     return true;
                 }
 

--- a/Hagalaz.Game.Scripts/Skills/Thieving/Stall.rsobj.cs
+++ b/Hagalaz.Game.Scripts/Skills/Thieving/Stall.rsobj.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
 using Hagalaz.Game.Abstractions.Model.GameObjects;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Scripts.Model.GameObjects;
 
 namespace Hagalaz.Game.Scripts.Skills.Thieving
@@ -11,6 +12,10 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
     /// </summary>
     public class Stall : GameObjectScript
     {
+        private readonly IMapRegionService _mapRegionService;
+
+        public Stall(IMapRegionService mapRegionService) => _mapRegionService = mapRegionService;
+
         /// <summary>
         ///     Contains the steal definition.
         /// </summary>
@@ -19,7 +24,10 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
         /// <summary>
         ///     Contains the stall owner.
         /// </summary>
-        public INpc? StallOwner => Owner.Region.FindAllNpcs().FirstOrDefault(npc => npc.Appearance.CompositeID == Definition.NpcOwnerID);
+        public INpc? StallOwner => _mapRegionService
+            .GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false)
+            .FindAllNpcs()
+            .FirstOrDefault(npc => npc.Appearance.CompositeID == Definition.NpcOwnerID);
 
         /// <summary>
         ///     Contains the local guards.

--- a/Hagalaz.Game.Scripts/Skills/Thieving/StandardStealTask.cs
+++ b/Hagalaz.Game.Scripts/Skills/Thieving/StandardStealTask.cs
@@ -11,6 +11,7 @@ using Hagalaz.Game.Abstractions.Tasks;
 using Hagalaz.Game.Common;
 using Hagalaz.Game.Common.Tasks;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Game.Scripts.Skills.Thieving
 {
@@ -72,7 +73,8 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
             }
 
             // check if someone else has stole from this stall.
-            var objRegion = _gameObject.Region;
+            var regionService = _performer.ServiceProvider.GetRequiredService<IMapRegionService>();
+            var objRegion = regionService.GetOrCreateMapRegion(_gameObject.Location.RegionId, _gameObject.Location.Dimension, false);
             var obj = objRegion.FindStandardGameObject(_gameObject.Location.RegionLocalX, _gameObject.Location.RegionLocalY, _gameObject.Location.Z);
             if (obj == null || obj.IsDestroyed || obj.Id != _gameObject.Id)
             {

--- a/Hagalaz.Game.Scripts/Skills/Thieving/Thieving.cs
+++ b/Hagalaz.Game.Scripts/Skills/Thieving/Thieving.cs
@@ -5,6 +5,7 @@ using Hagalaz.Game.Abstractions.Model.GameObjects;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Resources;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Game.Scripts.Skills.Thieving
 {
@@ -135,7 +136,9 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
                 return;
             }
             // check if the object isn't empty.
-            var checkObj = obj.Region.FindStandardGameObject(obj.Location.RegionLocalX, obj.Location.RegionLocalY, obj.Location.Z);
+            var regionService = clicker.ServiceProvider.GetRequiredService<IMapRegionService>();
+            var checkObj = regionService.GetOrCreateMapRegion(obj.Location.RegionId, obj.Location.Dimension, false)
+                .FindStandardGameObject(obj.Location.RegionLocalX, obj.Location.RegionLocalY, obj.Location.Z);
             if (checkObj == null || checkObj.Id != obj.Id)
             {
                 return;

--- a/Hagalaz.Game.Scripts/Skills/Woodcutting/WoodcuttingSkillService.cs
+++ b/Hagalaz.Game.Scripts/Skills/Woodcutting/WoodcuttingSkillService.cs
@@ -192,7 +192,9 @@ namespace Hagalaz.Game.Scripts.Skills.Woodcutting
                     // new trees have leaves, so remove the leaves if possible.
                     if (treeLeaves != null)
                     {
-                        tree.Region.Remove(treeLeaves);
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(tree.Location.RegionId, tree.Location.Dimension, false)
+                            .Remove(treeLeaves);
                     }
 
                     var goBuilder = _serviceProvider.GetRequiredService<IGameObjectBuilder>();
@@ -205,11 +207,15 @@ namespace Hagalaz.Game.Scripts.Skills.Woodcutting
                             .WithRotation(tree.Rotation)
                             .WithShape(tree.ShapeType)
                             .Build();
-                        tree.Region.Add(stumpObj);
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(tree.Location.RegionId, tree.Location.Dimension, false)
+                            .Add(stumpObj);
                     }
                     else // delete the tree object.
                     {
-                        tree.Region.Remove(tree);
+                        character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                            .GetOrCreateMapRegion(tree.Location.RegionId, tree.Location.Dimension, false)
+                            .Remove(tree);
                     }
 
                     var characterCount = await _characterStore.CountAsync();
@@ -217,10 +223,14 @@ namespace Hagalaz.Game.Scripts.Skills.Woodcutting
                     // register a task that will respawn the tree once it has reached the respawn rate.
                     _rsTaskService.Schedule(new RsTask(() =>
                         {
-                            tree.Region.Add(tree);
+                            character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                                .GetOrCreateMapRegion(tree.Location.RegionId, tree.Location.Dimension, false)
+                                .Add(tree);
                             if (treeLeaves != null)
                             {
-                                tree.Region.Add(treeLeaves);
+                                character.ServiceProvider.GetRequiredService<IMapRegionService>()
+                                    .GetOrCreateMapRegion(tree.Location.RegionId, tree.Location.Dimension, false)
+                                    .Add(treeLeaves);
                             }
                         },
                         respawnTick));

--- a/Hagalaz.Services.GameWorld.Tests/CreatureCollectionTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CreatureCollectionTests.cs
@@ -245,8 +245,6 @@ namespace Hagalaz.Services.GameWorld.Tests
 
             public ILocation Location => throw new NotImplementedException();
 
-            public IMapRegion Region => throw new NotImplementedException();
-
             public bool IsDestroyed => throw new NotImplementedException();
 
             public int Size => throw new NotImplementedException();

--- a/Hagalaz.Services.GameWorld.Tests/CreatureCombatTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CreatureCombatTests.cs
@@ -4,6 +4,7 @@ using Hagalaz.Game.Abstractions.Builders.Projectile;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Configuration;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -40,6 +41,7 @@ namespace Hagalaz.Services.GameWorld.Tests
             serviceProviderMock.GetService(typeof(IProjectileBuilder)).Returns(Substitute.For<IProjectileBuilder>());
             serviceProviderMock.GetService(typeof(IProjectilePathFinder)).Returns(Substitute.For<IProjectilePathFinder>());
             serviceProviderMock.GetService(typeof(ISmartPathFinder)).Returns(Substitute.For<ISmartPathFinder>());
+            serviceProviderMock.GetService(typeof(IMapRegionService)).Returns(Substitute.For<IMapRegionService>());
 
             var combatOptions = new CombatOptions();
             var optionsMock = Substitute.For<IOptions<CombatOptions>>();

--- a/Hagalaz.Services.GameWorld.Tests/GroundItemTickTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/GroundItemTickTests.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Abstractions.Builders.GameObject;
 using Hagalaz.Game.Abstractions.Builders.GroundItem;
@@ -21,7 +22,7 @@ namespace Hagalaz.Services.GameWorld.Tests
             var npcService = Substitute.For<INpcService>();
             var regionService = Substitute.For<IMapRegionService>();
             var gameObjectBuilder = Substitute.For<IGameObjectBuilder>();
-            var groundItemBuilder = new SimpleGroundItemBuilder(publicTicks);
+            var groundItemBuilder = new SimpleGroundItemBuilder(publicTicks, regionService);
             var mapper = new MapperConfiguration(cfg => { }, LoggerFactory.Create(_ => { })).CreateMapper();
             var location = Location.Create(0, 0);
             return new MapRegion(
@@ -46,7 +47,7 @@ namespace Hagalaz.Services.GameWorld.Tests
             item.Count.Returns(1);
             item.Id.Returns(0);
             var location = Location.Create(10, 10);
-            return new GroundItem(item, location, null, respawnTicks, ticksLeft);
+            return new GroundItem(item, location, null, respawnTicks, ticksLeft, Substitute.For<IMapRegionService>());
         }
 
         private static IGroundItem CreatePrivateItem(bool tradable, int ticksLeft)
@@ -62,7 +63,7 @@ namespace Hagalaz.Services.GameWorld.Tests
             item.Id.Returns(0);
             var location = Location.Create(10, 10);
             var owner = Substitute.For<ICharacter>();
-            return new GroundItem(item, location, owner, 0, ticksLeft);
+            return new GroundItem(item, location, owner, 0, ticksLeft, Substitute.For<IMapRegionService>());
         }
 
         [TestMethod]
@@ -157,7 +158,7 @@ namespace Hagalaz.Services.GameWorld.Tests
         public void CanDestroy_Returns_False_When_Respawning()
         {
             var item = CreateItem(5, 0);
-            var respawning = new GroundItem(item.ItemOnGround, item.Location, null, item.RespawnTicks, 0, true);
+            var respawning = new GroundItem(item.ItemOnGround, item.Location, null, item.RespawnTicks, 0, Substitute.For<IMapRegionService>(), true);
 
             Assert.IsFalse(respawning.CanDestroy());
         }
@@ -170,22 +171,40 @@ namespace Hagalaz.Services.GameWorld.Tests
             Assert.IsTrue(item.CanDestroy());
         }
 
+        [TestMethod]
+        public void Despawn_RemovesItemFromLocationRegion()
+        {
+            var regionService = Substitute.For<IMapRegionService>();
+            var region = Substitute.For<IMapRegion>();
+            var item = CreateItem(0, 0);
+            var groundItem = new GroundItem(item.ItemOnGround, item.Location, null, 0, 0, regionService);
+            regionService.GetOrCreateMapRegion(item.Location.RegionId, item.Location.Dimension, false).Returns(region);
+
+            var result = groundItem.Despawn();
+
+            Assert.IsTrue(result);
+            regionService.Received(1).GetOrCreateMapRegion(item.Location.RegionId, item.Location.Dimension, false);
+            region.Received(1).Remove(groundItem);
+        }
+
         public class SimpleGroundItemBuilder : IGroundItemBuilder, IGroundItemOnGround, IGroundItemLocation, IGroundItemOptional, IGroundItemBuild {
             private int? _respawnTicks;
             private int? _ticks;
             private readonly int _publicTicks;
+            private readonly IMapRegionService _mapRegionService;
             private IItem _item = default!;
             private ILocation _location = default!;
             private ICharacter? _owner;
             private bool _isRespawning;
 
-            public SimpleGroundItemBuilder(int publicTicks = 100)
+            public SimpleGroundItemBuilder(int publicTicks, IMapRegionService mapRegionService)
             {
                 _publicTicks = publicTicks;
+                _mapRegionService = mapRegionService;
             }
 
             // IGroundItemBuilder
-            public IGroundItemOnGround Create() => new SimpleGroundItemBuilder(_publicTicks);
+            public IGroundItemOnGround Create() => new SimpleGroundItemBuilder(_publicTicks, _mapRegionService);
 
             // IGroundItemOnGround
             public IGroundItemLocation WithItem(IItem item) { _item = item; return this; }
@@ -219,7 +238,7 @@ namespace Hagalaz.Services.GameWorld.Tests
                     ticks = respawnTicks;
                 }
 
-                var result = new GroundItem(_item, _location, _owner, respawnTicks, ticks, _isRespawning);
+                var result = new GroundItem(_item, _location, _owner, respawnTicks, ticks, _mapRegionService, _isRespawning);
 
                 return result;
             }

--- a/Hagalaz.Services.GameWorld/Builders/GroundItemBuilder.cs
+++ b/Hagalaz.Services.GameWorld/Builders/GroundItemBuilder.cs
@@ -102,6 +102,7 @@ namespace Hagalaz.Services.GameWorld.Builders
                 _owner,
                 respawnTicks,
                 ticks,
+                _serviceProvider.GetRequiredService<IMapRegionService>(),
                 _isRespawning);
         }
 

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
@@ -13,6 +13,7 @@ using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters.Actions;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Abstractions.Tasks;
 using Hagalaz.Game.Common;
 using Hagalaz.Game.Common.Events;
@@ -37,6 +38,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         private readonly IAnimationBuilder _animationBuilder;
         private readonly IGraphicBuilder _graphicBuilder;
         private readonly IProjectileBuilder _projectileBuilder;
+        private readonly IMapRegionService _mapRegionService;
 
         /// <summary>
         /// Construct's new combat class for specified
@@ -50,6 +52,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             _animationBuilder = _character.ServiceProvider.GetRequiredService<IAnimationBuilder>();
             _graphicBuilder = _character.ServiceProvider.GetRequiredService<IGraphicBuilder>();
             _projectileBuilder = _character.ServiceProvider.GetRequiredService<IProjectileBuilder>();
+            _mapRegionService = _character.ServiceProvider.GetRequiredService<IMapRegionService>();
         }
 
 
@@ -137,7 +140,8 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                     .WithLocation(Owner.Location)
                     .WithOwner(groundItemOwner)
                     .Build();
-                Owner.Region.Add(groundItem); // we spawn it with this method, as the container was normally stacked.
+                _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false)
+                    .Add(groundItem); // we spawn it with this method, as the container was normally stacked.
             }
 
             var bones = groundItemBuilder.Create()
@@ -145,7 +149,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 .WithLocation(Owner.Location)
                 .WithOwner(groundItemOwner)
                 .Build();
-            Owner.Region.Add(bones);
+            _mapRegionService.GetOrCreateMapRegion(Owner.Location.RegionId, Owner.Location.Dimension, false).Add(bones);
             _character.Inventory.AddRange(itemsOnDeath.keptItems);
             _character.Inventory.OnUpdate();
             _character.Equipment.OnUpdate();

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/InventoryContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/InventoryContainer.cs
@@ -7,6 +7,7 @@ using Hagalaz.Game.Abstractions.Logic.Dehydrations;
 using Hagalaz.Game.Abstractions.Logic.Hydrations;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Instance of the character who owns this container.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IMapRegionService _mapRegionService;
 
         /// <summary>
         /// Contstructs a container for character inventories.
@@ -31,7 +33,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// <param name="capacity">The capacity of the container.</param>
         public InventoryContainer(ICharacter owner, int capacity)
             : base(StorageType.Normal, capacity) =>
-            _owner = owner;
+            (_owner, _mapRegionService) = (owner, owner.ServiceProvider.GetRequiredService<IMapRegionService>());
 
         /// <summary>
         /// Called when multiple items from specified slot(s) have changed.
@@ -55,7 +57,8 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 .WithLocation(_owner.Location)
                 .WithOwner(_owner)
                 .Build();
-            _owner.Region.Add(groundItem); // we spawn it with this method, as the container was normally stacked.
+            _mapRegionService.GetOrCreateMapRegion(_owner.Location.RegionId, _owner.Location.Dimension, false)
+                .Add(groundItem); // we spawn it with this method, as the container was normally stacked.
             return true;
         }
 

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/RegionMethods.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/RegionMethods.cs
@@ -63,7 +63,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             this.QueueTask(async () =>
             {
                 var musicService = ServiceProvider.GetRequiredService<IMusicService>();
-                var musicIds = await musicService.FindMusicIdsByRegionId(Region.Id);
+                var region = ServiceProvider.GetRequiredService<IMapRegionService>()
+                    .GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
+                var musicIds = await musicService.FindMusicIdsByRegionId(region.Id);
                 if (musicIds.Any(musicId => Music.UnlockMusic(musicId)))
                 {
                     Music.RefreshMusicList();

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Creature.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Creature.cs
@@ -98,22 +98,6 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
         public ICreatureCombat Combat { get; protected set; } = default!;
 
         /// <summary>
-        ///     Contains entity map region.
-        /// </summary>
-        /// <value>The region.</value>
-        public IMapRegion Region
-        {
-            get
-            {
-                if (Location == null)
-                {
-                    throw new InvalidOperationException($"{nameof(Location)} is not initialized yet.");
-                }
-                return MapRegionService.GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
-            }
-        }
-
-        /// <summary>
         ///     Contains creature to which this creature is facing ,
         ///     can be null.
         /// </summary>
@@ -240,7 +224,8 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (Location != null)
             {
-                RemoveFromRegion(Region);
+                var region = MapRegionService.GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
+                RemoveFromRegion(region);
             }
             Area?.OnCreatureExitArea(this);
             OnDestroy();

--- a/Hagalaz.Services.GameWorld/Model/Items/GroundItem.cs
+++ b/Hagalaz.Services.GameWorld/Model/Items/GroundItem.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using Hagalaz.DependencyInjection.Extensions;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Items;
-using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Services;
 
 namespace Hagalaz.Services.GameWorld.Model.Items
@@ -12,14 +10,7 @@ namespace Hagalaz.Services.GameWorld.Model.Items
     {
         public IItem ItemOnGround { get; }
         public ILocation Location { get; }
-        public IMapRegion Region
-        {
-            get
-            {
-                var regionManager = ServiceLocator.Current.GetInstance<IMapRegionService>();
-                return regionManager.GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
-            }
-        }
+        private readonly IMapRegionService _mapRegionService;
         public ICharacter? Owner { get; set; }
         public int TicksLeft { get; set; }
         public int RespawnTicks { get; private set; }
@@ -29,18 +20,13 @@ namespace Hagalaz.Services.GameWorld.Model.Items
         public string Name => ItemOnGround.Name;
         public bool IsDestroyed { get; private set; }
 
-        private GroundItem(IItem itemOnGround, ILocation location)
-        {
-            ItemOnGround = itemOnGround;
-            Location = location;
-        }
-
         public GroundItem(
             IItem itemOnGround,
             ILocation location,
             ICharacter? owner,
             int respawnTicks,
             int ticksLeft,
+            IMapRegionService mapRegionService,
             bool isRespawning = false)
         {
             ItemOnGround = itemOnGround;
@@ -48,6 +34,7 @@ namespace Hagalaz.Services.GameWorld.Model.Items
             Owner = owner;
             RespawnTicks = respawnTicks;
             TicksLeft = ticksLeft;
+            _mapRegionService = mapRegionService;
             IsRespawning = isRespawning;
         }
 
@@ -99,7 +86,8 @@ namespace Hagalaz.Services.GameWorld.Model.Items
         /// <returns></returns>
         public bool Despawn()
         {
-            Region.Remove(this);
+            var region = _mapRegionService.GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
+            region.Remove(this);
             return true;
         }
 
@@ -129,6 +117,7 @@ namespace Hagalaz.Services.GameWorld.Model.Items
             Owner,
             RespawnTicks,
             TicksLeft,
+            _mapRegionService,
             IsRespawning);
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Maps/GameObjects/GameObject.cs
+++ b/Hagalaz.Services.GameWorld/Model/Maps/GameObjects/GameObject.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using Hagalaz.DependencyInjection.Extensions;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.GameObjects;
-using Hagalaz.Game.Abstractions.Model.Maps;
-using Hagalaz.Game.Abstractions.Services;
 
 namespace Hagalaz.Services.GameWorld.Model.Maps.GameObjects
 {
@@ -26,18 +23,6 @@ namespace Hagalaz.Services.GameWorld.Model.Maps.GameObjects
         /// Contains location of this object.
         /// </summary>
         public ILocation Location { get; }
-
-        /// <summary>
-        /// Contains Region of this object.
-        /// </summary>
-        public IMapRegion Region
-        {
-            get
-            {
-                var regionManager = ServiceLocator.Current.GetInstance<IMapRegionService>();
-                return regionManager.GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
-            }
-        }
 
         /// <summary>
         /// Contains definition of this object.

--- a/openspec/changes/remove-entity-region/.openspec.yaml
+++ b/openspec/changes/remove-entity-region/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/remove-entity-region/design.md
+++ b/openspec/changes/remove-entity-region/design.md
@@ -1,0 +1,35 @@
+## Context
+
+Entities currently expose a deprecated `Region` property. The property hides lookup of the singleton `IMapRegionService` inside `Creature`, `GameObject`, and `GroundItem`, while most newer code already resolves the service directly. Removing the property affects the abstractions project, GameWorld models, scripts, commands, and tests.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `IMapRegionService` the only region lookup mechanism exposed to callers.
+- Preserve the existing region lookup, add/remove, update, and ground-item despawn behavior.
+- Keep dependency ownership explicit at existing DI and character service boundaries.
+
+**Non-Goals:**
+
+- Changing `IMapRegionService` methods or map-region lifecycle ownership.
+- Introducing a general entity-to-region adapter, helper framework, or replacement property.
+- Migrating unrelated service-locator usage or unrelated `Region` properties.
+
+## Decisions
+
+- **Remove the contract and concrete convenience properties.** `IEntity.Region`, `Creature.Region`, `GameObject.Region`, and `GroundItem.Region` are deleted. This is a deliberate breaking change; retaining a compatibility wrapper would preserve the implicit lookup this change is intended to eliminate.
+- **Reuse the existing map service API.** Callers resolve the region with `GetOrCreateMapRegion(location.RegionId, location.Dimension, false)`, preserving the legacy property's behavior. No new service method is added.
+- **Use existing character service boundaries for character-bound operations.** Commands, skills, combat, and inventory code resolve `IMapRegionService` from `ICharacter.ServiceProvider`, matching the existing command and script patterns.
+- **Use constructor injection for standalone object scripts.** Scripts that operate on `Owner` without a character context receive `IMapRegionService` through their existing DI constructors. Adding a shared service-locator-backed property to `GameObjectScript` was rejected because it would create another implicit access mechanism.
+- **Inject the service into `GroundItem`.** `GroundItemBuilder` supplies the existing service to the model, and `Clone` carries the same dependency forward. `IGroundItem.Despawn()` remains the public operation and removes the item from the region selected by its location.
+
+## Risks / Trade-offs
+
+- [Risk] Constructor signatures for concrete scripts and `GroundItem` change. → All affected instances are created through existing DI/builders or are updated in focused test helpers; solution compilation verifies remaining callers.
+- [Risk] A missed `.Region` caller could break a less frequently built project. → Search the full C# source/test tree and run both affected test projects plus the solution build.
+- [Risk] Region lookup semantics could accidentally change during replacement. → Keep the exact existing `GetOrCreateMapRegion` arguments and add a direct despawn regression test.
+
+## Migration Plan
+
+This is an in-repository source migration with no persisted data or deployment sequencing. Apply the contract removal and caller updates together, run focused tests and the solution build, then archive the OpenSpec change after validation. Rollback is a source revert if required.

--- a/openspec/changes/remove-entity-region/proposal.md
+++ b/openspec/changes/remove-entity-region/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`IEntity.Region` is a deprecated convenience property that makes entity models resolve map-region infrastructure implicitly. Removing it completes the migration to the existing `IMapRegionService`, gives region lookup one owner, and prevents new callers from depending on the legacy contract.
+
+## What Changes
+
+- **BREAKING**: Remove `IEntity.Region` and the corresponding concrete properties from creatures, game objects, and ground items.
+- Migrate every production and test caller to `IMapRegionService`, preserving the current `GetOrCreateMapRegion(location.RegionId, location.Dimension, false)` semantics.
+- Inject `IMapRegionService` into `GroundItem` through `GroundItemBuilder` so `IGroundItem.Despawn()` retains its behavior without restoring an entity region property.
+- Supply the service to standalone game-object scripts through their existing dependency-injection constructors; character-bound code uses the existing character service provider.
+- Do not change `IMapRegionService`, map-region lifecycle ownership, or unrelated properties named `Region`.
+
+## Capabilities
+
+### New Capabilities
+
+- `entity-map-region-access`: Defines the authoritative service-based map-region access contract for entities and their callers.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected contracts: `IEntity` and inherited entity interfaces.
+- Affected implementations: `Creature`, `GameObject`, `GroundItem`, and region-using scripts/services.
+- Affected tests: entity test doubles, command tests, and ground-item lifecycle tests.
+- No new packages, workers, queues, persistence, or service APIs.
+
+## Acceptance Criteria
+
+- The solution contains no `IEntity.Region` member or concrete entity `.Region` compatibility property.
+- All former region operations resolve through `IMapRegionService` and preserve existing lookup semantics.
+- `IGroundItem.Despawn()` removes the item from the map region determined by its location.
+- Focused tests and the solution build pass.
+
+## Non-Goals and Stop Conditions
+
+- Do not redesign `IMapRegionService` or map-region lifecycle behavior.
+- Do not migrate unrelated service-locator usage or unrelated `Region` properties.
+- Stop and record follow-up work if the change requires a second region owner, a new persistence mechanism, or behavior changes beyond the legacy property removal.

--- a/openspec/changes/remove-entity-region/specs/entity-map-region-access/spec.md
+++ b/openspec/changes/remove-entity-region/specs/entity-map-region-access/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Entity region access uses the map-region service
+
+Consumers needing an entity's map region MUST resolve it through `IMapRegionService` using the entity location. Entity contracts MUST NOT expose a region property as an alternate lookup path.
+
+#### Scenario: Region is resolved from an entity location
+
+- **WHEN** a consumer needs the region for an entity at a location
+- **THEN** it resolves the region through `IMapRegionService` using that location's region ID and dimension
+
+#### Scenario: Entity contract is consumed
+
+- **WHEN** code consumes an `IEntity`, `ICreature`, `IGameObject`, or `IGroundItem`
+- **THEN** no region property is required or available on the entity contract
+
+### Requirement: Existing region operation semantics are preserved
+
+Region add, remove, update, collision, and lookup operations MUST target the same region selected by the legacy entity property for the entity's current location.
+
+#### Scenario: Entity region operation is migrated
+
+- **WHEN** a former entity-region operation is performed
+- **THEN** the operation targets the region returned for the entity's current region ID and dimension with the existing create/resume behavior
+
+### Requirement: Ground-item despawn removes the located item
+
+`IGroundItem.Despawn()` MUST remove the ground item from the map region identified by its location and MUST retain its existing success result and removal behavior.
+
+#### Scenario: Ground item despawns
+
+- **WHEN** `Despawn()` is called for a ground item
+- **THEN** the item is removed from the region identified by its location and the operation returns success

--- a/openspec/changes/remove-entity-region/tasks.md
+++ b/openspec/changes/remove-entity-region/tasks.md
@@ -1,0 +1,18 @@
+## 1. Remove the legacy entity contract
+
+- [x] 1.1 Remove `IEntity.Region` and the concrete `Region` properties from `Creature`, `GameObject`, and `GroundItem`.
+- [x] 1.2 Inject `IMapRegionService` into `GroundItem` through `GroundItemBuilder` and preserve `IGroundItem.Despawn()` and clone behavior.
+
+## 2. Migrate production callers
+
+- [x] 2.1 Replace character-bound `.Region` operations in commands, skills, combat, inventory, thieving, cannon, and mining with `IMapRegionService` lookups.
+- [x] 2.2 Inject `IMapRegionService` into standalone object scripts that operate on their owner and migrate their region operations.
+
+## 3. Update regression coverage
+
+- [x] 3.1 Update test doubles and command tests to configure `IMapRegionService` instead of `IEntity.Region`.
+- [x] 3.2 Add or update ground-item tests covering service-based `Despawn()` removal.
+
+## 4. Validate the migration
+
+- [x] 4.1 Verify no C# production or test caller references the removed entity/concrete `Region` property, then run both focused test projects and the solution build.


### PR DESCRIPTION
## Summary
- Remove the obsolete `IEntity.Region` property
- Update scripts and commands to resolve map regions through `IMapRegionService`
- Adjust affected tests and dependency injection constructors

## Testing
- Not run (not requested)