### PR TITLE
Correct wall collision direction flags and add regressions

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/CollisionMethodsTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CollisionMethodsTests.cs
@@ -1,0 +1,503 @@
+using AutoMapper;
+using Hagalaz.Game.Abstractions.Builders.GameObject;
+using Hagalaz.Game.Abstractions.Builders.GroundItem;
+using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.GameObjects;
+using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Services.GameWorld.Model.Maps.Regions;
+using NSubstitute;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class CollisionMethodsTests
+{
+    private const int OriginX = 10;
+    private const int OriginY = 10;
+    private const int Plane = 0;
+    private const int Dimension = 0;
+    private const CollisionFlag UnrelatedFlag = CollisionFlag.FloorBlock;
+
+    private const CollisionFlag WallLayerMask =
+        CollisionFlag.WallNorthWest | CollisionFlag.WallNorth | CollisionFlag.WallNorthEast | CollisionFlag.WallEast |
+        CollisionFlag.WallSouthEast | CollisionFlag.WallSouth | CollisionFlag.WallSouthWest | CollisionFlag.WallWest;
+
+    private const CollisionFlag BlockedLayerMask =
+        CollisionFlag.BlockedNorthWest | CollisionFlag.BlockedNorth | CollisionFlag.BlockedNorthEast | CollisionFlag.BlockedEast |
+        CollisionFlag.BlockedSouthEast | CollisionFlag.BlockedSouth | CollisionFlag.BlockedSouthWest | CollisionFlag.BlockedWest;
+
+    private const CollisionFlag RangeLayerMask =
+        CollisionFlag.WallAllowRangeNorthWest | CollisionFlag.WallAllowRangeNorth | CollisionFlag.WallAllowRangeNorthEast |
+        CollisionFlag.WallAllowRangeEast | CollisionFlag.WallAllowRangeSouthEast | CollisionFlag.WallAllowRangeSouth |
+        CollisionFlag.WallAllowRangeSouthWest | CollisionFlag.WallAllowRangeWest;
+
+    public static IEnumerable<TestDataRow<WallCase>> WallCases =>
+    [
+        WallCaseFor(ShapeType.Wall, 0, [new(0, 0, CollisionFlag.WallWest), new(-1, 0, CollisionFlag.WallEast)]),
+        WallCaseFor(ShapeType.Wall, 1, [new(0, 0, CollisionFlag.WallNorth), new(0, 1, CollisionFlag.WallSouth)]),
+        WallCaseFor(ShapeType.Wall, 2, [new(0, 0, CollisionFlag.WallEast), new(1, 0, CollisionFlag.WallWest)]),
+        WallCaseFor(ShapeType.Wall, 3, [new(0, 0, CollisionFlag.WallSouth), new(0, -1, CollisionFlag.WallNorth)]),
+
+        WallCaseFor(ShapeType.WallCornerDiagonal, 0, [new(0, 0, CollisionFlag.WallNorthWest), new(-1, 1, CollisionFlag.WallSouthEast)]),
+        WallCaseFor(ShapeType.WallCornerDiagonal, 1, [new(0, 0, CollisionFlag.WallNorthEast), new(1, 1, CollisionFlag.WallSouthWest)]),
+        WallCaseFor(ShapeType.WallCornerDiagonal, 2, [new(0, 0, CollisionFlag.WallSouthEast), new(1, -1, CollisionFlag.WallNorthWest)]),
+        WallCaseFor(ShapeType.WallCornerDiagonal, 3, [new(0, 0, CollisionFlag.WallSouthWest), new(-1, -1, CollisionFlag.WallNorthEast)]),
+
+        WallCaseFor(ShapeType.WallCorner, 0, [new(0, 0, CollisionFlag.WallNorthWest), new(-1, 1, CollisionFlag.WallSouthEast)]),
+        WallCaseFor(ShapeType.WallCorner, 1, [new(0, 0, CollisionFlag.WallNorthEast), new(1, 1, CollisionFlag.WallSouthWest)]),
+        WallCaseFor(ShapeType.WallCorner, 2, [new(0, 0, CollisionFlag.WallSouthEast), new(1, -1, CollisionFlag.WallNorthWest)]),
+        WallCaseFor(ShapeType.WallCorner, 3, [new(0, 0, CollisionFlag.WallSouthWest), new(-1, -1, CollisionFlag.WallNorthEast)]),
+
+        WallCaseFor(ShapeType.UnfinishedWall, 0,
+        [
+            new(0, 0, CollisionFlag.WallWest | CollisionFlag.WallNorth),
+            new(-1, 0, CollisionFlag.WallEast),
+            new(0, 1, CollisionFlag.WallSouth)
+        ]),
+        WallCaseFor(ShapeType.UnfinishedWall, 1,
+        [
+            new(0, 0, CollisionFlag.WallNorth | CollisionFlag.WallEast),
+            new(0, 1, CollisionFlag.WallSouth),
+            new(1, 0, CollisionFlag.WallWest)
+        ]),
+        WallCaseFor(ShapeType.UnfinishedWall, 2,
+        [
+            new(0, 0, CollisionFlag.WallSouth | CollisionFlag.WallEast),
+            new(1, 0, CollisionFlag.WallWest),
+            new(0, -1, CollisionFlag.WallNorth)
+        ]),
+        WallCaseFor(ShapeType.UnfinishedWall, 3,
+        [
+            new(0, 0, CollisionFlag.WallWest | CollisionFlag.WallSouth),
+            new(0, -1, CollisionFlag.WallNorth),
+            new(-1, 0, CollisionFlag.WallEast)
+        ])
+    ];
+
+    public static IEnumerable<TestDataRow<StandardCase>> StandardCases =>
+    [
+        StandardCaseFor(0, true, false),
+        StandardCaseFor(1, true, false),
+        StandardCaseFor(2, true, false),
+        StandardCaseFor(3, true, false),
+        StandardCaseFor(0, false, false),
+        StandardCaseFor(0, true, true),
+        StandardCaseFor(0, false, true)
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(WallCases))]
+    public void FlagWallObject_AllShapesAndRotations_WritesExpectedLayers(WallCase testCase)
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(testCase.ShapeType, testCase.Rotation);
+        SeedWallTiles(recorder, testCase.Tiles);
+
+        // Act
+        region.FlagWallObject(gameObject);
+
+        // Assert
+        AssertWallState(recorder, testCase.Tiles, solid: true, gateway: false);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(WallCases))]
+    public void WallObject_AllShapesAndRotations_FlagThenUnflag_RestoresUnrelatedCollision(WallCase testCase)
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(testCase.ShapeType, testCase.Rotation);
+        SeedWallTiles(recorder, testCase.Tiles);
+
+        // Act
+        region.FlagWallObject(gameObject);
+        region.UnFlagWallObject(gameObject);
+
+        // Assert
+        AssertWallBaseline(recorder, testCase.Tiles);
+    }
+
+    [TestMethod]
+    public void FlagWallObject_NonSolid_OmitsOnlyBlockedLayer()
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(ShapeType.Wall, 0, solid: false);
+        ExpectedTile[] expectedTiles = [new(0, 0, CollisionFlag.WallWest), new(-1, 0, CollisionFlag.WallEast)];
+        SeedWallTiles(recorder, expectedTiles);
+
+        // Act
+        region.FlagWallObject(gameObject);
+
+        // Assert
+        AssertWallState(recorder, expectedTiles, solid: false, gateway: false);
+    }
+
+    [TestMethod]
+    public void FlagWallObject_Gateway_OmitsOnlyRangeLayer()
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(ShapeType.Wall, 0, gateway: true, clipType: 0);
+        ExpectedTile[] expectedTiles = [new(0, 0, CollisionFlag.WallWest), new(-1, 0, CollisionFlag.WallEast)];
+        SeedWallTiles(recorder, expectedTiles);
+
+        // Act
+        region.FlagWallObject(gameObject);
+
+        // Assert
+        AssertWallState(recorder, expectedTiles, solid: true, gateway: true);
+    }
+
+    [TestMethod]
+    [DataRow(ShapeType.Wall)]
+    [DataRow(ShapeType.WallCornerDiagonal)]
+    [DataRow(ShapeType.UnfinishedWall)]
+    [DataRow(ShapeType.WallCorner)]
+    public void FlagWallObject_NonClippedNonGateway_WritesNoCollision(ShapeType shapeType)
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(shapeType, 0, clipType: 0);
+
+        // Act
+        region.FlagWallObject(gameObject);
+
+        // Assert
+        Assert.IsEmpty(recorder.Tiles);
+    }
+
+    [TestMethod]
+    public void FloorDecoration_WithClipTypeOne_FlagThenUnflag_RestoresUnrelatedCollision()
+    {
+        // Arrange
+        var (region, _) = CreateRegion();
+        var gameObject = CreateGameObject(ShapeType.GroundDecoration, 0, clipType: 1);
+        region.SetCollision(OriginX, OriginY, Plane, UnrelatedFlag);
+
+        // Act
+        region.FlagFloorDecorationCollision(gameObject);
+
+        // Assert
+        Assert.AreEqual(UnrelatedFlag | CollisionFlag.FloorDecorationBlock, region.GetCollision(OriginX, OriginY, Plane));
+
+        // Act
+        region.UnFlagFloorDecorationCollision(gameObject);
+
+        // Assert
+        Assert.AreEqual(UnrelatedFlag, region.GetCollision(OriginX, OriginY, Plane));
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(2)]
+    public void FlagFloorDecorationCollision_UnsupportedClipType_WritesNoCollision(int clipType)
+    {
+        // Arrange
+        var (region, _) = CreateRegion();
+        var gameObject = CreateGameObject(ShapeType.GroundDecoration, 0, clipType: clipType);
+        region.SetCollision(OriginX, OriginY, Plane, UnrelatedFlag);
+
+        // Act
+        region.FlagFloorDecorationCollision(gameObject);
+
+        // Assert
+        Assert.AreEqual(UnrelatedFlag, region.GetCollision(OriginX, OriginY, Plane));
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(StandardCases))]
+    public void StandardObject_FlagThenUnflag_WritesRotatedFootprintAndRestoresBaseline(StandardCase testCase)
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(
+            ShapeType.GroundDefault,
+            testCase.Rotation,
+            testCase.Solid,
+            testCase.Gateway,
+            clipType: 1,
+            sizeX: 2,
+            sizeY: 3);
+        var footprint = GetStandardFootprint(testCase.Rotation);
+        foreach (var (x, y) in footprint)
+        {
+            recorder.Seed(Location.Create(x, y, Plane, Dimension), UnrelatedFlag);
+        }
+        recorder.Seed(Location.Create(20, 20, Plane, Dimension), CollisionFlag.ObjectTile);
+
+        // Act
+        region.FlagStandardObject(gameObject);
+
+        // Assert
+        foreach (var (x, y) in footprint)
+        {
+            Assert.AreEqual(UnrelatedFlag | testCase.ExpectedFlags, recorder.Get(x, y, Plane, Dimension));
+        }
+        Assert.HasCount(footprint.Count + 1, recorder.Tiles);
+        Assert.AreEqual(CollisionFlag.ObjectTile, recorder.Get(20, 20, Plane, Dimension));
+
+        // Act
+        region.UnFlagStandardObject(gameObject);
+
+        // Assert
+        foreach (var (x, y) in footprint)
+        {
+            Assert.AreEqual(UnrelatedFlag, recorder.Get(x, y, Plane, Dimension));
+        }
+        Assert.HasCount(footprint.Count + 1, recorder.Tiles);
+        Assert.AreEqual(CollisionFlag.ObjectTile, recorder.Get(20, 20, Plane, Dimension));
+    }
+
+    [TestMethod]
+    public void FlagStandardObject_NonClippedNonGateway_WritesNoCollision()
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var gameObject = CreateGameObject(ShapeType.GroundDefault, 0, clipType: 0, sizeX: 2, sizeY: 3);
+        foreach (var (x, y) in GetStandardFootprint(0))
+        {
+            recorder.Seed(Location.Create(x, y, Plane, Dimension), UnrelatedFlag);
+        }
+
+        // Act
+        region.FlagStandardObject(gameObject);
+
+        // Assert
+        foreach (var (x, y) in GetStandardFootprint(0))
+        {
+            Assert.AreEqual(UnrelatedFlag, recorder.Get(x, y, Plane, Dimension));
+        }
+        Assert.HasCount(GetStandardFootprint(0).Count, recorder.Tiles);
+    }
+
+    [TestMethod]
+    public void CollisionDispatcher_EachLayer_UsesItsMappedWriter()
+    {
+        // Arrange
+        var (region, recorder) = CreateRegion();
+        var wall = CreateGameObject(ShapeType.Wall, 0);
+        var standardObject = CreateGameObject(ShapeType.GroundDefault, 0);
+        var floorDecoration = CreateGameObject(ShapeType.GroundDecoration, 0, clipType: 1);
+        var wallDecoration = CreateGameObject(ShapeType.WallDecorationStraightXOffset, 0);
+        ExpectedTile[] wallTiles = [new(0, 0, CollisionFlag.WallWest), new(-1, 0, CollisionFlag.WallEast)];
+        SeedWallTiles(recorder, wallTiles);
+        region.SetCollision(30, 30, Plane, UnrelatedFlag);
+        region.SetCollision(40, 40, Plane, UnrelatedFlag);
+        standardObject.Location.Returns(Location.Create(20, 20, Plane, Dimension));
+        floorDecoration.Location.Returns(Location.Create(30, 30, Plane, Dimension));
+        wallDecoration.Location.Returns(Location.Create(40, 40, Plane, Dimension));
+
+        // Act
+        region.FlagCollision(wall);
+
+        // Assert
+        AssertWallState(recorder, wallTiles, solid: true, gateway: false);
+
+        // Act
+        region.UnFlagCollision(wall);
+
+        // Assert
+        AssertWallBaseline(recorder, wallTiles);
+
+        // Act
+        recorder.Seed(Location.Create(20, 20, Plane, Dimension), UnrelatedFlag);
+        region.FlagCollision(standardObject);
+        region.FlagCollision(floorDecoration);
+        region.FlagCollision(wallDecoration);
+
+        // Assert
+        Assert.AreEqual(UnrelatedFlag | CollisionFlag.ObjectTile | CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange, recorder.Get(20, 20, Plane, Dimension));
+        Assert.AreEqual(UnrelatedFlag | CollisionFlag.FloorDecorationBlock, region.GetCollision(30, 30, Plane));
+        Assert.AreEqual(UnrelatedFlag, region.GetCollision(40, 40, Plane));
+
+        // Act
+        region.UnFlagCollision(standardObject);
+        region.UnFlagCollision(floorDecoration);
+        region.UnFlagCollision(wallDecoration);
+
+        // Assert
+        Assert.AreEqual(UnrelatedFlag, recorder.Get(20, 20, Plane, Dimension));
+        Assert.AreEqual(UnrelatedFlag, region.GetCollision(30, 30, Plane));
+        Assert.AreEqual(UnrelatedFlag, region.GetCollision(40, 40, Plane));
+    }
+
+    private static TestDataRow<WallCase> WallCaseFor(ShapeType shapeType, int rotation, ExpectedTile[] tiles) =>
+        new(new WallCase(shapeType, rotation, tiles)) { DisplayName = $"{shapeType} rotation {rotation}" };
+
+    private static TestDataRow<StandardCase> StandardCaseFor(int rotation, bool solid, bool gateway)
+    {
+        var expectedFlags = CollisionFlag.ObjectTile;
+        if (solid)
+        {
+            expectedFlags |= CollisionFlag.ObjectBlock;
+        }
+        if (!gateway)
+        {
+            expectedFlags |= CollisionFlag.ObjectAllowRange;
+        }
+
+        return new(new StandardCase(rotation, solid, gateway, expectedFlags))
+        {
+            DisplayName = $"rotation {rotation}, solid {solid}, gateway {gateway}"
+        };
+    }
+
+    private static (MapRegion Region, CollisionRecorder Recorder) CreateRegion()
+    {
+        var mapRegionService = Substitute.For<IMapRegionService>();
+        var recorder = new CollisionRecorder();
+        mapRegionService.When(service => service.FlagCollision(Arg.Any<ILocation>(), Arg.Any<CollisionFlag>()))
+            .Do(call => recorder.Flag(call.Arg<ILocation>()!, call.Arg<CollisionFlag>()));
+        mapRegionService.When(service => service.UnFlagCollision(Arg.Any<ILocation>(), Arg.Any<CollisionFlag>()))
+            .Do(call => recorder.UnFlag(call.Arg<ILocation>()!, call.Arg<CollisionFlag>()));
+
+        var region = new MapRegion(
+            Location.Zero,
+            new int[4],
+            Substitute.For<INpcService>(),
+            mapRegionService,
+            Substitute.For<IGameObjectBuilder>(),
+            Substitute.For<IGroundItemBuilder>(),
+            Substitute.For<IMapper>());
+
+        return (region, recorder);
+    }
+
+    private static IGameObject CreateGameObject(
+        ShapeType shapeType,
+        int rotation,
+        bool solid = true,
+        bool gateway = false,
+        int clipType = 1,
+        int sizeX = 1,
+        int sizeY = 1)
+    {
+        var definition = Substitute.For<IGameObjectDefinition>();
+        definition.Solid.Returns(solid);
+        definition.Gateway.Returns(gateway);
+        definition.ClipType.Returns(clipType);
+        definition.SizeX.Returns(sizeX);
+        definition.SizeY.Returns(sizeY);
+
+        var gameObject = Substitute.For<IGameObject>();
+        gameObject.ShapeType.Returns(shapeType);
+        gameObject.Rotation.Returns(rotation);
+        gameObject.Location.Returns(Location.Create(OriginX, OriginY, Plane, Dimension));
+        gameObject.Definition.Returns(definition);
+        return gameObject;
+    }
+
+    private static void SeedWallTiles(CollisionRecorder recorder, IEnumerable<ExpectedTile> tiles)
+    {
+        foreach (var tile in tiles)
+        {
+            recorder.Seed(Location.Create(OriginX + tile.XOffset, OriginY + tile.YOffset, Plane, Dimension), UnrelatedFlag);
+        }
+    }
+
+    private static void AssertWallState(CollisionRecorder recorder, IReadOnlyList<ExpectedTile> expectedTiles, bool solid, bool gateway)
+    {
+        Assert.HasCount(expectedTiles.Count, recorder.Tiles);
+
+        foreach (var tile in expectedTiles)
+        {
+            var actual = recorder.Get(OriginX + tile.XOffset, OriginY + tile.YOffset, Plane, Dimension);
+            var expectedBlocked = solid ? ToBlockedFlags(tile.WallFlags) : CollisionFlag.Walkable;
+            var expectedRange = gateway ? CollisionFlag.Walkable : ToRangeFlags(tile.WallFlags);
+            var expected = UnrelatedFlag | tile.WallFlags | expectedBlocked | expectedRange;
+
+            Assert.AreEqual(tile.WallFlags, actual & WallLayerMask, $"Low wall layer at ({tile.XOffset}, {tile.YOffset})");
+            Assert.AreEqual(expectedBlocked, actual & BlockedLayerMask, $"Solid wall layer at ({tile.XOffset}, {tile.YOffset})");
+            Assert.AreEqual(expectedRange, actual & RangeLayerMask, $"Range wall layer at ({tile.XOffset}, {tile.YOffset})");
+            Assert.AreEqual(expected, actual, $"Exact collision flags at ({tile.XOffset}, {tile.YOffset})");
+        }
+    }
+
+    private static void AssertWallBaseline(CollisionRecorder recorder, IReadOnlyList<ExpectedTile> expectedTiles)
+    {
+        Assert.HasCount(expectedTiles.Count, recorder.Tiles);
+
+        foreach (var tile in expectedTiles)
+        {
+            Assert.AreEqual(UnrelatedFlag, recorder.Get(OriginX + tile.XOffset, OriginY + tile.YOffset, Plane, Dimension));
+        }
+    }
+
+    private static CollisionFlag ToBlockedFlags(CollisionFlag wallFlags)
+    {
+        var result = CollisionFlag.Walkable;
+        if ((wallFlags & CollisionFlag.WallNorthWest) != 0) result |= CollisionFlag.BlockedNorthWest;
+        if ((wallFlags & CollisionFlag.WallNorth) != 0) result |= CollisionFlag.BlockedNorth;
+        if ((wallFlags & CollisionFlag.WallNorthEast) != 0) result |= CollisionFlag.BlockedNorthEast;
+        if ((wallFlags & CollisionFlag.WallEast) != 0) result |= CollisionFlag.BlockedEast;
+        if ((wallFlags & CollisionFlag.WallSouthEast) != 0) result |= CollisionFlag.BlockedSouthEast;
+        if ((wallFlags & CollisionFlag.WallSouth) != 0) result |= CollisionFlag.BlockedSouth;
+        if ((wallFlags & CollisionFlag.WallSouthWest) != 0) result |= CollisionFlag.BlockedSouthWest;
+        if ((wallFlags & CollisionFlag.WallWest) != 0) result |= CollisionFlag.BlockedWest;
+        return result;
+    }
+
+    private static CollisionFlag ToRangeFlags(CollisionFlag wallFlags)
+    {
+        var result = CollisionFlag.Walkable;
+        if ((wallFlags & CollisionFlag.WallNorthWest) != 0) result |= CollisionFlag.WallAllowRangeNorthWest;
+        if ((wallFlags & CollisionFlag.WallNorth) != 0) result |= CollisionFlag.WallAllowRangeNorth;
+        if ((wallFlags & CollisionFlag.WallNorthEast) != 0) result |= CollisionFlag.WallAllowRangeNorthEast;
+        if ((wallFlags & CollisionFlag.WallEast) != 0) result |= CollisionFlag.WallAllowRangeEast;
+        if ((wallFlags & CollisionFlag.WallSouthEast) != 0) result |= CollisionFlag.WallAllowRangeSouthEast;
+        if ((wallFlags & CollisionFlag.WallSouth) != 0) result |= CollisionFlag.WallAllowRangeSouth;
+        if ((wallFlags & CollisionFlag.WallSouthWest) != 0) result |= CollisionFlag.WallAllowRangeSouthWest;
+        if ((wallFlags & CollisionFlag.WallWest) != 0) result |= CollisionFlag.WallAllowRangeWest;
+        return result;
+    }
+
+    private static IReadOnlyList<(int X, int Y)> GetStandardFootprint(int rotation)
+    {
+        var sizeX = rotation is 1 or 3 ? 3 : 2;
+        var sizeY = rotation is 1 or 3 ? 2 : 3;
+        var footprint = new List<(int X, int Y)>();
+
+        for (var x = OriginX; x < OriginX + sizeX; x++)
+        {
+            for (var y = OriginY; y < OriginY + sizeY; y++)
+            {
+                footprint.Add((x, y));
+            }
+        }
+
+        return footprint;
+    }
+
+    public sealed record WallCase(ShapeType ShapeType, int Rotation, IReadOnlyList<ExpectedTile> Tiles);
+
+    public sealed record StandardCase(int Rotation, bool Solid, bool Gateway, CollisionFlag ExpectedFlags);
+
+    public readonly record struct ExpectedTile(int XOffset, int YOffset, CollisionFlag WallFlags);
+
+    private sealed class CollisionRecorder
+    {
+        private readonly Dictionary<(int X, int Y, int Z, int Dimension), CollisionFlag> _tiles = [];
+
+        public IReadOnlyDictionary<(int X, int Y, int Z, int Dimension), CollisionFlag> Tiles => _tiles;
+
+        public void Seed(ILocation location, CollisionFlag flags) => Flag(location, flags);
+
+        public void Flag(ILocation location, CollisionFlag flags)
+        {
+            var key = (location.X, location.Y, location.Z, location.Dimension);
+            _tiles[key] = Get(location.X, location.Y, location.Z, location.Dimension) | flags;
+        }
+
+        public void UnFlag(ILocation location, CollisionFlag flags)
+        {
+            var key = (location.X, location.Y, location.Z, location.Dimension);
+            _tiles[key] = Get(location.X, location.Y, location.Z, location.Dimension) & ~flags;
+        }
+
+        public CollisionFlag Get(int x, int y, int z, int dimension) =>
+            _tiles.GetValueOrDefault((x, y, z, dimension), CollisionFlag.Walkable);
+    }
+}

--- a/Hagalaz.Services.GameWorld/Model/Maps/Regions/CollisionMethods.cs
+++ b/Hagalaz.Services.GameWorld/Model/Maps/Regions/CollisionMethods.cs
@@ -279,7 +279,7 @@ namespace Hagalaz.Services.GameWorld.Model.Maps.Regions
 
                     if (obj.Rotation == 1)
                     {
-                        _regionService.FlagCollision(x0Y0, CollisionFlag.BlockedSouthEast);
+                        _regionService.FlagCollision(x0Y0, CollisionFlag.BlockedNorthEast);
                         _regionService.FlagCollision(x1Y1, CollisionFlag.BlockedSouthWest);
                     }
 
@@ -292,7 +292,7 @@ namespace Hagalaz.Services.GameWorld.Model.Maps.Regions
                     if (obj.Rotation == 3)
                     {
                         _regionService.FlagCollision(x0Y0, CollisionFlag.BlockedSouthWest);
-                        _regionService.FlagCollision(xm1Ym1, CollisionFlag.BlockedSouthEast);
+                        _regionService.FlagCollision(xm1Ym1, CollisionFlag.BlockedNorthEast);
                     }
                 }
 
@@ -388,7 +388,7 @@ namespace Hagalaz.Services.GameWorld.Model.Maps.Regions
                 {
                     if (obj.Rotation == 0)
                     {
-                        _regionService.FlagCollision(x0Y0, CollisionFlag.WallAllowRangeSouth | CollisionFlag.WallAllowRangeEast);
+                        _regionService.FlagCollision(x0Y0, CollisionFlag.WallAllowRangeWest | CollisionFlag.WallAllowRangeNorth);
                         _regionService.FlagCollision(xm1Y0, CollisionFlag.WallAllowRangeEast);
                         _regionService.FlagCollision(x0Y1, CollisionFlag.WallAllowRangeSouth);
                     }
@@ -552,7 +552,7 @@ namespace Hagalaz.Services.GameWorld.Model.Maps.Regions
                     if (obj.Rotation == 0)
                     {
                         _regionService.UnFlagCollision(x0Y0, CollisionFlag.BlockedNorthWest);
-                        _regionService.UnFlagCollision(xm1Y1, CollisionFlag.BlockedSouthWest);
+                        _regionService.UnFlagCollision(xm1Y1, CollisionFlag.BlockedSouthEast);
                     }
 
                     if (obj.Rotation == 1)
@@ -563,7 +563,7 @@ namespace Hagalaz.Services.GameWorld.Model.Maps.Regions
 
                     if (obj.Rotation == 2)
                     {
-                        _regionService.UnFlagCollision(x0Y0, CollisionFlag.BlockedSouthWest);
+                        _regionService.UnFlagCollision(x0Y0, CollisionFlag.BlockedSouthEast);
                         _regionService.UnFlagCollision(x1Ym1, CollisionFlag.BlockedNorthWest);
                     }
 

--- a/openspec/changes/correct-wall-collision-writer-flags/.openspec.yaml
+++ b/openspec/changes/correct-wall-collision-writer-flags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/correct-wall-collision-writer-flags/design.md
+++ b/openspec/changes/correct-wall-collision-writer-flags/design.md
@@ -1,0 +1,47 @@
+## Context
+
+`MapRegion` is the existing owner of collision mutations for map objects. It delegates absolute-location updates to `IMapRegionService`; the service remains the only collision-store boundary. The diagonal/corner solid layer has two incorrect directions in the flag path and two mismatched directions in the unflag path. Unfinished-wall rotation 0 similarly writes a range pair that its inverse does not remove.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the existing writer topology while making low, solid, and range directional pairs geometrically consistent.
+- Exercise every writer and the public dispatch methods with deterministic, stateful collision assertions.
+
+**Non-Goals:**
+
+- Change collision enumeration values, projectile traversal, line-of-sight policy, map loading, or collision-store ownership.
+- Add a production helper, service, dependency, persistence model, queue, or retry mechanism.
+
+## Decisions
+
+### Keep `MapRegion` as the sole writer
+
+The five corrected assignments stay in the existing `FlagWallObject` and `UnFlagWallObject` branches. Redirecting writes through a new directional mapper would broaden the change and risk altering unrelated wall semantics.
+
+### Use the client geometry for diagonal directions and local writer symmetry for unfinished walls
+
+The existing `CollisionFlag` numeric layout already matches the client. For unfinished-wall rotation 0, the low and solid layers plus the removal path agree on the west/north origin pair, making that pair the authoritative range geometry.
+
+### Use a test-local stateful map-service recorder
+
+`IMapRegionService` is the existing seam. Tests will update an in-memory coordinate-to-flag map from NSubstitute callbacks, allowing exact layer and inverse assertions without changing production APIs or creating a second collision implementation.
+
+### Parameterize geometry instead of duplicating test bodies
+
+Typed MSTest dynamic data will describe rotations, affected coordinates, and expected directional masks. Tests will assert low, solid, and range masks independently so a correct layer cannot hide an error in another.
+
+## Risks / Trade-offs
+
+- [Risk] The comprehensive matrix can accidentally encode an incorrect direction. → Mitigation: use explicit rotation tables, client parity for diagonal walls, and independent per-layer assertions.
+- [Risk] Flag bitmasks do not track overlapping object ownership. → Mitigation: validate the supported lifecycle of an object being flagged and then removed, while preserving an unrelated seeded flag; do not redefine collision ownership in this change.
+- [Risk] A wider test suite might reveal unrelated writer defects. → Mitigation: the approved unfinished-wall correction is included; any further production defect pauses this change for a follow-up.
+
+## Migration Plan
+
+No data migration or rollout sequencing is required. Deploy the corrected server assembly normally. Roll back by reverting the focused source and test changes together.
+
+## Open Questions
+
+None.

--- a/openspec/changes/correct-wall-collision-writer-flags/proposal.md
+++ b/openspec/changes/correct-wall-collision-writer-flags/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+`MapRegion` writes incorrect solid directional bits for diagonal/corner walls, so the server collision map disagrees with the game client. Its unfinished-wall rotation-0 range flags also disagree with the corresponding unflag path, leaving collision state behind after removal.
+
+## What Changes
+
+- Correct the `Blocked*` directions for diagonal/corner wall rotations 1 and 3, and make the corresponding removal operations exact inverses.
+- Correct unfinished-wall rotation 0's origin `WallAllowRange*` pair to match its geometry and existing inverse.
+- Add focused unit coverage for all `MapRegion` collision writers: floor decorations, standard objects, wall shapes, flag/removal inversion, and layer dispatch.
+
+### In Scope
+
+- Wall, diagonal/corner wall, and unfinished-wall collision flags for rotations 0 through 3.
+- Standard-object footprints and floor-decoration collision behavior.
+- The existing `IMapRegionService` collision-writing seam in unit tests.
+
+### Non-goals
+
+- Change projectile or line-of-sight traversal semantics tracked by issue #364.
+- Rename or reinterpret `CollisionFlag` values.
+- Add collision storage, ownership, retry, persistence, or public API mechanisms.
+
+### Acceptance Criteria
+
+- Solid `WallCornerDiagonal` and `WallCorner` rotations use `NW/SE`, `NE/SW`, `SE/NW`, and `SW/NE` direction pairs for low, solid, and range layers.
+- Flagging and unflagging every supported collision writer are exact inverses for the flags written by that object and preserve unrelated seeded collision bits.
+- Unfinished-wall rotation 0 range flags match its west/north geometry and are removed exactly.
+- The focused GameWorld unit tests, solution build, strict OpenSpec validation, and diff check pass.
+
+### Stop Conditions
+
+Pause and record follow-up work if the corrections require collision-enum changes, projectile traversal changes, a new production abstraction, or alterations outside `MapRegion` collision writing.
+
+## Capabilities
+
+### New Capabilities
+
+- `map-collision-writer`: Server collision writers generate and remove geometric low, solid, and range layers consistently.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Model/Maps/Regions/CollisionMethods.cs`
+- `Hagalaz.Services.GameWorld.Tests/CollisionMethodsTests.cs`
+- No public APIs, dependencies, configuration, migrations, or distributed runtime topology changes.

--- a/openspec/changes/correct-wall-collision-writer-flags/specs/map-collision-writer/spec.md
+++ b/openspec/changes/correct-wall-collision-writer-flags/specs/map-collision-writer/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Collision writers preserve object geometry
+
+`MapRegion` MUST write low wall, solid-blocked, and range wall collision layers at the positions and directions represented by each supported object shape and rotation.
+
+#### Scenario: Diagonal and corner walls use client-parity directions
+- **WHEN** a clipped, solid, non-gateway `WallCornerDiagonal` or `WallCorner` is written at rotations 0 through 3
+- **THEN** its origin/opposite pairs MUST be north-west/south-east, north-east/south-west, south-east/north-west, and south-west/north-east respectively in every applicable layer
+
+#### Scenario: Unfinished wall rotation zero uses west and north range directions
+- **WHEN** a clipped, non-gateway `UnfinishedWall` at rotation 0 is written
+- **THEN** its origin tile MUST include `WallAllowRangeWest` and `WallAllowRangeNorth`
+
+#### Scenario: Standard objects use rotated footprints
+- **WHEN** a clipped standard object is written at rotations 1 or 3
+- **THEN** its collision footprint MUST use the definition's Y size for X extent and X size for Y extent
+
+#### Scenario: Writer gates preserve layer meaning
+- **WHEN** a supported wall or standard object is non-solid or a gateway
+- **THEN** non-solid objects MUST omit only the solid-blocked layer and gateways MUST omit only the range layer
+
+### Requirement: Collision writer removal is reversible
+
+For an object that is eligible to write collision, `MapRegion` MUST remove exactly the flags that it wrote without clearing unrelated collision bits.
+
+#### Scenario: Supported object is removed after being written
+- **WHEN** a floor decoration, standard object, or supported wall shape is flagged and then unflagged
+- **THEN** every affected tile MUST return to its pre-flag collision state
+
+#### Scenario: Unrelated collision bit exists on an affected tile
+- **WHEN** an affected tile contains a collision bit not owned by the object before the object is flagged
+- **THEN** flagging and unflagging the object MUST preserve that bit
+
+### Requirement: Collision dispatch selects the object layer writer
+
+`MapRegion` MUST route wall, standard-object, and floor-decoration shapes to their corresponding collision writers and MUST leave wall decorations without collision mutations.
+
+#### Scenario: Object is flagged through the public dispatcher
+- **WHEN** a wall, standard object, floor decoration, or wall decoration is passed to `FlagCollision`
+- **THEN** only the mapped writer's collision behavior MUST be applied

--- a/openspec/changes/correct-wall-collision-writer-flags/tasks.md
+++ b/openspec/changes/correct-wall-collision-writer-flags/tasks.md
@@ -1,0 +1,16 @@
+## 1. Collision Writer Regression Coverage
+
+- [x] 1.1 Add a test-local `IMapRegionService` collision recorder and object/region fixtures using the existing MSTest and NSubstitute project infrastructure.
+- [x] 1.2 Add floor-decoration and standard-object writer coverage for clip gates, rotated footprints, solid/range combinations, and valid flag/unflag restoration.
+- [x] 1.3 Add parameterized wall coverage for every supported wall shape and rotation, including independent low/solid/range assertions, gateway/non-solid gates, and inverse preservation of unrelated flags.
+- [x] 1.4 Add public collision-dispatch coverage for wall, standard-object, floor-decoration, and wall-decoration shapes.
+
+## 2. Wall Collision Corrections
+
+- [x] 2.1 Correct diagonal/corner solid `Blocked*` writes and removals to the client-parity direction pairs.
+- [x] 2.2 Correct unfinished-wall rotation-0 origin range flags to the west/north pair used by its geometry and inverse.
+
+## 3. Verification
+
+- [x] 3.1 Confirm the new targeted regressions fail against the uncorrected writer and pass after the focused corrections.
+- [x] 3.2 Run focused and complete GameWorld unit tests, solution-level discovery, a non-incremental solution build, strict OpenSpec validation, and `git diff --check`.


### PR DESCRIPTION
## Summary

- Correct diagonal and corner wall solid collision directions.
- Align unfinished-wall range flags with rotation-0 geometry and removal.
- Add comprehensive collision-writer and dispatch regression coverage.

## Testing

- GameWorld collision writer unit tests pass, covering wall shapes, rotations, layer gates, inverse operations, standard objects, floor decorations, and dispatch.

fixes #370 