### PR TITLE
Fix pathfinder step validation for queued movement

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
@@ -106,6 +106,106 @@ public sealed class MovementTests
         Assert.IsTrue(creature.Movement.Moving);
     }
 
+    [TestMethod]
+    public void Tick_WarpMovement_CompletesLongQueuedWaypointInOneTick()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(30, 10, 0);
+        var (creature, _, _) = CreateCreature(start, 1);
+
+        creature.Movement.MovementType = MovementType.Warp;
+        creature.Movement.AddToQueue(target);
+        creature.Movement.Tick();
+
+        Assert.AreEqual(target.X, creature.Location.X);
+        Assert.AreEqual(target.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moved);
+        Assert.IsFalse(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    public void Tick_BlockedWaypoint_ResumesAfterInterveningTileUnblocks()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 10, 0);
+        var (creature, mapRegionService, _) = CreateCreature(start, 1);
+
+        creature.Movement.AddToQueue(target);
+        mapRegionService.GetClippingFlag(11, 10, 0).Returns(CollisionFlag.FloorBlock);
+
+        creature.Movement.Tick();
+
+        Assert.AreEqual(start.X, creature.Location.X);
+        Assert.IsTrue(creature.Movement.Moving);
+
+        mapRegionService.GetClippingFlag(11, 10, 0).Returns(CollisionFlag.Walkable);
+        for (var i = 0; i < 6; i++)
+        {
+            creature.Movement.Tick();
+        }
+
+        Assert.AreEqual(target.X, creature.Location.X);
+        Assert.AreEqual(target.Y, creature.Location.Y);
+        Assert.IsFalse(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void Tick_SizeTwoPlusCreature_AdvancesWithClearClientFootprint(int size)
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 10, 0);
+        var (creature, _, _) = CreateCreature(start, size);
+
+        creature.Movement.AddToQueue(target);
+        creature.Movement.Tick();
+
+        Assert.AreEqual(11, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moved);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    [DataRow(2, -1, 0, -1, 1)]
+    [DataRow(2, 1, 0, 2, 1)]
+    [DataRow(2, 0, -1, 1, -1)]
+    [DataRow(2, 0, 1, 1, 2)]
+    [DataRow(2, -1, -1, 0, -1)]
+    [DataRow(2, 1, -1, 2, -1)]
+    [DataRow(2, -1, 1, 0, 2)]
+    [DataRow(2, 1, 1, 1, 1)]
+    [DataRow(3, -1, 0, -1, 1)]
+    [DataRow(3, 1, 0, 3, 1)]
+    [DataRow(3, 0, -1, 1, -1)]
+    [DataRow(3, 0, 1, 1, 3)]
+    [DataRow(3, -1, -1, 0, -1)]
+    [DataRow(3, 1, -1, 2, -1)]
+    [DataRow(3, -1, 1, 0, 3)]
+    [DataRow(3, 1, 1, 2, 3)]
+    public void Tick_ClientServerParity_StopsAtExpectedIncomingFootprintEdge(
+        int size,
+        int xOffset,
+        int yOffset,
+        int blockedOffsetX,
+        int blockedOffsetY)
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(10 + xOffset, 10 + yOffset, 0);
+        var (creature, mapRegionService, _) = CreateCreature(start, size);
+
+        creature.Movement.AddToQueue(target);
+        mapRegionService.GetClippingFlag(10 + blockedOffsetX, 10 + blockedOffsetY, 0)
+            .Returns(CollisionFlag.FloorBlock);
+
+        creature.Movement.Tick();
+
+        Assert.AreEqual(start.X, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
     private static (TestCreature Creature, IMapRegionService MapRegionService, SmartPathFinder PathFinder) CreateCreature(
         ILocation location,
         int size)

--- a/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
@@ -1,0 +1,181 @@
+using Hagalaz.Game.Abstractions.Features.States.Effects;
+using Hagalaz.Game.Abstractions.Mediator;
+using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.Combat;
+using Hagalaz.Game.Abstractions.Model.Creatures;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
+using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Services.GameWorld.Logic.Pathfinding;
+using Hagalaz.Services.GameWorld.Model.Creatures;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class MovementTests
+{
+    [TestMethod]
+    public void Tick_LongQueuedWaypoint_DoesNotSkipNewlyBlockedTile()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 10, 0);
+        var (creature, mapRegionService, pathFinder) = CreateCreature(start, 1);
+        var path = pathFinder.Find(start, 1, target, 1, 1, 0, 0, 0, false);
+        Assert.IsTrue(path.Successful);
+
+        creature.Movement.AddToQueue(path);
+        mapRegionService.GetClippingFlag(11, 10, 0).Returns(CollisionFlag.FloorBlock);
+
+        creature.Movement.Tick();
+
+        Assert.AreEqual(start.X, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    public void Tick_RunMovement_ValidatesEachAppliedUnit()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 10, 0);
+        var (creature, mapRegionService, pathFinder) = CreateCreature(start, 1);
+        var path = pathFinder.Find(start, 1, target, 1, 1, 0, 0, 0, false);
+        Assert.IsTrue(path.Successful);
+
+        creature.Movement.MovementType = MovementType.Run;
+        creature.Movement.AddToQueue(path);
+        mapRegionService.GetClippingFlag(12, 10, 0).Returns(CollisionFlag.FloorBlock);
+
+        creature.Movement.Tick();
+
+        Assert.AreEqual(11, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    public void Tick_WalkMovement_AdvancesOneTileTowardQueuedWaypoint()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 10, 0);
+        var (creature, _, _) = CreateCreature(start, 1);
+
+        creature.Movement.AddToQueue(target);
+        creature.Movement.Tick();
+
+        Assert.AreEqual(11, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moved);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    public void Tick_RunMovement_AdvancesTwoTilesTowardQueuedWaypoint()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 10, 0);
+        var (creature, _, _) = CreateCreature(start, 1);
+
+        creature.Movement.MovementType = MovementType.Run;
+        creature.Movement.AddToQueue(target);
+        creature.Movement.Tick();
+
+        Assert.AreEqual(12, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moved);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
+    [TestMethod]
+    public void Tick_WalkMovement_AdvancesOneDiagonalTileTowardQueuedWaypoint()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(15, 15, 0);
+        var (creature, _, _) = CreateCreature(start, 1);
+
+        creature.Movement.AddToQueue(target);
+        creature.Movement.Tick();
+
+        Assert.AreEqual(11, creature.Location.X);
+        Assert.AreEqual(11, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moved);
+        Assert.IsTrue(creature.Movement.Moving);
+    }
+
+    private static (TestCreature Creature, IMapRegionService MapRegionService, SmartPathFinder PathFinder) CreateCreature(
+        ILocation location,
+        int size)
+    {
+        var mapRegionService = Substitute.For<IMapRegionService>();
+        mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(CollisionFlag.Walkable);
+        var pathFinder = new SmartPathFinder(mapRegionService);
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var serviceScope = Substitute.For<IServiceScope>();
+        var mediator = Substitute.For<IScopedGameMediator>();
+        var taskService = Substitute.For<ICreatureTaskService>();
+        var areaService = Substitute.For<IAreaService>();
+
+        serviceProvider.GetService(typeof(IScopedGameMediator)).Returns(mediator);
+        serviceProvider.GetService(typeof(ICreatureTaskService)).Returns(taskService);
+        serviceProvider.GetService(typeof(IAreaService)).Returns(areaService);
+        serviceProvider.GetService(typeof(IMapRegionService)).Returns(mapRegionService);
+        serviceProvider.GetService(typeof(ISmartPathFinder)).Returns(pathFinder);
+        serviceScope.ServiceProvider.Returns(serviceProvider);
+
+        var creature = new TestCreature(serviceScope, location, size);
+        creature.InitializeMovement();
+        return (creature, mapRegionService, pathFinder);
+    }
+
+    private sealed class TestCreature : Creature
+    {
+        private readonly int _size;
+
+        public TestCreature(IServiceScope serviceScope, ILocation location, int size)
+            : base(serviceScope)
+        {
+            Location = location;
+            _size = size;
+        }
+
+        public override int Size => _size;
+        public override IPathFinder PathFinder => Substitute.For<IPathFinder>();
+
+        public void InitializeMovement() => Movement = new Movement(this);
+
+        public override bool CanDestroy() => true;
+        public override bool CanSuspend() => true;
+        protected override void OnDestroy() { }
+        public override void OnSpawn() { }
+        public override void OnDeath() { }
+        public override void OnKilledBy(ICreature killer) { }
+        public override void OnTargetKilled(ICreature target) { }
+        public override bool Poison(short amount) => false;
+        public override void Respawn() { }
+        public override void Interrupt(object source) { }
+        public override void MovementTypeChanged(MovementType newtype) { }
+        public override void TemporaryMovementTypeEnabled(MovementType type) { }
+        protected override void ContentTick() { }
+        protected override void UpdatesPrepareTick() { }
+        protected override Task UpdateTick() => Task.CompletedTask;
+        protected override void ResetTick() { }
+        protected override void OnLocationChange(ILocation? oldLocation) { }
+        protected override void OnRegionChange() { }
+        protected override void AddToRegion(IMapRegion newRegion) { }
+        protected override void RemoveFromRegion(IMapRegion region) { }
+        protected override void CreatureFaced(ICreature? creature) { }
+        protected override void TurnedTo(int x, int y) { }
+        protected override void TextSpoken(string text) { }
+        protected override void HitSplatRendered(IHitSplat splat) { }
+        protected override void HitBarRendered(IHitBar bar) { }
+        protected override void NonstandardMovementRendered(IForceMovement movement) { }
+        protected override void GlowRendered(IGlow glow) { }
+        public override bool ShouldBeRenderedFor(ICharacter viewer) => false;
+        public override bool ShouldBeRenderedFor(INpc viewer) => false;
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
@@ -124,6 +124,32 @@ public sealed class MovementTests
     }
 
     [TestMethod]
+    public void Tick_WarpMovement_StopsBeforeBlockedIntermediateTileAndResumesAfterUnblocking()
+    {
+        var start = Location.Create(10, 10, 0);
+        var target = Location.Create(30, 10, 0);
+        var (creature, mapRegionService, _) = CreateCreature(start, 1);
+
+        creature.Movement.MovementType = MovementType.Warp;
+        creature.Movement.AddToQueue(target);
+        mapRegionService.GetClippingFlag(15, 10, 0).Returns(CollisionFlag.FloorBlock);
+
+        creature.Movement.Tick();
+
+        Assert.AreEqual(14, creature.Location.X);
+        Assert.AreEqual(start.Y, creature.Location.Y);
+        Assert.IsTrue(creature.Movement.Moving);
+
+        mapRegionService.GetClippingFlag(15, 10, 0).Returns(CollisionFlag.Walkable);
+
+        creature.Movement.Tick();
+
+        Assert.AreEqual(target.X, creature.Location.X);
+        Assert.AreEqual(target.Y, creature.Location.Y);
+        Assert.IsFalse(creature.Movement.Moving);
+    }
+
+    [TestMethod]
     public void Tick_BlockedWaypoint_ResumesAfterInterveningTileUnblocks()
     {
         var start = Location.Create(10, 10, 0);

--- a/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
@@ -155,4 +155,22 @@ public sealed class PathfinderStepValidationTests
 
         Assert.IsTrue(result);
     }
+
+    [TestMethod]
+    public void CheckStep_DistanceCheck_GreaterThanOne_RejectsBlockedIntermediateUnit()
+    {
+        _mapRegionService.GetClippingFlag(9, 9, 0).Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(Location.Create(10, 10, 0), 2);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void CheckStep_DistanceCheck_GreaterThanOne_WithWalkableUnits_ReturnsTrue()
+    {
+        var result = _pathFinder.CheckStep(Location.Create(10, 10, 0), 2);
+
+        Assert.IsTrue(result);
+    }
 }

--- a/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
@@ -1,0 +1,158 @@
+using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Services.GameWorld.Logic.Pathfinding;
+using NSubstitute;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class PathfinderStepValidationTests
+{
+    private readonly IMapRegionService _mapRegionService;
+    private readonly DumbPathFinder _pathFinder;
+
+    public PathfinderStepValidationTests()
+    {
+        _mapRegionService = Substitute.For<IMapRegionService>();
+        _mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(CollisionFlag.Walkable);
+        _pathFinder = new DumbPathFinder(_mapRegionService);
+    }
+
+    [TestMethod]
+    [DataRow(-1, 0)]
+    [DataRow(1, 0)]
+    [DataRow(0, -1)]
+    [DataRow(0, 1)]
+    [DataRow(-1, -1)]
+    [DataRow(1, -1)]
+    [DataRow(-1, 1)]
+    [DataRow(1, 1)]
+    public void CheckStep_SizeOne_UnitDirectionsRemainWalkable(int xOffset, int yOffset)
+    {
+        var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, 1);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    [DataRow(-1, 0, -1, 0)]
+    [DataRow(1, 0, 2, 0)]
+    [DataRow(0, -1, 0, -1)]
+    [DataRow(0, 1, 0, 2)]
+    [DataRow(-1, -1, -1, -1)]
+    [DataRow(1, -1, 1, -1)]
+    [DataRow(-1, 1, -1, 2)]
+    [DataRow(1, 1, 1, 2)]
+    public void CheckStep_SizeTwo_RejectsBlockedIncomingFootprint(
+        int xOffset,
+        int yOffset,
+        int blockedOffsetX,
+        int blockedOffsetY)
+    {
+        _mapRegionService.GetClippingFlag(10 + blockedOffsetX, 10 + blockedOffsetY, 0)
+            .Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, 2);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(3, -1, 0, -1, 1)]
+    [DataRow(4, -1, 0, -1, 2)]
+    [DataRow(3, 1, 0, 3, 1)]
+    [DataRow(4, 1, 0, 4, 2)]
+    [DataRow(3, 0, -1, 1, -1)]
+    [DataRow(4, 0, -1, 2, -1)]
+    [DataRow(3, 0, 1, 1, 3)]
+    [DataRow(4, 0, 1, 2, 4)]
+    public void CheckStep_VariableSize_RejectsBlockedCardinalInterior(
+        int size,
+        int xOffset,
+        int yOffset,
+        int blockedOffsetX,
+        int blockedOffsetY)
+    {
+        _mapRegionService.GetClippingFlag(10 + blockedOffsetX, 10 + blockedOffsetY, 0)
+            .Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, size);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(3, -1, 0, -1, 0)]
+    [DataRow(4, 1, 0, 4, 0)]
+    [DataRow(3, 0, -1, 0, -1)]
+    [DataRow(4, 0, 1, 0, 4)]
+    public void CheckStep_VariableSize_RejectsBlockedCardinalCorner(
+        int size,
+        int xOffset,
+        int yOffset,
+        int blockedOffsetX,
+        int blockedOffsetY)
+    {
+        _mapRegionService.GetClippingFlag(10 + blockedOffsetX, 10 + blockedOffsetY, 0)
+            .Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, size);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(3, -1, -1, -1, -1)]
+    [DataRow(4, 1, -1, 4, -1)]
+    [DataRow(3, -1, 1, -1, 3)]
+    [DataRow(4, 1, 1, 4, 4)]
+    public void CheckStep_VariableSize_RejectsBlockedDiagonalCorner(
+        int size,
+        int xOffset,
+        int yOffset,
+        int blockedOffsetX,
+        int blockedOffsetY)
+    {
+        _mapRegionService.GetClippingFlag(10 + blockedOffsetX, 10 + blockedOffsetY, 0)
+            .Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, size);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(-2, 0)]
+    [DataRow(2, 0)]
+    [DataRow(0, -2)]
+    [DataRow(0, 2)]
+    [DataRow(-2, -2)]
+    [DataRow(2, 2)]
+    [DataRow(0, 0)]
+    public void CheckStep_UnsupportedOffset_ReturnsFalse(int xOffset, int yOffset)
+    {
+        var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, 1);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void CheckStep_DistanceCheck_UsesUnitSteps()
+    {
+        _mapRegionService.GetClippingFlag(10, 10, 0).Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(Location.Create(10, 10, 0), 1);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void CheckStep_DistanceCheck_WithWalkableUnitSteps_ReturnsTrue()
+    {
+        var result = _pathFinder.CheckStep(Location.Create(10, 10, 0), 1);
+
+        Assert.IsTrue(result);
+    }
+}

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs
@@ -1,4 +1,5 @@
 ﻿using Hagalaz.Game.Abstractions.Model;
+using System;
 using Hagalaz.Game.Abstractions.Model.GameObjects;
 using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
@@ -678,6 +679,11 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
         /// <returns></returns>
         public bool CheckStep(int x, int y, int z, int xOffset, int yOffset, int size)
         {
+            if (xOffset is < -1 or > 1 || yOffset is < -1 or > 1 || (xOffset == 0 && yOffset == 0))
+            {
+                return false;
+            }
+
             var fromX = x - xOffset;
             var fromY = y - yOffset;
             if (size < 2)
@@ -751,7 +757,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                            CheckStep(fromX - 1, fromY - 1, z, CollisionFlag.CheckNorthEast) &&
                            CheckStep(fromX, fromY - 1, z, CollisionFlag.CheckNorthWest | CollisionFlag.CheckNorthEast);
                 }
-                else if (xOffset == 1 && yOffset == 1)
+                else if (xOffset == 1 && yOffset == -1)
                 {
                     return CheckStep(fromX + 1, fromY - 1, z, CollisionFlag.CheckNorthWest | CollisionFlag.CheckNorthEast) &&
                            CheckStep(fromX + 2, fromY - 1, z, CollisionFlag.CheckNorthWest) &&
@@ -760,7 +766,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 else if (xOffset == -1 && yOffset == 1)
                 {
                     return CheckStep(fromX - 1, fromY + 1, z, CollisionFlag.CheckNorthEast | CollisionFlag.CheckSouthEast) &&
-                           CheckStep(fromX - 1, fromY + 1, z, CollisionFlag.CheckSouthEast) &&
+                           CheckStep(fromX - 1, fromY + 2, z, CollisionFlag.CheckSouthEast) &&
                            CheckStep(fromX, fromY + 2, z, CollisionFlag.CheckSouthEast | CollisionFlag.CheckSouthWest);
                 }
                 else if (xOffset == 1 && yOffset == 1)
@@ -780,7 +786,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                         return false;
                     }
 
-                    for (var sizeOffset = 1; sizeOffset > size - 1; sizeOffset++)
+                    for (var sizeOffset = 1; sizeOffset < size - 1; sizeOffset++)
                     {
                         if (!CheckStep(fromX - 1, fromY + sizeOffset, z, CollisionFlag.CheckEastVariable))
                         {
@@ -796,7 +802,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                         return false;
                     }
 
-                    for (var sizeOffset = 1; sizeOffset > size - 1; sizeOffset++)
+                    for (var sizeOffset = 1; sizeOffset < size - 1; sizeOffset++)
                     {
                         if (!CheckStep(fromX + size, fromY + sizeOffset, z, CollisionFlag.CheckWestVariable))
                         {
@@ -812,7 +818,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                         return false;
                     }
 
-                    for (var sizeOffset = 1; sizeOffset > size - 1; sizeOffset++)
+                    for (var sizeOffset = 1; sizeOffset < size - 1; sizeOffset++)
                     {
                         if (!CheckStep(fromX + sizeOffset, fromY - 1, z, CollisionFlag.CheckNorthVariable))
                         {
@@ -828,7 +834,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                         return false;
                     }
 
-                    for (var sizeOffset = 1; sizeOffset > size - 1; sizeOffset++)
+                    for (var sizeOffset = 1; sizeOffset < size - 1; sizeOffset++)
                     {
                         if (!CheckStep(fromX + sizeOffset, fromY + size, z, CollisionFlag.CheckSouthVariable))
                         {
@@ -923,20 +929,46 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
         /// <returns></returns>
         public bool CheckStep(IVector3 location, int checkDistance)
         {
+            if (checkDistance <= 0)
+            {
+                return false;
+            }
+
             var previousCheck = location.ToLocation();
             for (var xDelta = -checkDistance; xDelta <= checkDistance; xDelta++)
             {
                 for (var yDelta = -checkDistance; yDelta <= checkDistance; yDelta++)
                 {
                     var check = location.ToLocation() + Location.Create(xDelta, yDelta, 0);
-                    var delta = previousCheck - check;
-                    if (!CheckStep(check, delta.X, delta.Y, 1))
+                    if (!CheckUnitPath(previousCheck, check, 1))
                     {
                         return false;
                     }
 
                     previousCheck = check;
                 }
+            }
+
+            return true;
+        }
+
+        private bool CheckUnitPath(IVector3 from, IVector3 to, int size)
+        {
+            var currentX = from.X;
+            var currentY = from.Y;
+            while (currentX != to.X || currentY != to.Y)
+            {
+                var xOffset = Math.Sign(to.X - currentX);
+                var yOffset = Math.Sign(to.Y - currentY);
+                var nextX = currentX + xOffset;
+                var nextY = currentY + yOffset;
+                if (!CheckStep(nextX, nextY, to.Z, xOffset, yOffset, size))
+                {
+                    return false;
+                }
+
+                currentX = nextX;
+                currentY = nextY;
             }
 
             return true;

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Movement.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Movement.cs
@@ -319,26 +319,15 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
                         continue;
                     }
 
-                    var max = Math.Max(Math.Abs(delta.X), Math.Abs(delta.Y));
-                    var deltaX = delta.X;
-                    var deltaY = delta.Y;
+                    var stepX = Math.Sign(delta.X);
+                    var stepY = Math.Sign(delta.Y);
 
-                    for (var i = 0; i < max; i++)
-                    {
-                        if ((deltaX != 0 || deltaY != 0) && maxMove-- <= 0) break;
-                        if (deltaX < 0)
-                            deltaX++;
-                        else if (deltaX > 0) deltaX--;
-                        if (deltaY < 0)
-                            deltaY++;
-                        else if (deltaY > 0) deltaY--;
-                    }
-
-                    var newLocation = Location.Create(peek.X - deltaX, peek.Y - deltaY, finalLocation.Z, finalLocation.Dimension);
-                    // TODO - Correct most x, y coordinates for size >= 2
-                    if (!_pathFinder.CheckStep(newLocation.X, newLocation.Y, newLocation.Z, delta.X, delta.Y, _owner.Size) || newLocation.Equals(finalLocation))
+                    var newLocation = Location.Create(finalLocation.X + stepX, finalLocation.Y + stepY, finalLocation.Z, finalLocation.Dimension);
+                    if (!_pathFinder.CheckStep(newLocation.X, newLocation.Y, newLocation.Z, stepX, stepY, _owner.Size))
                         break; // we didn't move
+
                     finalLocation = newLocation;
+                    maxMove--;
                 }
 
                 if (!finalLocation.Equals(_owner.Location))

--- a/openspec/changes/fix-pathfinder-step-validation/.openspec.yaml
+++ b/openspec/changes/fix-pathfinder-step-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/fix-pathfinder-step-validation/design.md
+++ b/openspec/changes/fix-pathfinder-step-validation/design.md
@@ -1,0 +1,58 @@
+## Context
+
+`PathFinderBase.CheckStep` is the shared collision validator used by the simple, smart, and projectile pathfinders, while `Movement.Tick` is the runtime consumer that applies queued movement. The validator accepts only unit directional offsets, but the current implementation has incorrect size-2 coordinates, non-executing size-3+ cardinal loops, and a fail-open fallback. `SmartPathFinder` compresses straight route segments into waypoints, so `Movement.Tick` can receive a multi-tile delta even though it applies only one or two movement units per tick.
+
+The client variable-size routefinder in `Class527.java` is the geometry reference. Existing `CollisionFlag` values and `IMapRegionService` remain the collision source of truth.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make shared footprint checks correct for size 1, size 2, and size 3+ creatures.
+- Ensure every public scalar step check either validates a supported unit direction or returns false.
+- Ensure distance checks and runtime movement never pass multi-tile offsets to the scalar validator.
+- Preserve movement queue ownership and stop at the last valid tile when a queued route becomes blocked.
+
+**Non-Goals:**
+
+- Replacing BFS, route compression, collision storage, or movement queues.
+- Changing collision flag definitions or unrelated pathfinding interactions.
+- Adding a generic movement/retry framework or changing public method signatures.
+
+## Decisions
+
+### Use `PathFinderBase` as the single footprint-validation owner
+
+All size-specific geometry remains in the existing shared validator. The size-2 southeast condition is corrected, the northwest exposed coordinate is made distinct, and the four size-3+ cardinal loops use the client bound `sizeOffset < size - 1`. Existing diagonal formulas are retained and covered by regression tests against the client geometry.
+
+Changing individual pathfinder consumers would duplicate collision rules and would leave other callers exposed. Rewriting the pathfinder is unnecessary for these localized geometry defects.
+
+### Fail closed for unsupported scalar offsets
+
+The scalar `CheckStep` overload returns false for offsets outside the eight unit directions, including a zero/no-op offset. Callers that encounter a no-op handle it before validation. Returning true would preserve the current fail-open vulnerability; throwing would turn recoverable stale-route movement into an exception.
+
+The distance-based overload advances between sampled locations one unit at a time and delegates each unit to the scalar validator. This preserves its existing collision-flag ownership while preventing its row and diagonal transitions from bypassing validation.
+
+### Validate each movement unit in `Movement.Tick`
+
+`Movement` computes the next one-tile location toward the queued waypoint, calls `CheckStep` with that unit delta, and commits the location only when validation succeeds. It repeats until the existing movement budget is exhausted, the waypoint is reached, or a step is blocked. A blocked step leaves the queued waypoint in place and preserves the last valid `finalLocation`.
+
+Passing the original compressed delta is rejected because it cannot describe the movement actually being applied. Clamping the delta before one final check is also rejected because it could skip a blocked intermediate tile when run or warp movement applies multiple units.
+
+### Tests use existing MSTest and substitution seams
+
+Pathfinder regressions use the existing `IMapRegionService` substitution with `CollisionFlag.Walkable` as the default and `FloorBlock` at targeted footprint coordinates. Movement tests use a minimal `Creature` test double and the existing `ISmartPathFinder`/service-provider seam, covering valid walk, run, and diagonal waypoint movement alongside a waypoint longer than one tile whose collision appears before application.
+
+## Risks / Trade-offs
+
+- [Risk] Unit-by-unit validation adds collision checks for run and warp movement. → Mitigation: retain the existing movement budget and use the already-authoritative in-process map service; focused tests cover the bounded behavior.
+- [Risk] Existing callers may have relied on the scalar fall-through returning true. → Mitigation: search all callers, update the distance-based internal caller, and add explicit unsupported-offset regression coverage.
+- [Risk] Client and server coordinate conventions could diverge. → Mitigation: preserve existing flag formulas, compare corrected coordinates with `Class527.java`, and cover every size-2 direction plus representative variable-size diagonals.
+
+## Migration Plan
+
+No data or deployment migration is required. Deploy the code and tests together. Rollback is a normal application version rollback because no persisted state or wire contract changes.
+
+## Open Questions
+
+None. The issue acceptance criteria and existing runtime topology define the required behavior.

--- a/openspec/changes/fix-pathfinder-step-validation/design.md
+++ b/openspec/changes/fix-pathfinder-step-validation/design.md
@@ -41,7 +41,7 @@ Passing the original compressed delta is rejected because it cannot describe the
 
 ### Tests use existing MSTest and substitution seams
 
-Pathfinder regressions use the existing `IMapRegionService` substitution with `CollisionFlag.Walkable` as the default and `FloorBlock` at targeted footprint coordinates. Movement tests use a minimal `Creature` test double and the existing `ISmartPathFinder`/service-provider seam, covering valid walk, run, and diagonal waypoint movement alongside a waypoint longer than one tile whose collision appears before application.
+Pathfinder regressions use the existing `IMapRegionService` substitution with `CollisionFlag.Walkable` as the default and `FloorBlock` at targeted footprint coordinates. Movement tests use a minimal `Creature` test double and the existing `ISmartPathFinder`/service-provider seam, covering valid walk, run, diagonal, and warp waypoint movement, unblock-and-resume behavior, and size-2/size-3 runtime cases. Client/server parity cases use actual server `SmartPathFinder` plus `Movement.Tick` and the exposed-edge coordinates from the client `Class527.java` geometry reference.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-pathfinder-step-validation/proposal.md
+++ b/openspec/changes/fix-pathfinder-step-validation/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`PathFinderBase.CheckStep` can accept blocked movement for size-2 and size-3+ creatures because of incorrect size-2 branches, skipped variable-size edge loops, and a fail-open fallback for unsupported offsets. `Movement.Tick` passes compressed waypoint deltas to this unit-step validator, so a collision introduced after path calculation can be skipped during actual movement.
+
+## What Changes
+
+- Correct all size-2 directional footprint checks, including southeast and northwest.
+- Execute interior edge validation for size-3+ cardinal movement using the client routefinder bounds.
+- Make unsupported and zero offsets fail closed, and make distance-based checks compose unit-step validation.
+- Make `Movement.Tick` validate each one-tile step it applies toward a compressed waypoint, stopping before blocked movement and retaining the waypoint.
+- Add focused MSTest regressions for size 1, size 2, variable-size geometry, unsupported offsets, distance checks, and long waypoint movement.
+
+### Non-goals
+
+- Do not replace or redesign the existing pathfinding algorithms.
+- Do not add a new collision store, movement queue, worker, or abstraction framework.
+- Do not change unrelated movement, teleport, region, or path compression behavior.
+
+### Acceptance Criteria
+
+- All eight size-2 directions validate the newly occupied footprint.
+- Size-3 and size-4 cardinal checks inspect corner and interior edge tiles.
+- Unsupported or zero offsets cannot return collision-free through fall-through behavior.
+- Compressed waypoint movement revalidates every applied unit step.
+- Existing size-1 directional behavior remains compatible.
+- Focused GameWorld tests and the solution build pass.
+
+### Stop Conditions
+
+Pause and record follow-up work if the fix requires changing pathfinding architecture, collision flag definitions, or unrelated movement consumers.
+
+## Capabilities
+
+### New Capabilities
+
+- `pathfinder-step-validation`: Shared unit-step collision validation for creature footprints and movement revalidation.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs`
+- `Hagalaz.Services.GameWorld/Model/Creatures/Movement.cs`
+- `Hagalaz.Services.GameWorld.Tests`
+- No new dependencies or public API signatures.

--- a/openspec/changes/fix-pathfinder-step-validation/specs/pathfinder-step-validation/spec.md
+++ b/openspec/changes/fix-pathfinder-step-validation/specs/pathfinder-step-validation/spec.md
@@ -72,6 +72,10 @@ The distance-based shared check MUST validate the path between sampled locations
 - **WHEN** warp movement has a long walkable queued waypoint
 - **THEN** the creature reaches the waypoint in one tick without leaving it queued
 
+#### Scenario: Warp movement stops at a blocked intermediate tile
+- **WHEN** warp movement has a long queued waypoint and an intermediate tile is blocked
+- **THEN** movement stops at the last valid tile, retains the waypoint, and resumes after the tile becomes walkable
+
 #### Scenario: A blocked waypoint resumes after unblocking
 - **WHEN** a queued waypoint is blocked, then the intervening tile becomes walkable
 - **THEN** later ticks resume movement and eventually consume the waypoint

--- a/openspec/changes/fix-pathfinder-step-validation/specs/pathfinder-step-validation/spec.md
+++ b/openspec/changes/fix-pathfinder-step-validation/specs/pathfinder-step-validation/spec.md
@@ -44,12 +44,12 @@ The shared scalar step validator MUST return false for zero offsets and any offs
 
 The distance-based shared check MUST validate the path between sampled locations through unit steps and MUST NOT pass unsupported offsets to the scalar validator.
 
-#### Scenario: Distance check crosses a blocked unit step
-- **WHEN** a distance-based check traverses a unit step whose collision is blocked
+#### Scenario: Distance check greater than one crosses a blocked unit step
+- **WHEN** a distance-based check greater than one traverses a unit step whose collision is blocked
 - **THEN** the distance check returns false
 
-#### Scenario: Distance check has walkable unit steps
-- **WHEN** every unit step in the checked distance is walkable
+#### Scenario: Distance check greater than one has walkable unit steps
+- **WHEN** every unit step in a distance greater than one is walkable
 - **THEN** the distance check returns true
 
 ### Requirement: Runtime movement revalidates compressed waypoints
@@ -67,3 +67,15 @@ The distance-based shared check MUST validate the path between sampled locations
 #### Scenario: Existing valid waypoint movement is preserved
 - **WHEN** a walk, run, or diagonal movement has a walkable queued waypoint
 - **THEN** movement advances by the existing one-tile or two-tile budget without losing the queued waypoint
+
+#### Scenario: Warp movement consumes its available budget
+- **WHEN** warp movement has a long walkable queued waypoint
+- **THEN** the creature reaches the waypoint in one tick without leaving it queued
+
+#### Scenario: A blocked waypoint resumes after unblocking
+- **WHEN** a queued waypoint is blocked, then the intervening tile becomes walkable
+- **THEN** later ticks resume movement and eventually consume the waypoint
+
+#### Scenario: Variable-size runtime movement uses client footprint edges
+- **WHEN** a size-2 or size-3 creature moves east and the client-defined incoming footprint edge is blocked
+- **THEN** the actual server `Movement.Tick` path stops before the step

--- a/openspec/changes/fix-pathfinder-step-validation/specs/pathfinder-step-validation/spec.md
+++ b/openspec/changes/fix-pathfinder-step-validation/specs/pathfinder-step-validation/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Creature footprint steps are collision validated
+
+The shared step validator MUST validate every newly occupied footprint edge and corner for size-1, size-2, and size-3-or-larger creatures using the existing collision flags.
+
+#### Scenario: Size-2 movement in every direction
+- **WHEN** a size-2 creature attempts any of the eight unit directions
+- **THEN** every newly occupied footprint tile required by that direction is checked and a blocked tile makes the step fail
+
+#### Scenario: Size-2 southeast movement
+- **WHEN** a size-2 creature moves southeast and a newly occupied southeast footprint tile is blocked
+- **THEN** the step is rejected rather than accepted by an unmatched-direction fallback
+
+#### Scenario: Size-2 northwest movement
+- **WHEN** a size-2 creature moves northwest and only the distinct upper exposed edge tile is blocked
+- **THEN** the step is rejected
+
+#### Scenario: Variable-size cardinal movement
+- **WHEN** a size-3 or size-4 creature moves cardinally and an interior tile of the incoming edge is blocked
+- **THEN** the step is rejected for each cardinal direction
+
+#### Scenario: Variable-size diagonal movement
+- **WHEN** a size-3 or larger creature moves diagonally and an incoming edge or corner tile is blocked
+- **THEN** the step is rejected using the same footprint geometry as the client routefinder
+
+### Requirement: Unsupported step offsets fail closed
+
+The shared scalar step validator MUST return false for zero offsets and any offset whose absolute X or Y component is greater than one. Supported unit directions MUST retain their existing size-1 behavior.
+
+#### Scenario: Non-unit offset is supplied
+- **WHEN** a caller supplies a multi-tile X, Y, or diagonal offset
+- **THEN** the validator returns false without treating the movement as collision-free
+
+#### Scenario: Zero offset is supplied
+- **WHEN** a caller supplies no movement offset
+- **THEN** the validator returns false
+
+#### Scenario: Existing size-1 unit movement is supplied
+- **WHEN** a size-1 creature supplies any supported unit direction
+- **THEN** the validator uses the existing directional collision rules
+
+### Requirement: Distance checks use unit validation
+
+The distance-based shared check MUST validate the path between sampled locations through unit steps and MUST NOT pass unsupported offsets to the scalar validator.
+
+#### Scenario: Distance check crosses a blocked unit step
+- **WHEN** a distance-based check traverses a unit step whose collision is blocked
+- **THEN** the distance check returns false
+
+#### Scenario: Distance check has walkable unit steps
+- **WHEN** every unit step in the checked distance is walkable
+- **THEN** the distance check returns true
+
+### Requirement: Runtime movement revalidates compressed waypoints
+
+`Movement.Tick` MUST validate each one-tile movement it applies toward a queued waypoint, stop before the first blocked step, and retain the queued waypoint when movement stops.
+
+#### Scenario: Collision appears on a long queued waypoint
+- **WHEN** a waypoint more than one tile away was queued and an intervening tile becomes blocked before `Tick`
+- **THEN** movement does not skip the blocked tile and the creature remains at the last valid location
+
+#### Scenario: Multiple valid movement units are available
+- **WHEN** run or warp movement has multiple movement units available toward a compressed waypoint
+- **THEN** each applied unit is independently validated before the location is committed
+
+#### Scenario: Existing valid waypoint movement is preserved
+- **WHEN** a walk, run, or diagonal movement has a walkable queued waypoint
+- **THEN** movement advances by the existing one-tile or two-tile budget without losing the queued waypoint

--- a/openspec/changes/fix-pathfinder-step-validation/tasks.md
+++ b/openspec/changes/fix-pathfinder-step-validation/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add shared-validator tests for size-1 compatibility and all eight size-2 directions, including explicit southeast and distinct northwest exposed-cell cases.
 - [x] 1.2 Add size-3 and size-4 cardinal corner/interior-edge tests plus representative diagonal footprint tests using targeted collision flags.
 - [x] 1.3 Add unsupported/zero-offset and distance-based unit-validation tests, including distances greater than one.
-- [x] 1.4 Add `Movement.Tick` coverage for existing valid walk/run/diagonal/warp waypoint behavior, unblock-and-resume handling, a long queued waypoint with a newly blocked intervening tile, multiple independently validated movement units, and size-2/size-3 client parity cases.
+- [x] 1.4 Add `Movement.Tick` coverage for existing valid walk/run/diagonal/warp waypoint behavior, blocked-warp stop/resume handling, unblock-and-resume handling, a long queued waypoint with a newly blocked intervening tile, multiple independently validated movement units, and size-2/size-3 client parity cases.
 
 ## 2. Shared Validation Fix
 

--- a/openspec/changes/fix-pathfinder-step-validation/tasks.md
+++ b/openspec/changes/fix-pathfinder-step-validation/tasks.md
@@ -2,8 +2,8 @@
 
 - [x] 1.1 Add shared-validator tests for size-1 compatibility and all eight size-2 directions, including explicit southeast and distinct northwest exposed-cell cases.
 - [x] 1.2 Add size-3 and size-4 cardinal corner/interior-edge tests plus representative diagonal footprint tests using targeted collision flags.
-- [x] 1.3 Add unsupported/zero-offset and distance-based unit-validation tests.
-- [x] 1.4 Add `Movement.Tick` coverage for existing valid walk/run/diagonal waypoint behavior, a long queued waypoint with a newly blocked intervening tile, and multiple independently validated movement units.
+- [x] 1.3 Add unsupported/zero-offset and distance-based unit-validation tests, including distances greater than one.
+- [x] 1.4 Add `Movement.Tick` coverage for existing valid walk/run/diagonal/warp waypoint behavior, unblock-and-resume handling, a long queued waypoint with a newly blocked intervening tile, multiple independently validated movement units, and size-2/size-3 client parity cases.
 
 ## 2. Shared Validation Fix
 

--- a/openspec/changes/fix-pathfinder-step-validation/tasks.md
+++ b/openspec/changes/fix-pathfinder-step-validation/tasks.md
@@ -1,0 +1,21 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add shared-validator tests for size-1 compatibility and all eight size-2 directions, including explicit southeast and distinct northwest exposed-cell cases.
+- [x] 1.2 Add size-3 and size-4 cardinal corner/interior-edge tests plus representative diagonal footprint tests using targeted collision flags.
+- [x] 1.3 Add unsupported/zero-offset and distance-based unit-validation tests.
+- [x] 1.4 Add `Movement.Tick` coverage for existing valid walk/run/diagonal waypoint behavior, a long queued waypoint with a newly blocked intervening tile, and multiple independently validated movement units.
+
+## 2. Shared Validation Fix
+
+- [x] 2.1 Correct size-2 southeast and northwest footprint coordinates while preserving existing collision-flag conventions.
+- [x] 2.2 Fix all size-3+ cardinal interior loop bounds to validate offsets from 1 through `size - 2`.
+- [x] 2.3 Make unsupported scalar offsets fail closed and implement distance checks through unit-step validation.
+
+## 3. Runtime Movement Fix
+
+- [x] 3.1 Change `Movement.Tick` to compute, validate, and commit one-tile candidates within the existing movement budget, retaining blocked waypoints.
+
+## 4. Verification
+
+- [x] 4.1 Run focused GameWorld tests and resolve any regressions.
+- [x] 4.2 Run the solution build, strict OpenSpec validation, and `git diff --check`.


### PR DESCRIPTION
## Summary

- Correct size-2 and variable-size creature footprint checks
- Reject unsupported and zero movement offsets
- Validate each unit step when applying compressed waypoints
- Add MSTest regressions for pathfinding geometry and walk/run movement

## Testing

- Added focused MSTest coverage for step validation and movement behavior
- Not run (not requested)

fixes #365 