### PR TITLE
Correct north-east pathfinder collision geometry

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/MovementTests.cs
@@ -201,7 +201,7 @@ public sealed class MovementTests
     [DataRow(2, -1, -1, 0, -1)]
     [DataRow(2, 1, -1, 2, -1)]
     [DataRow(2, -1, 1, 0, 2)]
-    [DataRow(2, 1, 1, 1, 1)]
+    [DataRow(2, 1, 1, 2, 1)]
     [DataRow(3, -1, 0, -1, 1)]
     [DataRow(3, 1, 0, 3, 1)]
     [DataRow(3, 0, -1, 1, -1)]

--- a/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
@@ -45,6 +45,7 @@ public sealed class PathfinderStepValidationTests
     [DataRow(1, -1, 1, -1)]
     [DataRow(-1, 1, -1, 2)]
     [DataRow(1, 1, 1, 2)]
+    [DataRow(1, 1, 2, 1)]
     public void CheckStep_SizeTwo_RejectsBlockedIncomingFootprint(
         int xOffset,
         int yOffset,
@@ -119,6 +120,32 @@ public sealed class PathfinderStepValidationTests
             .Returns(CollisionFlag.FloorBlock);
 
         var result = _pathFinder.CheckStep(10 + xOffset, 10 + yOffset, 0, xOffset, yOffset, size);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(3)]
+    [DataRow(4)]
+    public void CheckStep_VariableSize_NorthEast_UsesSouthVariableForTopEdge(int size)
+    {
+        _mapRegionService.GetClippingFlag(11, 10 + size, 0)
+            .Returns(CollisionFlag.WallSouthEast);
+
+        var result = _pathFinder.CheckStep(11, 11, 0, 1, 1, size);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(3)]
+    [DataRow(4)]
+    public void CheckStep_VariableSize_NorthEast_UsesWestVariableForRightEdge(int size)
+    {
+        _mapRegionService.GetClippingFlag(10 + size, 11, 0)
+            .Returns(CollisionFlag.WallNorthEast);
+
+        var result = _pathFinder.CheckStep(11, 11, 0, 1, 1, size);
 
         Assert.IsFalse(result);
     }

--- a/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs
@@ -125,6 +125,17 @@ public sealed class PathfinderStepValidationTests
     }
 
     [TestMethod]
+    public void CheckStep_SizeTwo_NorthEast_IgnoresBlockedOverlappingTile()
+    {
+        _mapRegionService.GetClippingFlag(11, 11, 0)
+            .Returns(CollisionFlag.FloorBlock);
+
+        var result = _pathFinder.CheckStep(11, 11, 0, 1, 1, 2);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
     [DataRow(3)]
     [DataRow(4)]
     public void CheckStep_VariableSize_NorthEast_UsesSouthVariableForTopEdge(int size)

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs
@@ -773,7 +773,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 {
                     return CheckStep(fromX + 1, fromY + 2, z, CollisionFlag.CheckSouthEast | CollisionFlag.CheckSouthWest) &&
                            CheckStep(fromX + 2, fromY + 2, z, CollisionFlag.CheckSouthWest) &&
-                           CheckStep(fromX + 1, fromY + 1, z, CollisionFlag.CheckNorthWest | CollisionFlag.CheckSouthWest);
+                           CheckStep(fromX + 2, fromY + 1, z, CollisionFlag.CheckNorthWest | CollisionFlag.CheckSouthWest);
                 }
             }
             else
@@ -899,8 +899,8 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
 
                     for (var sizeOffset = 1; sizeOffset < size; sizeOffset++)
                     {
-                        if (!CheckStep(fromX + sizeOffset, fromY + size, z, CollisionFlag.CheckWestVariable) ||
-                            !CheckStep(fromX + size, fromY + sizeOffset, z, CollisionFlag.CheckSouthVariable))
+                        if (!CheckStep(fromX + sizeOffset, fromY + size, z, CollisionFlag.CheckSouthVariable) ||
+                            !CheckStep(fromX + size, fromY + sizeOffset, z, CollisionFlag.CheckWestVariable))
                         {
                             return false;
                         }

--- a/openspec/changes/fix-pathfinder-ne-geometry/.openspec.yaml
+++ b/openspec/changes/fix-pathfinder-ne-geometry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/fix-pathfinder-ne-geometry/design.md
+++ b/openspec/changes/fix-pathfinder-ne-geometry/design.md
@@ -1,0 +1,25 @@
+## Context
+
+`PathfinderBase.CheckStep` is the existing owner of creature-footprint collision validation. For a north-east unit step, a size-2 creature exposes two top-edge cells and the new right-side cell; the client reference uses `(fromX + 2, fromY + 1)` for that final cell. For size greater than two, the client geometry checks the incoming top edge with the south-facing variable composite and the incoming right edge with the west-facing variable composite.
+
+The existing `CollisionFlag` composites are the authoritative directional masks. `WallSouthEast` is present in `CheckSouthVariable` but not `CheckWestVariable`; `WallNorthEast` is present in `CheckWestVariable` but not `CheckSouthVariable`. These bits provide focused tests for the mapping without introducing new flags or relying on shared `FloorBlock` bits.
+
+## Decisions
+
+### Keep `PathfinderBase` as the single validation owner
+
+The two coordinate/mask corrections stay in the existing shared validator. Changing `Movement` or individual pathfinder consumers would duplicate the footprint rules and would not protect other callers of `CheckStep`.
+
+### Use client footprint geometry as the reference
+
+The size-2 north-east checks remain three exposed cells, with only the third coordinate corrected. The variable-size north-east loop retains its current coordinates and bounds while swapping only the two directional composites to match the top/right edge orientation.
+
+### Test directional masks with exclusive bits
+
+The regression suite will use `WallSouthEast` on an incoming top-edge cell and `WallNorthEast` on an incoming right-edge cell for sizes 3 and 4. Each bit is exclusive to the expected composite, so a swapped mask fails the test rather than being hidden by a common floor bit.
+
+## Rejected Alternatives
+
+- Refactoring all diagonal branches: unnecessary for two localized errors and increases regression risk.
+- Adding special-case checks in `Movement`: the root behavior belongs to the shared validator and would leave pathfinding callers inconsistent.
+- Using `FloorBlock` for mask tests: it is included in every directional composite and cannot distinguish the required mapping.

--- a/openspec/changes/fix-pathfinder-ne-geometry/proposal.md
+++ b/openspec/changes/fix-pathfinder-ne-geometry/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+PR #380 corrected most of issue #365, but the shared `PathfinderBase.CheckStep` still has two north-east geometry errors. The size-2 branch checks an overlapping tile instead of the newly occupied east edge, and the size-3+ north-east branch applies the top and right edge masks in reverse. Existing tests do not catch the mask swap because they mostly use `FloorBlock`, which belongs to both directional composites.
+
+## What Changes
+
+- Correct the size-2 north-east third footprint coordinate to `(fromX + 2, fromY + 1)`.
+- Correct the variable-size north-east top edge to use `CheckSouthVariable` and the right edge to use `CheckWestVariable`.
+- Update the client-parity movement row to block the actual size-2 north-east incoming east-edge tile.
+- Add directional-bit regressions that distinguish the two variable-size composites without relying on `FloorBlock`.
+
+### Non-goals
+
+- Do not revert or redesign PR #380's unit-step movement validation.
+- Do not change size-1 behavior, other directions, collision flag definitions, path compression, or movement ownership.
+- Do not add a new collision abstraction, pathfinding algorithm, or runtime workaround.
+
+### Acceptance Criteria
+
+- A size-2 north-east step is rejected when `(fromX + 2, fromY + 1)` is blocked, and does not depend on `(fromX + 1, fromY + 1)`.
+- Size-2 client-parity coverage blocks `(fromX + 2, fromY + 1)` for north-east movement.
+- A size-3 or size-4 north-east step rejects a top-edge `WallSouthEast` bit through `CheckSouthVariable`.
+- A size-3 or size-4 north-east step rejects a right-edge `WallNorthEast` bit through `CheckWestVariable`.
+- Existing focused GameWorld tests and the solution build remain passing.
+
+### Stop Conditions
+
+Pause and record follow-up work if the correction requires changing collision flag definitions, movement consumers, pathfinding algorithms, or unrelated directional branches.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs`
+- `Hagalaz.Services.GameWorld.Tests/PathfinderStepValidationTests.cs`
+- `Hagalaz.Services.GameWorld.Tests/MovementTests.cs`
+- No new dependencies, public APIs, or persisted data.

--- a/openspec/changes/fix-pathfinder-ne-geometry/specs/pathfinder-step-validation/spec.md
+++ b/openspec/changes/fix-pathfinder-ne-geometry/specs/pathfinder-step-validation/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: North-east footprint validation matches client geometry
+
+The shared step validator MUST validate the newly occupied north-east footprint using the client coordinate and directional-mask geometry for size-2 and size-3-or-larger creatures.
+
+#### Scenario: Size-2 north-east checks the new east-side tile
+- **GIVEN** a size-2 creature at `(fromX, fromY)`
+- **WHEN** it moves one tile north-east and `(fromX + 2, fromY + 1)` is blocked
+- **THEN** the step is rejected
+- **AND** an overlapping tile at `(fromX + 1, fromY + 1)` is not used as a substitute for that incoming east edge
+
+#### Scenario: Variable-size north-east checks the top edge with the south mask
+- **GIVEN** a size-3 or size-4 creature moving north-east
+- **WHEN** an incoming top-edge tile contains `WallSouthEast`
+- **THEN** the step is rejected by the `CheckSouthVariable` composite
+
+#### Scenario: Variable-size north-east checks the right edge with the west mask
+- **GIVEN** a size-3 or size-4 creature moving north-east
+- **WHEN** an incoming right-edge tile contains `WallNorthEast`
+- **THEN** the step is rejected by the `CheckWestVariable` composite

--- a/openspec/changes/fix-pathfinder-ne-geometry/tasks.md
+++ b/openspec/changes/fix-pathfinder-ne-geometry/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Add a size-2 north-east validator regression that blocks `(fromX + 2, fromY + 1)`.
 - [x] 1.2 Correct the movement client-parity north-east row to block `(fromX + 2, fromY + 1)`.
 - [x] 1.3 Add size-3 and size-4 north-east top/right edge tests using `WallSouthEast` and `WallNorthEast` directional bits.
+- [x] 1.4 Add a positive size-2 north-east regression proving a blocked overlapping tile does not reject a clear incoming edge.
 
 ## 2. North-east Validation Fix
 

--- a/openspec/changes/fix-pathfinder-ne-geometry/tasks.md
+++ b/openspec/changes/fix-pathfinder-ne-geometry/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a size-2 north-east validator regression that blocks `(fromX + 2, fromY + 1)`.
+- [x] 1.2 Correct the movement client-parity north-east row to block `(fromX + 2, fromY + 1)`.
+- [x] 1.3 Add size-3 and size-4 north-east top/right edge tests using `WallSouthEast` and `WallNorthEast` directional bits.
+
+## 2. North-east Validation Fix
+
+- [x] 2.1 Change the size-2 north-east third coordinate to `(fromX + 2, fromY + 1)`.
+- [x] 2.2 Map the variable-size north-east top edge to `CheckSouthVariable` and right edge to `CheckWestVariable`.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused GameWorld tests and confirm the new regressions fail before the production correction and pass afterward.
+- [x] 3.2 Run the solution build, strict OpenSpec validation, and `git diff --check`.


### PR DESCRIPTION
## Summary

- Correct size-2 north-east footprint coordinates.
- Apply the correct directional masks to variable-size north-east edges.
- Add focused regressions for size-2, size-3, and size-4 movement.

## Testing

- Focused GameWorld unit tests passed.
- Solution build passed.
- Strict OpenSpec validation and `git diff --check` passed.

fixes #365 