### PR TITLE
Fix large-entity interaction reach validation

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/PathfinderInteractionReachTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/PathfinderInteractionReachTests.cs
@@ -1,0 +1,392 @@
+using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Services.GameWorld.Logic.Pathfinding;
+using NSubstitute;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class PathfinderInteractionReachTests
+{
+    private const int CurrentX = 41;
+    private const int CurrentY = 73;
+    private const int Plane = 0;
+
+    private readonly IMapRegionService _mapRegionService;
+    private readonly DumbPathFinder _pathFinder;
+
+    public PathfinderInteractionReachTests()
+    {
+        _mapRegionService = Substitute.For<IMapRegionService>();
+        _mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(CollisionFlag.Walkable);
+        _pathFinder = new DumbPathFinder(_mapRegionService);
+    }
+
+    public static IEnumerable<TestDataRow<OverlapCase>> LargeEntityOutsideFootprintCases =>
+        CreateLargeEntityOutsideFootprintCases()
+            .Select(testCase => new TestDataRow<OverlapCase>(testCase) { DisplayName = testCase.Name });
+
+    public static IEnumerable<TestDataRow<DoorInteractionCase>> LargeDoorInteractionCases =>
+        CreateLargeDoorInteractionCases()
+            .Select(testCase => new TestDataRow<DoorInteractionCase>(testCase) { DisplayName = testCase.Name });
+
+    public static IEnumerable<TestDataRow<DecorationInteractionCase>> LargeDecorationInteractionCases =>
+        CreateLargeDecorationInteractionCases()
+            .Select(testCase => new TestDataRow<DecorationInteractionCase>(testCase) { DisplayName = testCase.Name });
+
+    [TestMethod]
+    [DynamicData(nameof(LargeEntityOutsideFootprintCases))]
+    public void CanDecorationInteract_LargeEntityTargetOutsideEitherFootprintAxis_ReturnsFalse(OverlapCase testCase)
+    {
+        // Act
+        var result = _pathFinder.CanDecorationInteract(
+            shape: 99,
+            CurrentX,
+            CurrentY,
+            testCase.TargetX,
+            testCase.TargetY,
+            testCase.Size,
+            rotation: 0,
+            Plane);
+
+        // Assert
+        Assert.IsFalse(result, testCase.Name);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(LargeEntityOutsideFootprintCases))]
+    public void CanDoorInteract_LargeEntityTargetOutsideEitherFootprintAxis_ReturnsFalse(OverlapCase testCase)
+    {
+        // Act
+        var result = _pathFinder.CanDoorInteract(
+            shape: 99,
+            testCase.TargetX,
+            testCase.TargetY,
+            CurrentX,
+            CurrentY,
+            rotation: 0,
+            testCase.Size,
+            Plane);
+
+        // Assert
+        Assert.IsFalse(result, testCase.Name);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void CanDecorationInteract_LargeEntityTargetInsideBothFootprintAxes_ReturnsTrue(int size)
+    {
+        // Act
+        var result = _pathFinder.CanDecorationInteract(
+            shape: 99,
+            CurrentX,
+            CurrentY,
+            CurrentX + size - 1,
+            CurrentY + size - 1,
+            size,
+            rotation: 0,
+            Plane);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void CanDoorInteract_LargeEntityTargetInsideBothFootprintAxes_ReturnsTrue(int size)
+    {
+        // Act
+        var result = _pathFinder.CanDoorInteract(
+            shape: 99,
+            CurrentX + size - 1,
+            CurrentY + size - 1,
+            CurrentX,
+            CurrentY,
+            rotation: 0,
+            size,
+            Plane);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(LargeDoorInteractionCases))]
+    public void CanDoorInteract_LargeEntityActualSideIsBlocked_ReturnsFalse(DoorInteractionCase testCase)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(testCase.CollisionX, testCase.CollisionY, Plane)
+            .Returns(CollisionFlag.FloorBlock);
+
+        // Act
+        var result = _pathFinder.CanDoorInteract(
+            testCase.Shape,
+            testCase.TargetX,
+            testCase.TargetY,
+            CurrentX,
+            CurrentY,
+            testCase.Rotation,
+            testCase.Size,
+            Plane);
+
+        // Assert
+        Assert.IsFalse(result, testCase.Name);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(LargeDoorInteractionCases))]
+    public void CanDoorInteract_LargeEntityUnrelatedCollision_ReturnsTrue(DoorInteractionCase testCase)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(testCase.CollisionX + 20, testCase.CollisionY + 20, Plane)
+            .Returns(CollisionFlag.FloorBlock);
+
+        // Act
+        var result = _pathFinder.CanDoorInteract(
+            testCase.Shape,
+            testCase.TargetX,
+            testCase.TargetY,
+            CurrentX,
+            CurrentY,
+            testCase.Rotation,
+            testCase.Size,
+            Plane);
+
+        // Assert
+        Assert.IsTrue(result, testCase.Name);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void CanDoorInteract_ShapeZeroRotationZero_UsesTargetXAndCurrentYForCollision(int size)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(CurrentX, CurrentY, Plane)
+            .Returns(CollisionFlag.FloorBlock);
+
+        // Act
+        var result = _pathFinder.CanDoorInteract(0, CurrentX, CurrentY - 1, CurrentX, CurrentY, 0, size, Plane);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void CanDoorInteract_ShapeZeroRotationZero_IgnoresCollisionAtXUsedAsY(int size)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(CurrentX, CurrentX, Plane)
+            .Returns(CollisionFlag.FloorBlock);
+
+        // Act
+        var result = _pathFinder.CanDoorInteract(0, CurrentX, CurrentY - 1, CurrentX, CurrentY, 0, size, Plane);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(LargeDecorationInteractionCases))]
+    public void CanDecorationInteract_LargeEntityActualSideIsBlocked_ReturnsFalse(DecorationInteractionCase testCase)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(testCase.CollisionX, testCase.CollisionY, Plane)
+            .Returns(testCase.BlockingFlag);
+
+        // Act
+        var result = _pathFinder.CanDecorationInteract(
+            testCase.Shape,
+            CurrentX,
+            CurrentY,
+            testCase.TargetX,
+            testCase.TargetY,
+            testCase.Size,
+            testCase.Rotation,
+            Plane);
+
+        // Assert
+        Assert.IsFalse(result, testCase.Name);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(LargeDecorationInteractionCases))]
+    public void CanDecorationInteract_LargeEntityUnrelatedCollision_ReturnsTrue(DecorationInteractionCase testCase)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(testCase.CollisionX + 20, testCase.CollisionY + 20, Plane)
+            .Returns(testCase.BlockingFlag);
+
+        // Act
+        var result = _pathFinder.CanDecorationInteract(
+            testCase.Shape,
+            CurrentX,
+            CurrentY,
+            testCase.TargetX,
+            testCase.TargetY,
+            testCase.Size,
+            testCase.Rotation,
+            Plane);
+
+        // Assert
+        Assert.IsTrue(result, testCase.Name);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void CanDecorationInteract_ShapeSixRotationZero_UsesWestSideTargetYForCollision(int size)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(CurrentX, CurrentY, Plane)
+            .Returns(CollisionFlag.WallWest);
+
+        // Act
+        var result = _pathFinder.CanDecorationInteract(6, CurrentX, CurrentY, CurrentX - 1, CurrentY, size, 0, Plane);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void CanDecorationInteract_ShapeSixRotationZero_IgnoresCollisionAtTargetXAsY(int size)
+    {
+        // Arrange
+        _mapRegionService.GetClippingFlag(CurrentX, CurrentX - 1, Plane)
+            .Returns(CollisionFlag.WallWest);
+
+        // Act
+        var result = _pathFinder.CanDecorationInteract(6, CurrentX, CurrentY, CurrentX - 1, CurrentY, size, 0, Plane);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    [DataRow(0, CurrentX, CurrentY, 0)]
+    [DataRow(2, CurrentX, CurrentY, 1)]
+    [DataRow(9, CurrentX, CurrentY, 3)]
+    public void CanDoorInteract_SizeOneValidSupportedApproach_ReturnsTrue(int shape, int targetX, int targetY, int rotation)
+    {
+        // Act
+        var result = _pathFinder.CanDoorInteract(shape, targetX, targetY, CurrentX - 1, CurrentY, rotation, 1, Plane);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    [DataRow(6, CurrentX - 2, CurrentY, 0)]
+    [DataRow(7, CurrentX - 2, CurrentY, 1)]
+    [DataRow(8, CurrentX - 2, CurrentY, 0)]
+    public void CanDecorationInteract_SizeOneValidSupportedApproach_ReturnsTrue(int shape, int targetX, int targetY, int rotation)
+    {
+        // Act
+        var result = _pathFinder.CanDecorationInteract(shape, CurrentX - 1, CurrentY, targetX, targetY, 1, rotation, Plane);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    private static IEnumerable<OverlapCase> CreateLargeEntityOutsideFootprintCases()
+    {
+        foreach (var size in new[] { 2, 3 })
+        {
+            yield return new OverlapCase($"size {size}, X inside and Y below", size, CurrentX, CurrentY - 1);
+            yield return new OverlapCase($"size {size}, X inside and Y above", size, CurrentX, CurrentY + size);
+            yield return new OverlapCase($"size {size}, Y inside and X west", size, CurrentX - 1, CurrentY);
+            yield return new OverlapCase($"size {size}, Y inside and X east", size, CurrentX + size, CurrentY);
+        }
+    }
+
+    private static IEnumerable<DoorInteractionCase> CreateLargeDoorInteractionCases()
+    {
+        foreach (var size in new[] { 2, 3 })
+        {
+            yield return DoorCase("shape 0 rotation 0 south", 0, 0, size, CurrentX, CurrentY - 1, CurrentX, CurrentY);
+            yield return DoorCase("shape 0 rotation 1 east", 0, 1, size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY);
+            yield return DoorCase("shape 0 rotation 2 south", 0, 2, size, CurrentX, CurrentY - 1, CurrentX, CurrentY);
+            yield return DoorCase("shape 0 rotation 3 east", 0, 3, size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY);
+
+            yield return DoorCase("shape 2 rotation 0 west", 2, 0, size, CurrentX - 1, CurrentY, CurrentX, CurrentY);
+            yield return DoorCase("shape 2 rotation 1 east", 2, 1, size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY);
+            yield return DoorCase("shape 2 rotation 2 east", 2, 2, size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY);
+            yield return DoorCase("shape 2 rotation 3 south", 2, 3, size, CurrentX, CurrentY - 1, CurrentX, CurrentY);
+
+            yield return DoorCase("shape 9 rotation 0 south", 9, 0, size, CurrentX, CurrentY - 1, CurrentX, CurrentY);
+            yield return DoorCase("shape 9 rotation 1 north", 9, 1, size, CurrentX, CurrentY + size, CurrentX, CurrentY + size - 1);
+            yield return DoorCase("shape 9 rotation 2 east", 9, 2, size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY);
+            yield return DoorCase("shape 9 rotation 3 west", 9, 3, size, CurrentX - 1, CurrentY, CurrentX, CurrentY);
+        }
+    }
+
+    private static IEnumerable<DecorationInteractionCase> CreateLargeDecorationInteractionCases()
+    {
+        foreach (var size in new[] { 2, 3 })
+        {
+            foreach (var shape in new[] { 6, 7 })
+            {
+                yield return DecorationCase("rotation 0 west", shape, RotationFor(shape, 0), size, CurrentX - 1, CurrentY, CurrentX, CurrentY, CollisionFlag.WallWest);
+                yield return DecorationCase("rotation 0 north", shape, RotationFor(shape, 0), size, CurrentX, CurrentY + size, CurrentX, CurrentY + size - 1, CollisionFlag.WallNorth);
+                yield return DecorationCase("rotation 1 east", shape, RotationFor(shape, 1), size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY, CollisionFlag.WallEast);
+                yield return DecorationCase("rotation 1 north", shape, RotationFor(shape, 1), size, CurrentX, CurrentY + size, CurrentX, CurrentY + size - 1, CollisionFlag.WallNorth);
+                yield return DecorationCase("rotation 2 east", shape, RotationFor(shape, 2), size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY, CollisionFlag.WallEast);
+                yield return DecorationCase("rotation 2 south", shape, RotationFor(shape, 2), size, CurrentX, CurrentY - 1, CurrentX, CurrentY, CollisionFlag.WallSouth);
+                yield return DecorationCase("rotation 3 west", shape, RotationFor(shape, 3), size, CurrentX - 1, CurrentY, CurrentX, CurrentY, CollisionFlag.WallWest);
+                yield return DecorationCase("rotation 3 south", shape, RotationFor(shape, 3), size, CurrentX, CurrentY - 1, CurrentX, CurrentY, CollisionFlag.WallSouth);
+            }
+
+            yield return DecorationCase("shape 8 south", 8, 0, size, CurrentX, CurrentY - 1, CurrentX, CurrentY, CollisionFlag.WallSouth);
+            yield return DecorationCase("shape 8 north", 8, 1, size, CurrentX, CurrentY + size, CurrentX, CurrentY + size - 1, CollisionFlag.WallNorth);
+            yield return DecorationCase("shape 8 east", 8, 2, size, CurrentX + size, CurrentY, CurrentX + size - 1, CurrentY, CollisionFlag.WallEast);
+            yield return DecorationCase("shape 8 west", 8, 3, size, CurrentX - 1, CurrentY, CurrentX, CurrentY, CollisionFlag.WallWest);
+        }
+    }
+
+    private static DoorInteractionCase DoorCase(string name, int shape, int rotation, int size, int targetX, int targetY, int collisionX, int collisionY) =>
+        new($"size {size}, {name}", shape, rotation, size, targetX, targetY, collisionX, collisionY);
+
+    private static DecorationInteractionCase DecorationCase(
+        string name,
+        int shape,
+        int rotation,
+        int size,
+        int targetX,
+        int targetY,
+        int collisionX,
+        int collisionY,
+        CollisionFlag blockingFlag) =>
+        new($"size {size}, shape {shape}, {name}", shape, rotation, size, targetX, targetY, collisionX, collisionY, blockingFlag);
+
+    private static int RotationFor(int shape, int effectiveRotation) => shape == 7 ? effectiveRotation + 2 & 0x3 : effectiveRotation;
+
+    public sealed record OverlapCase(string Name, int Size, int TargetX, int TargetY);
+
+    public sealed record DoorInteractionCase(
+        string Name,
+        int Shape,
+        int Rotation,
+        int Size,
+        int TargetX,
+        int TargetY,
+        int CollisionX,
+        int CollisionY);
+
+    public sealed record DecorationInteractionCase(
+        string Name,
+        int Shape,
+        int Rotation,
+        int Size,
+        int TargetX,
+        int TargetY,
+        int CollisionX,
+        int CollisionY,
+        CollisionFlag BlockingFlag);
+}

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs
@@ -108,7 +108,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
         {
             if (selfSize != 1)
             {
-                if (fromAbsX <= toAbsX && toAbsX <= selfSize + fromAbsX - 1 && toAbsY <= selfSize + toAbsY - 1)
+                if (fromAbsX <= toAbsX && toAbsX <= selfSize + fromAbsX - 1 && fromAbsY <= toAbsY && toAbsY <= selfSize + fromAbsY - 1)
                     return true;
             }
             else if (fromAbsX == toAbsX && fromAbsY == toAbsY)
@@ -182,7 +182,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
 
                     if (rotation == 0)
                     {
-                        if (toAbsX + 1 == fromAbsX && toAbsY >= fromAbsY && cornerY >= toAbsY && !GetClippingFlag(fromAbsX, toAbsX, z).HasFlag(CollisionFlag.WallWest))
+                        if (toAbsX + 1 == fromAbsX && toAbsY >= fromAbsY && cornerY >= toAbsY && !GetClippingFlag(fromAbsX, toAbsY, z).HasFlag(CollisionFlag.WallWest))
                             return true;
                         if (fromAbsX <= toAbsX && toAbsX <= cornerX && fromAbsY == toAbsY - selfSize && !GetClippingFlag(toAbsX, cornerY, z).HasFlag(CollisionFlag.WallNorth))
                             return true;
@@ -409,7 +409,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
         {
             if (selfSize != 1)
             {
-                if (toAbsX >= currentAbsX && toAbsX <= currentAbsX + (selfSize - 1) && currentAbsY <= toAbsY && toAbsY <= selfSize - 1 + toAbsY)
+                if (toAbsX >= currentAbsX && toAbsX <= currentAbsX + (selfSize - 1) && currentAbsY <= toAbsY && toAbsY <= currentAbsY + (selfSize - 1))
                     return true;
             }
             else if (currentAbsX == toAbsX && currentAbsY == toAbsY)
@@ -429,7 +429,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                         //    return true; // old
                         if (toAbsX - selfSize == currentAbsX && toAbsY >= currentAbsY && toAbsY <= cornerY)
                             return true;
-                        if (currentAbsX <= toAbsX && toAbsX <= cornerX && currentAbsY == toAbsY + 1 && (GetClippingFlagInt(toAbsX, currentAbsX, z) & 0x2c0120) == 0)
+                        if (currentAbsX <= toAbsX && toAbsX <= cornerX && currentAbsY == toAbsY + 1 && (GetClippingFlagInt(toAbsX, currentAbsY, z) & 0x2c0120) == 0)
                             return true;
                         if (toAbsX >= currentAbsX && toAbsX <= cornerX && currentAbsY == toAbsY - selfSize && (GetClippingFlagInt(toAbsX, cornerY, z) & 0x2c0102) == 0)
                             return true;

--- a/openspec/changes/fix-large-entity-interaction-reach/.openspec.yaml
+++ b/openspec/changes/fix-large-entity-interaction-reach/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/fix-large-entity-interaction-reach/design.md
+++ b/openspec/changes/fix-large-entity-interaction-reach/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`PathfinderBase` already owns the shared reach decision for door and decoration targets. Its large-entity branches query the existing clipping map directly, but their early overlap guards only constrain one axis and two branches pass an X coordinate as the clipping-map Y coordinate. There is no focused interaction-reach test suite today; the existing pathfinder tests exercise route steps rather than these public reach methods.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make large-entity overlap a two-dimensional footprint check in both shared reach methods.
+- Query collision from the actual side tile in the two confirmed malformed branches.
+- Establish direct, table-driven regressions for sizes 2 and 3 without making equal coordinates hide an X/Y swap.
+
+**Non-Goals:**
+
+- Do not alter the remaining shape/rotation semantics, size-1 branch, route traversal, or collision flag values.
+- Do not introduce a generic geometry helper or interaction subsystem.
+
+## Decisions
+
+### Keep `PathfinderBase` as the single interaction-reach owner
+
+Correct the existing guards and clipping calls in place. All pathfinder consumers already use these methods, so moving logic to combat or a new reach service would create a second authority and broaden the change beyond #368.
+
+### Express the overlap correction directly
+
+Each large-entity guard will compare target X and Y against the mover origin and inclusive `size - 1` corner. A shared rectangle helper is rejected because it would only conceal two short checks and add an abstraction with no second current owner.
+
+### Characterize branches through the public methods
+
+Use a focused test fixture with the existing substituted `IMapRegionService`, calling `CanDoorInteract` and `CanDecorationInteract` directly. Parameterized cases will cover the existing supported shapes/rotations, size 2 and 3, actual-side blocking, and unrelated collision. The tests will use deliberately distinct X/Y coordinates; they validate behavior rather than reimplementing pathfinding geometry.
+
+### Use the GameClient selectively
+
+Use the coherent client shape/rotation collision lookup as evidence for the corrected door tile `(toAbsX, currentAbsY)`, but derive overlap behavior from ordinary two-dimensional footprint geometry. The client's malformed initial overlap guard is not copied.
+
+## Risks / Trade-offs
+
+- [A rotation matrix can accidentally mask an incorrect coordinate] → Keep X and Y distinct and pair actual-side blocking with an unrelated-tile control for every touched lookup family.
+- [Broader legacy branch defects may be uncovered] → Preserve existing behavior unless a regression demonstrates a defect within this issue's acceptance criteria; record anything else as a follow-up.
+- [Table-driven tests become opaque] → Give each case a descriptive display name with shape, rotation, size, side, and collision condition.
+
+## Migration Plan
+
+No migration or deployment sequencing is required. The change is an in-process logic correction with test coverage; rollback is a normal code rollback.
+
+## Open Questions
+
+None. The scope and intended geometry are fixed by the issue's audited defects.

--- a/openspec/changes/fix-large-entity-interaction-reach/proposal.md
+++ b/openspec/changes/fix-large-entity-interaction-reach/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Large creatures can be reported as already able to interact with decorations and doors when only their X coordinate overlaps the target, because the shared reach guards do not actually bound the Y coordinate. Two large-entity collision lookups also pass an X value as the map Y coordinate, letting unrelated collision tiles affect interaction reach.
+
+## What Changes
+
+- Correct the existing large-entity overlap guards in `PathfinderBase.CanDecorationInteract` and `PathfinderBase.CanDoorInteract` to test both target coordinates against the mover footprint.
+- Correct the confirmed X/Y collision lookup defects in the affected decoration and door rotation-0 branches.
+- Add focused, test-first MSTest coverage for size-2 and size-3 interaction reach, including footprint boundaries, rotations, blocking versus unrelated collision, and size-1 characterization.
+
+### Non-goals
+
+- Do not change path traversal, path compression, combat-specific targeting, collision flag definitions, or size-1 interaction behavior.
+- Do not add a new interaction/pathfinding framework, helper abstraction, dependency, or public API.
+- Do not copy the malformed decompiled-client overlap guard; use direct two-dimensional footprint geometry while using coherent client branches only to validate concrete collision coordinates.
+
+### Acceptance Criteria
+
+- Both large-entity methods only treat a target as overlapping when it lies within the mover footprint on both axes.
+- The affected door lookup reads `(toAbsX, currentAbsY)` and the affected decoration lookup reads the west-side tile using its actual Y coordinate.
+- Sizes 2 and 3 are covered across the supported door and decoration shapes/rotations, with distinct X/Y values, actual-side blocking, and unrelated-collision cases.
+- Size-1 behavior is characterized and remains unchanged.
+
+### Stop Conditions
+
+Pause and record follow-up work if the correction requires changing collision flag definitions, movement/pathfinding algorithms, combat consumers, persisted data, or any behavior beyond interaction reach.
+
+## Capabilities
+
+### New Capabilities
+
+- `large-entity-interaction-reach`: Defines correct footprint and collision-side evaluation when a multi-tile entity checks object or door interaction reach.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/PathfinderBase.cs`
+- A focused GameWorld pathfinder interaction MSTest suite
+- Reuses the existing `PathfinderBase` reach methods and `IMapRegionService` clipping lookups; no API, dependency, or persistence changes.

--- a/openspec/changes/fix-large-entity-interaction-reach/specs/large-entity-interaction-reach/spec.md
+++ b/openspec/changes/fix-large-entity-interaction-reach/specs/large-entity-interaction-reach/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Multi-tile interaction overlap is two-dimensional
+`CanDecorationInteract` and `CanDoorInteract` SHALL treat a target as overlapping a multi-tile mover only when both target coordinates are within that mover's inclusive footprint.
+
+#### Scenario: Target overlaps only one footprint axis
+- **WHEN** a size-2 or size-3 mover has a target whose X is inside its footprint but Y is below or above it, or whose Y is inside its footprint but X is outside it
+- **THEN** the method SHALL not report automatic overlap reach
+
+#### Scenario: Target overlaps both footprint axes
+- **WHEN** a target lies within both X and Y bounds of a size-2 or size-3 mover
+- **THEN** the method SHALL report overlap reach before evaluating approach-side collision
+
+### Requirement: Large door reach uses the approached collision side
+`CanDoorInteract` SHALL evaluate size-2 and size-3 doorway approaches for shapes 0, 2, and 9 using the collision tile on the approached mover side for each supported rotation.
+
+#### Scenario: Door approach is blocked on its actual side
+- **WHEN** the collision flag that blocks a supported size-2 or size-3 door approach is placed on the actual approach-side tile
+- **THEN** the method SHALL reject interaction reach
+
+#### Scenario: Unrelated door collision is ignored
+- **WHEN** the actual approach-side tile is clear and an unrelated tile is blocked
+- **THEN** the method SHALL preserve interaction reach
+
+#### Scenario: Rotation-zero door lookup uses current Y
+- **WHEN** a size-2 or size-3 mover approaches the relevant shape-0 rotation-zero side with distinct X and Y coordinates
+- **THEN** the collision lookup SHALL use the target X and mover current Y coordinates
+
+### Requirement: Large decoration reach uses the approached collision side
+`CanDecorationInteract` SHALL evaluate size-2 and size-3 decoration approaches for shapes 6, 7, and 8 using the collision tile on the approached mover side for each relevant rotation.
+
+#### Scenario: Decoration approach is blocked on its actual side
+- **WHEN** the collision flag that blocks a supported size-2 or size-3 decoration approach is placed on the actual approach-side tile
+- **THEN** the method SHALL reject interaction reach
+
+#### Scenario: Unrelated decoration collision is ignored
+- **WHEN** the actual approach-side tile is clear and an unrelated tile is blocked
+- **THEN** the method SHALL preserve interaction reach
+
+#### Scenario: Rotation-zero decoration lookup uses the west-side Y
+- **WHEN** a size-2 or size-3 mover approaches the relevant shape-6 or shape-7 rotation-zero west side with distinct X and Y coordinates
+- **THEN** the collision lookup SHALL use the mover west-side X and target Y coordinates
+
+### Requirement: Single-tile interaction behavior is preserved
+The system SHALL preserve the existing `selfSize == 1` interaction-reach behavior for the supported door and decoration shapes.
+
+#### Scenario: Existing single-tile approach remains valid
+- **WHEN** a size-1 mover approaches a currently valid supported door or decoration side with clear collision
+- **THEN** the method SHALL continue to report interaction reach

--- a/openspec/changes/fix-large-entity-interaction-reach/tasks.md
+++ b/openspec/changes/fix-large-entity-interaction-reach/tasks.md
@@ -1,0 +1,18 @@
+## 1. Test-first interaction reach regressions
+
+- [x] 1.1 Add a focused `PathfinderBase` interaction-reach fixture using the existing substituted clipping-map service and deliberately distinct X/Y coordinates.
+- [x] 1.2 Add size-2 and size-3 overlap-boundary regressions for `CanDecorationInteract` and `CanDoorInteract`, covering targets inside one axis only and inside both axes.
+- [x] 1.3 Add table-driven door regressions for shapes 0, 2, and 9 across supported rotations, actual-side blocking, unrelated collision, and the rotation-0 `(toAbsX, currentAbsY)` lookup.
+- [x] 1.4 Add table-driven decoration regressions for shapes 6, 7, and 8 across relevant rotations, actual-side blocking, unrelated collision, and the rotation-0 west-side Y lookup.
+- [x] 1.5 Characterize currently valid size-1 door and decoration interaction approaches.
+
+## 2. Shared reach corrections
+
+- [x] 2.1 Correct both large-entity overlap guards to use inclusive X and Y bounds of the mover footprint.
+- [x] 2.2 Correct only the two confirmed large-entity collision lookup coordinates while preserving all remaining branch behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run the new focused regressions before the production correction and confirm they fail for the documented footprint and coordinate defects.
+- [x] 3.2 Run the focused GameWorld tests after the correction and confirm the new regressions and size-1 characterization pass.
+- [x] 3.3 Run the solution build, strict positional OpenSpec validation, and `git diff --check`.


### PR DESCRIPTION
## Summary

- Correct large-entity footprint checks to validate both X and Y bounds.
- Fix two malformed collision lookups that used X coordinates as Y values.
- Add focused MSTest coverage for sizes 2 and 3, supported shapes and rotations, collision-side blocking, unrelated collisions, and preserved size-1 behavior.

## Testing

- Focused GameWorld Pathfinder MSTest regressions pass.
- Solution build, strict OpenSpec validation, and diff checks pass.

Fixes #368