### PR TITLE
Fix SmartPathfinder directional traversal defects for issue #366

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/SmartPathfinderDirectionalTraversalTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/SmartPathfinderDirectionalTraversalTests.cs
@@ -1,0 +1,458 @@
+using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Services.GameWorld.Logic.Pathfinding;
+using NSubstitute;
+using SmartPath = Hagalaz.Services.GameWorld.Logic.Pathfinding.Path;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class SmartPathfinderDirectionalTraversalTests
+{
+    private const int GraphSize = 104;
+    private const int FromX = 50;
+    private const int FromY = 50;
+
+    public sealed record TraversalCell(int XOffset, int YOffset, CollisionFlag MatchingBlocker);
+
+    public sealed record TraversalCase(string Name, int XOffset, int YOffset, TraversalCell[] IncomingCells);
+
+    public enum PositiveDirection
+    {
+        East,
+        North,
+        NorthEast,
+        NorthWest,
+        SouthEast
+    }
+
+    public static IEnumerable<TestDataRow<TraversalCase>> SingleTraversalCases =>
+    [
+        Case("south", 0, -1, [new(0, -1, CollisionFlag.WallAllowRangeNorth)]),
+        Case("west", -1, 0, [new(-1, 0, CollisionFlag.WallAllowRangeEast)]),
+        Case("north", 0, 1, [new(0, 1, CollisionFlag.WallAllowRangeSouth)]),
+        Case("east", 1, 0, [new(1, 0, CollisionFlag.WallAllowRangeWest)]),
+        Case("south-west", -1, -1,
+        [
+            new(-1, -1, CollisionFlag.WallAllowRangeSouthWest),
+            new(-1, 0, CollisionFlag.WallAllowRangeEast),
+            new(0, -1, CollisionFlag.WallAllowRangeNorth)
+        ]),
+        Case("north-west", -1, 1,
+        [
+            new(-1, 1, CollisionFlag.WallAllowRangeNorthWest),
+            new(-1, 0, CollisionFlag.WallAllowRangeEast),
+            new(0, 1, CollisionFlag.WallAllowRangeSouth)
+        ]),
+        Case("south-east", 1, -1,
+        [
+            new(1, -1, CollisionFlag.WallAllowRangeSouthEast),
+            new(1, 0, CollisionFlag.WallAllowRangeWest),
+            new(0, -1, CollisionFlag.WallAllowRangeNorth)
+        ]),
+        Case("north-east", 1, 1,
+        [
+            new(1, 1, CollisionFlag.WallAllowRangeNorthEast),
+            new(1, 0, CollisionFlag.WallAllowRangeWest),
+            new(0, 1, CollisionFlag.WallAllowRangeSouth)
+        ])
+    ];
+
+    public static IEnumerable<TestDataRow<TraversalCase>> DoubleTraversalCases =>
+    [
+        Case("south", 0, -1,
+        [
+            new(0, -1, CollisionFlag.WallAllowRangeSouthWest),
+            new(1, -1, CollisionFlag.WallAllowRangeSouthEast)
+        ]),
+        Case("west", -1, 0,
+        [
+            new(-1, 0, CollisionFlag.WallAllowRangeSouthWest),
+            new(-1, 1, CollisionFlag.WallAllowRangeNorthWest)
+        ]),
+        Case("north", 0, 1,
+        [
+            new(0, 2, CollisionFlag.WallAllowRangeNorthWest),
+            new(1, 2, CollisionFlag.WallAllowRangeNorthEast)
+        ]),
+        Case("east", 1, 0,
+        [
+            new(2, 0, CollisionFlag.WallAllowRangeSouthEast),
+            new(2, 1, CollisionFlag.WallAllowRangeNorthEast)
+        ]),
+        Case("south-west", -1, -1,
+        [
+            new(-1, -1, CollisionFlag.WallAllowRangeSouthWest),
+            new(-1, 0, CollisionFlag.WallAllowRangeNorthWest),
+            new(0, -1, CollisionFlag.WallAllowRangeSouthEast)
+        ]),
+        Case("north-west", -1, 1,
+        [
+            new(-1, 1, CollisionFlag.WallAllowRangeSouthWest),
+            new(-1, 2, CollisionFlag.WallAllowRangeNorthWest),
+            new(0, 2, CollisionFlag.WallAllowRangeNorthEast)
+        ]),
+        Case("south-east", 1, -1,
+        [
+            new(1, -1, CollisionFlag.WallAllowRangeSouthWest),
+            new(2, 0, CollisionFlag.WallAllowRangeNorthEast),
+            new(2, -1, CollisionFlag.WallAllowRangeSouthEast)
+        ]),
+        Case("north-east", 1, 1,
+        [
+            new(1, 2, CollisionFlag.WallAllowRangeNorthWest),
+            new(2, 2, CollisionFlag.WallAllowRangeNorthEast),
+            new(2, 1, CollisionFlag.WallAllowRangeSouthEast)
+        ])
+    ];
+
+    public static IEnumerable<TestDataRow<(int Size, int XOffset, int YOffset)>> VariableDiagonalCases =>
+    [
+        new((3, -1, -1)) { DisplayName = "size 3 south-west" },
+        new((4, -1, -1)) { DisplayName = "size 4 south-west" },
+        new((3, 1, -1)) { DisplayName = "size 3 south-east" },
+        new((4, 1, -1)) { DisplayName = "size 4 south-east" }
+    ];
+
+    public static IEnumerable<TestDataRow<(int Size, PositiveDirection Direction)>> PositiveBoundaryCases =>
+    [
+        new((3, PositiveDirection.East)),
+        new((3, PositiveDirection.North)),
+        new((3, PositiveDirection.NorthEast)),
+        new((3, PositiveDirection.NorthWest)),
+        new((3, PositiveDirection.SouthEast)),
+        new((4, PositiveDirection.East)),
+        new((4, PositiveDirection.North)),
+        new((4, PositiveDirection.NorthEast)),
+        new((4, PositiveDirection.NorthWest)),
+        new((4, PositiveDirection.SouthEast))
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(SingleTraversalCases))]
+    public void Find_SizeOne_ClearDirection_ReconstructsDirectPath(TraversalCase traversal)
+    {
+        var target = TargetFor(traversal);
+        var result = FindWithConstrainedCollision(1, target, traversal.IncomingCells);
+
+        AssertDirectPath(result.Path);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(SingleTraversalCases))]
+    public void Find_SizeOne_MatchingBlocker_PreventsDirectExpansion(TraversalCase traversal)
+    {
+        var target = TargetFor(traversal);
+
+        foreach (var blockedCell in traversal.IncomingCells)
+        {
+            var result = FindWithConstrainedCollision(1, target, traversal.IncomingCells, blockedCell, blockedCell.MatchingBlocker);
+
+            AssertDoesNotTakeDirectExpansion(result.Path);
+        }
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(SingleTraversalCases))]
+    public void Find_SizeOne_NonMatchingDestinationBlocker_DoesNotPreventDirectExpansion(TraversalCase traversal)
+    {
+        var target = TargetFor(traversal);
+        var destination = traversal.IncomingCells[0];
+        var result = FindWithConstrainedCollision(
+            1,
+            target,
+            traversal.IncomingCells,
+            destination,
+            OppositeDirectionalBlocker(destination.MatchingBlocker));
+
+        AssertDirectPath(result.Path);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(DoubleTraversalCases))]
+    public void Find_SizeTwo_ClearIncomingFootprint_ReconstructsDirectPath(TraversalCase traversal)
+    {
+        var target = TargetFor(traversal);
+        var result = FindWithConstrainedCollision(2, target, traversal.IncomingCells);
+
+        AssertDirectPath(result.Path);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(DoubleTraversalCases))]
+    public void Find_SizeTwo_MatchingBlockerOnEveryIncomingCell_PreventsDirectExpansion(TraversalCase traversal)
+    {
+        var target = TargetFor(traversal);
+
+        foreach (var blockedCell in traversal.IncomingCells)
+        {
+            var result = FindWithConstrainedCollision(2, target, traversal.IncomingCells, blockedCell, blockedCell.MatchingBlocker);
+
+            AssertDoesNotTakeDirectExpansion(result.Path);
+        }
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(DoubleTraversalCases))]
+    public void Find_SizeTwo_NonMatchingBlockerOnEveryIncomingCell_DoesNotPreventDirectExpansion(TraversalCase traversal)
+    {
+        var target = TargetFor(traversal);
+
+        foreach (var blockedCell in traversal.IncomingCells)
+        {
+            var result = FindWithConstrainedCollision(
+                2,
+                target,
+                traversal.IncomingCells,
+                blockedCell,
+                OppositeDirectionalBlocker(blockedCell.MatchingBlocker));
+
+            AssertDirectPath(result.Path);
+        }
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(VariableDiagonalCases))]
+    public void Find_VariableSize_DiagonalTraversal_ReconstructsTheCollisionValidatedAnchor(int size, int xOffset, int yOffset)
+    {
+        var target = Location.Create(FromX + xOffset, FromY + yOffset, 0);
+        var result = FindWithConstrainedCollision(size, target, VariableDiagonalIncomingCells(size, xOffset, yOffset));
+
+        AssertDirectPath(result.Path);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(PositiveBoundaryCases))]
+    public void Find_VariableSize_PositiveExpansionBeyondGraphBoundary_IsNotQueuedOrRead(int size, PositiveDirection direction)
+    {
+        var (target, walkableCells) = CreatePositiveBoundaryCorridor(size, direction);
+        var result = FindWithConstrainedCollision(size, target, walkableCells);
+
+        Assert.IsFalse(result.Path.Successful);
+        Assert.IsTrue(result.ClippingLookups.All(cell => cell.X is >= 0 and < GraphSize && cell.Y is >= 0 and < GraphSize));
+    }
+
+    private static TestDataRow<TraversalCase> Case(string name, int xOffset, int yOffset, TraversalCell[] incomingCells) =>
+        new(new TraversalCase(name, xOffset, yOffset, incomingCells)) { DisplayName = name };
+
+    private static Location TargetFor(TraversalCase traversal) => Location.Create(FromX + traversal.XOffset, FromY + traversal.YOffset, 0);
+
+    private static RouteResult FindWithConstrainedCollision(
+        int selfSize,
+        Location target,
+        IEnumerable<TraversalCell> walkableCells,
+        TraversalCell? blockedCell = null,
+        CollisionFlag blocker = CollisionFlag.Walkable)
+    {
+        var clippingFlags = walkableCells
+            .GroupBy(cell => (FromX + cell.XOffset, FromY + cell.YOffset))
+            .ToDictionary(group => group.Key, _ => CollisionFlag.Walkable);
+        if (blockedCell is not null)
+        {
+            clippingFlags[(FromX + blockedCell.XOffset, FromY + blockedCell.YOffset)] = blocker;
+        }
+
+        var clippingLookups = new List<(int X, int Y)>();
+        var mapRegionService = Substitute.For<IMapRegionService>();
+        mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(callInfo =>
+            {
+                var coordinate = (callInfo.ArgAt<int>(0), callInfo.ArgAt<int>(1));
+                clippingLookups.Add(coordinate);
+                return clippingFlags.GetValueOrDefault(coordinate, CollisionFlag.FloorBlock);
+            });
+
+        var pathFinder = new SmartPathFinder(mapRegionService);
+        var path = pathFinder.Find(Location.Create(FromX, FromY, 0), selfSize, target, 0, 0, 0, 0, 0, false);
+
+        return new RouteResult(path, clippingLookups);
+    }
+
+    private static IEnumerable<TraversalCell> VariableDiagonalIncomingCells(int size, int xOffset, int yOffset)
+    {
+        if (xOffset == -1 && yOffset == -1)
+        {
+            yield return new TraversalCell(-1, size - 2, CollisionFlag.Walkable);
+            yield return new TraversalCell(-1, -1, CollisionFlag.Walkable);
+            yield return new TraversalCell(size - 2, -1, CollisionFlag.Walkable);
+
+            for (var i = 1; i < size - 1; i++)
+            {
+                yield return new TraversalCell(-1, i - 1, CollisionFlag.Walkable);
+                yield return new TraversalCell(i - 1, -1, CollisionFlag.Walkable);
+            }
+
+            yield break;
+        }
+
+        if (xOffset == 1 && yOffset == -1)
+        {
+            yield return new TraversalCell(1, -1, CollisionFlag.Walkable);
+            yield return new TraversalCell(size, -1, CollisionFlag.Walkable);
+            yield return new TraversalCell(size, size - 2, CollisionFlag.Walkable);
+
+            for (var i = 1; i < size - 1; i++)
+            {
+                yield return new TraversalCell(size, i - 1, CollisionFlag.Walkable);
+                yield return new TraversalCell(i + 1, -1, CollisionFlag.Walkable);
+            }
+
+            yield break;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(xOffset));
+    }
+
+    private static (Location Target, IEnumerable<TraversalCell> WalkableCells) CreatePositiveBoundaryCorridor(int size, PositiveDirection direction)
+    {
+        var finalAnchor = GraphSize - size;
+        return direction switch
+        {
+            PositiveDirection.East =>
+                (Location.Create(finalAnchor + 1, FromY, 0), CardinalEastCorridor(size, finalAnchor)),
+            PositiveDirection.North =>
+                (Location.Create(FromX, finalAnchor + 1, 0), CardinalNorthCorridor(size, finalAnchor)),
+            PositiveDirection.NorthEast =>
+                (Location.Create(finalAnchor + 1, finalAnchor + 1, 0), DiagonalNorthEastCorridor(size, finalAnchor)),
+            PositiveDirection.NorthWest =>
+                (Location.Create(finalAnchor - 1, finalAnchor + 1, 0), NorthWestBoundaryCorridor(size, finalAnchor)),
+            PositiveDirection.SouthEast =>
+                (Location.Create(finalAnchor + 1, FromY - 1, 0), SouthEastBoundaryCorridor(size, finalAnchor)),
+            _ => throw new ArgumentOutOfRangeException(nameof(direction))
+        };
+    }
+
+    private static IEnumerable<TraversalCell> CardinalEastCorridor(int size, int finalAnchor)
+    {
+        for (var x = FromX; x <= finalAnchor; x++)
+        {
+            for (var y = 0; y < size; y++)
+            {
+                yield return new TraversalCell(x + size - FromX, y, CollisionFlag.Walkable);
+            }
+        }
+    }
+
+    private static IEnumerable<TraversalCell> CardinalNorthCorridor(int size, int finalAnchor)
+    {
+        for (var y = FromY; y <= finalAnchor; y++)
+        {
+            for (var x = 0; x < size; x++)
+            {
+                yield return new TraversalCell(x, y + size - FromY, CollisionFlag.Walkable);
+            }
+        }
+    }
+
+    private static IEnumerable<TraversalCell> DiagonalNorthEastCorridor(int size, int finalAnchor)
+    {
+        for (var anchor = FromX; anchor <= finalAnchor; anchor++)
+        {
+            foreach (var cell in VariableNorthEastIncomingCells(size, anchor, anchor))
+            {
+                yield return cell;
+            }
+        }
+    }
+
+    private static IEnumerable<TraversalCell> NorthWestBoundaryCorridor(int size, int finalAnchor)
+    {
+        for (var anchor = FromX; anchor < finalAnchor; anchor++)
+        {
+            foreach (var cell in VariableNorthEastIncomingCells(size, anchor, anchor))
+            {
+                yield return cell;
+            }
+        }
+
+        foreach (var cell in VariableNorthWestIncomingCells(size, finalAnchor, finalAnchor))
+        {
+            yield return cell;
+        }
+    }
+
+    private static IEnumerable<TraversalCell> SouthEastBoundaryCorridor(int size, int finalAnchor)
+    {
+        for (var anchor = FromX; anchor < finalAnchor; anchor++)
+        {
+            for (var y = 0; y < size; y++)
+            {
+                yield return new TraversalCell(anchor + size - FromX, y, CollisionFlag.Walkable);
+            }
+        }
+
+        foreach (var cell in VariableSouthEastIncomingCells(size, finalAnchor, FromY))
+        {
+            yield return cell;
+        }
+    }
+
+    private static IEnumerable<TraversalCell> VariableNorthEastIncomingCells(int size, int anchorX, int anchorY)
+    {
+        yield return Offset(anchorX + 1, anchorY + size);
+        yield return Offset(anchorX + size, anchorY + size);
+        yield return Offset(anchorX + size, anchorY + 1);
+
+        for (var i = 1; i < size - 1; i++)
+        {
+            yield return Offset(anchorX + i + 1, anchorY + size);
+            yield return Offset(anchorX + size, anchorY + i + 1);
+        }
+    }
+
+    private static IEnumerable<TraversalCell> VariableNorthWestIncomingCells(int size, int anchorX, int anchorY)
+    {
+        yield return Offset(anchorX - 1, anchorY + 1);
+        yield return Offset(anchorX - 1, anchorY + size);
+        yield return Offset(anchorX, anchorY + size);
+
+        for (var i = 1; i < size - 1; i++)
+        {
+            yield return Offset(anchorX - 1, anchorY + i - 1);
+            yield return Offset(anchorX + i - 1, anchorY + size);
+        }
+    }
+
+    private static IEnumerable<TraversalCell> VariableSouthEastIncomingCells(int size, int anchorX, int anchorY)
+    {
+        yield return Offset(anchorX + 1, anchorY - 1);
+        yield return Offset(anchorX + size, anchorY - 1);
+        yield return Offset(anchorX + size, anchorY + size - 2);
+
+        for (var i = 1; i < size - 1; i++)
+        {
+            yield return Offset(anchorX + size, anchorY + i - 1);
+            yield return Offset(anchorX + i + 1, anchorY - 1);
+        }
+    }
+
+    private static TraversalCell Offset(int x, int y) => new(x - FromX, y - FromY, CollisionFlag.Walkable);
+
+    private static CollisionFlag OppositeDirectionalBlocker(CollisionFlag matchingBlocker) => matchingBlocker switch
+    {
+        CollisionFlag.WallAllowRangeNorth => CollisionFlag.WallAllowRangeSouth,
+        CollisionFlag.WallAllowRangeSouth => CollisionFlag.WallAllowRangeNorth,
+        CollisionFlag.WallAllowRangeEast => CollisionFlag.WallAllowRangeWest,
+        CollisionFlag.WallAllowRangeWest => CollisionFlag.WallAllowRangeEast,
+        CollisionFlag.WallAllowRangeSouthWest => CollisionFlag.WallAllowRangeNorthEast,
+        CollisionFlag.WallAllowRangeNorthEast => CollisionFlag.WallAllowRangeSouthWest,
+        CollisionFlag.WallAllowRangeNorthWest => CollisionFlag.WallAllowRangeSouthEast,
+        CollisionFlag.WallAllowRangeSouthEast => CollisionFlag.WallAllowRangeNorthWest,
+        _ => throw new ArgumentOutOfRangeException(nameof(matchingBlocker))
+    };
+
+    private static void AssertDirectPath(IPath path)
+    {
+        Assert.IsTrue(path.Successful);
+        Assert.AreEqual(1, ((SmartPath)path).Steps);
+    }
+
+    private static void AssertDoesNotTakeDirectExpansion(IPath path)
+    {
+        Assert.IsTrue(!path.Successful || ((SmartPath)path).Steps > 1);
+    }
+
+    private sealed record RouteResult(IPath Path, IReadOnlyList<(int X, int Y)> ClippingLookups);
+}

--- a/Hagalaz.Services.GameWorld.Tests/SmartPathfinderDirectionalTraversalTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/SmartPathfinderDirectionalTraversalTests.cs
@@ -4,7 +4,6 @@ using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Services.GameWorld.Logic.Pathfinding;
 using NSubstitute;
-using SmartPath = Hagalaz.Services.GameWorld.Logic.Pathfinding.Path;
 
 namespace Hagalaz.Services.GameWorld.Tests;
 
@@ -200,15 +199,13 @@ public sealed class SmartPathfinderDirectionalTraversalTests
     {
         var target = TargetFor(traversal);
 
-        foreach (var blockedCell in traversal.IncomingCells)
+        foreach (var result in traversal.IncomingCells.Select(blockedCell => FindWithConstrainedCollision(
+                     2,
+                     target,
+                     traversal.IncomingCells,
+                     blockedCell,
+                     OppositeDirectionalBlocker(blockedCell.MatchingBlocker))))
         {
-            var result = FindWithConstrainedCollision(
-                2,
-                target,
-                traversal.IncomingCells,
-                blockedCell,
-                OppositeDirectionalBlocker(blockedCell.MatchingBlocker));
-
             AssertDirectPath(result.Path);
         }
     }
@@ -446,12 +443,12 @@ public sealed class SmartPathfinderDirectionalTraversalTests
     private static void AssertDirectPath(IPath path)
     {
         Assert.IsTrue(path.Successful);
-        Assert.AreEqual(1, ((SmartPath)path).Steps);
+        Assert.AreEqual(1, path.Count());
     }
 
     private static void AssertDoesNotTakeDirectExpansion(IPath path)
     {
-        Assert.IsTrue(!path.Successful || ((SmartPath)path).Steps > 1);
+        Assert.IsTrue(!path.Successful || path.Skip(1).Any());
     }
 
     private sealed record RouteResult(IPath Path, IReadOnlyList<(int X, int Y)> ClippingLookups);

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/SmartPathfinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/SmartPathfinder.cs
@@ -359,7 +359,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
 
                 if (_currentMapX < GraphSize - 1 && _currentMapY > 0 && _directions[_currentMapX + 1, _currentMapY - 1] == 0 &&
-                    (GetClippingFlag(absX + 1, absY - 1, z) & CollisionFlag.TraversableSouthWestBlocked) == 0 &&
+                    (GetClippingFlag(absX + 1, absY - 1, z) & CollisionFlag.TraversableSouthEastBlocked) == 0 &&
                     (GetClippingFlag(absX + 1, absY, z) & CollisionFlag.TraversableEastBlocked) == 0 &&
                     (GetClippingFlag(absX, absY - 1, z) & CollisionFlag.TraversableSouthBlocked) == 0)
                 {
@@ -413,7 +413,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
 
                 if (_currentMapX > 0 && _directions[_currentMapX - 1, _currentMapY] == 0 &&
-                    (GetClippingFlag(absX, absY - 1, z) & CollisionFlag.TraversableSouthWestBlocked) == 0 &&
+                    (GetClippingFlag(absX - 1, absY, z) & CollisionFlag.TraversableSouthWestBlocked) == 0 &&
                     (GetClippingFlag(absX - 1, absY + 1, z) & CollisionFlag.TraversableNorthWestBlocked) == 0)
                 {
                     Check(_currentMapX - 1, _currentMapY, DirectionFlag.West, thisCost);
@@ -421,7 +421,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
 
                 if (_currentMapY < GraphSize - 2 && _directions[_currentMapX, _currentMapY + 1] == 0 &&
                     (GetClippingFlag(absX, absY + 2, z) & CollisionFlag.TraversableNorthWestBlocked) == 0 &&
-                    (GetClippingFlag(absX + 1, absY + 2, z) & CollisionFlag.TraversableNorthWestBlocked) == 0)
+                    (GetClippingFlag(absX + 1, absY + 2, z) & CollisionFlag.TraversableNorthEastBlocked) == 0)
                 {
                     Check(_currentMapX, _currentMapY + 1, DirectionFlag.North, thisCost);
                 }
@@ -532,7 +532,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
                 north:
                 {
-                    if (_currentMapY < GraphSize - 2 && _directions[_currentMapX, _currentMapY + 1] == 0 &&
+                    if (_currentMapY < GraphSize - selfSize && _directions[_currentMapX, _currentMapY + 1] == 0 &&
                         (GetClippingFlag(absX, absY + selfSize, z) & CollisionFlag.TraversableNorthWestBlocked) == 0 &&
                         (GetClippingFlag(absX + (selfSize - 1), absY + selfSize, z) & CollisionFlag.TraversableNorthEastBlocked) == 0)
                     {
@@ -549,7 +549,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
                 east:
                 {
-                    if (_currentMapX < GraphSize - 2 && _directions[_currentMapX + 1, _currentMapY] == 0 &&
+                    if (_currentMapX < GraphSize - selfSize && _directions[_currentMapX + 1, _currentMapY] == 0 &&
                         (GetClippingFlag(absX + selfSize, absY, z) & CollisionFlag.TraversableSouthEastBlocked) == 0 &&
                         (GetClippingFlag(absX + selfSize, absY + (selfSize - 1), z) & CollisionFlag.TraversableNorthEastBlocked) == 0)
                     {
@@ -579,12 +579,12 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                             }
                         }
 
-                        Check(_currentMapX - 1, _currentMapY + 1, DirectionFlag.SouthWest, thisCost);
+                        Check(_currentMapX - 1, _currentMapY - 1, DirectionFlag.SouthWest, thisCost);
                     }
                 }
                 northWest:
                 {
-                    if (_currentMapX > 0 && _currentMapY < GraphSize - 2 && _directions[_currentMapX - 1, _currentMapY + 1] == 0 &&
+                    if (_currentMapX > 0 && _currentMapY < GraphSize - selfSize && _directions[_currentMapX - 1, _currentMapY + 1] == 0 &&
                         (GetClippingFlag(absX - 1, absY + 1, z) & CollisionFlag.TraversableSouthWestBlocked) == 0 &&
                         (GetClippingFlag(absX - 1, absY + selfSize, z) & CollisionFlag.TraversableNorthWestBlocked) == 0 &&
                         (GetClippingFlag(absX, absY + selfSize, z) & CollisionFlag.TraversableNorthEastBlocked) == 0)
@@ -602,7 +602,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
                 southEast:
                 {
-                    if (_currentMapX < GraphSize - 2 && _currentMapY > 0 && _directions[_currentMapX + 1, _currentMapY - 1] == 0 &&
+                    if (_currentMapX < GraphSize - selfSize && _currentMapY > 0 && _directions[_currentMapX + 1, _currentMapY - 1] == 0 &&
                         (GetClippingFlag(absX + 1, absY - 1, z) & CollisionFlag.TraversableSouthWestBlocked) == 0 &&
                         (GetClippingFlag(absX + selfSize, absY - 1, z) & CollisionFlag.TraversableSouthEastBlocked) == 0 &&
                         (GetClippingFlag(absX + selfSize, absY + (selfSize - 2), z) & CollisionFlag.TraversableNorthEastBlocked) == 0)
@@ -615,12 +615,12 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                             }
                         }
 
-                        Check(_currentMapX - 1, _currentMapY + 1, DirectionFlag.SouthEast, thisCost);
+                        Check(_currentMapX + 1, _currentMapY - 1, DirectionFlag.SouthEast, thisCost);
                     }
                 }
                 northEast:
                 {
-                    if (_currentMapX < GraphSize - 2 && _currentMapY < GraphSize - 2 && _directions[_currentMapX + 1, _currentMapY + 1] == 0 &&
+                    if (_currentMapX < GraphSize - selfSize && _currentMapY < GraphSize - selfSize && _directions[_currentMapX + 1, _currentMapY + 1] == 0 &&
                         (GetClippingFlag(absX + 1, absY + selfSize, z) & CollisionFlag.TraversableNorthWestBlocked) == 0 &&
                         (GetClippingFlag(absX + selfSize, absY + selfSize, z) & CollisionFlag.TraversableNorthEastBlocked) == 0 &&
                         (GetClippingFlag(absX + selfSize, absY + 1, z) & CollisionFlag.TraversableSouthEastBlocked) == 0)

--- a/openspec/changes/fix-smart-pathfinder-directional-traversal/.openspec.yaml
+++ b/openspec/changes/fix-smart-pathfinder-directional-traversal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/fix-smart-pathfinder-directional-traversal/design.md
+++ b/openspec/changes/fix-smart-pathfinder-directional-traversal/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`SmartPathFinder` owns breadth-first route expansion for one-tile, two-tile, and variable-size movers. Its existing per-direction branches already contain the collision lookups, queue write, and graph-bound checks required by this change. Issue #366 identifies six local copy/paste defects against the GameClient traversal geometry.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Align the six affected checks with their collision-validated direction and footprint.
+- Keep queued anchors, collision geometry, and `GraphSize` bounds mutually consistent.
+- Add readable route-level regressions that distinguish directional masks and coordinates.
+
+**Non-Goals:**
+
+- Do not replace the BFS, factor it into a new framework, or modify collision flag values.
+- Do not alter `DumbPathFinder`, `PathfinderBase`, movement execution, or client protocol behavior.
+
+## Decisions
+
+### Correct the existing branches in place
+
+Each defect is a wrong flag, coordinate, or bound in `SmartPathFinder`; the existing branch remains the sole owner of that expansion. A new traversal helper or pathfinding implementation is rejected because it would broaden a six-line family of corrections into a second mechanism for BFS geometry.
+
+### Use exclusive traversal bits for mask regressions
+
+Tests use the `WallAllowRange*` bits that belong to one relevant traversal composite, instead of `FloorBlock`, which occurs in every composite and would hide a direction swap. A constrained collision map leaves only the geometry for the branch under test walkable.
+
+### Drive variable-size boundaries through public route finding
+
+Boundary tests build a one-direction corridor to the final valid anchor and request the next invalid anchor. They assert the route fails and clipping lookups remain inside the 104x104 graph. This covers queue behavior and reconstruction through `Find` without exposing private BFS state.
+
+## Risks / Trade-offs
+
+- [A side cell shared by an alternative direction can hide a failed direct expansion] → Assert the direct one-step route length where appropriate, and constrain all non-required cells with `FloorBlock`.
+- [A collision bit common to multiple masks can hide a swapped mask] → Use direction-exclusive `WallAllowRange*` bits for each regression.
+- [A boundary test could only prove failure, not prevent an out-of-graph read] → Record clipping lookups and assert that their local coordinates remain in range.
+
+## Migration Plan
+
+No data migration or deployment sequencing is required. The correction is in-process pathfinding logic; rollback is a normal code rollback.
+
+## Open Questions
+
+None. The audited defects and expected geometry are specified by issue #366.

--- a/openspec/changes/fix-smart-pathfinder-directional-traversal/proposal.md
+++ b/openspec/changes/fix-smart-pathfinder-directional-traversal/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`SmartPathFinder` has six verified direction-specific traversal defects that can apply an incorrect collision mask, inspect a tile outside an incoming footprint, enqueue a tile different from the one it validated, or let a large footprint step beyond the local route graph. These defects can produce illegal routes or prevent valid routes for player and NPC movement.
+
+## What Changes
+
+- Correct the six audited size-1, size-2, and variable-size directional traversal conditions in the existing `SmartPathFinder` BFS.
+- Add direction-specific MSTest regressions that distinguish collision masks and coordinates, including large-footprint graph boundaries.
+- Preserve the existing queue, path reconstruction, and pathfinding architecture.
+
+### Non-goals
+
+- Do not change collision flag definitions, `DumbPathFinder`, path compression, movement execution, or client protocol behavior.
+- Do not introduce a new pathfinding algorithm, abstraction, dependency, or public API.
+- Do not repair unrelated traversal branches discovered outside the six audited defects.
+
+### Acceptance Criteria
+
+- Size-1 southeast uses the southeast destination mask.
+- Size-2 west validates exactly its two incoming west cells, and size-2 north uses distinct northwest and northeast top-edge masks.
+- Variable-size southwest and southeast enqueue the collision-validated adjacent anchors.
+- Variable-size positive expansion bounds prevent sizes 3 and 4 from extending beyond the 104x104 local graph.
+- Direction-specific tests prove size-1 and size-2 collision behavior, and size-3/size-4 directional and boundary behavior.
+
+### Stop Conditions
+
+Pause and record follow-up work if satisfying these criteria requires a change to collision flag definitions, route reconstruction architecture, movement execution, or a pathfinding implementation other than `SmartPathFinder`.
+
+## Capabilities
+
+### New Capabilities
+
+- `smart-pathfinder-directional-traversal`: Correct collision geometry, queue coordinates, and local-graph bounds for the existing smart pathfinder BFS.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/SmartPathfinder.cs`
+- `Hagalaz.Services.GameWorld.Tests/SmartPathfinderTests.cs`
+- Reuses the existing collision flags, `IMapRegionService` clipping lookups, and `SmartPathFinder` BFS with no API, dependency, persistence, or deployment change.

--- a/openspec/changes/fix-smart-pathfinder-directional-traversal/specs/smart-pathfinder-directional-traversal/spec.md
+++ b/openspec/changes/fix-smart-pathfinder-directional-traversal/specs/smart-pathfinder-directional-traversal/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Single-tile traversal uses the direction-specific destination mask
+`SmartPathFinder` SHALL evaluate each single-tile direction with its matching collision destination mask.
+
+#### Scenario: Southeast traversal has a southeast-only blocker
+- **WHEN** the southeast destination has `WallAllowRangeSouthEast` while its cardinal side cells are clear
+- **THEN** the pathfinder SHALL not enqueue the direct southeast expansion
+
+#### Scenario: Other single-tile directions retain their mask mapping
+- **WHEN** a cardinal or diagonal destination has its matching traversal blocker, or a distinct non-matching directional blocker
+- **THEN** only the matching blocker SHALL prevent the direct expansion
+
+### Requirement: Two-tile traversal validates its incoming footprint
+`SmartPathFinder` SHALL check every newly occupied size-two edge or corner tile with its direction-specific collision mask.
+
+#### Scenario: West footprint has a lower and upper incoming cell
+- **WHEN** a size-two mover expands west
+- **THEN** the pathfinder SHALL inspect `(x - 1, y)` with the southwest mask and `(x - 1, y + 1)` with the northwest mask
+
+#### Scenario: North footprint has distinct top-edge masks
+- **WHEN** a size-two mover expands north
+- **THEN** the pathfinder SHALL inspect the left top cell with the northwest mask and the right top cell with the northeast mask
+
+#### Scenario: Each direction-specific size-two blocker is present
+- **WHEN** any newly occupied edge or corner cell for a size-two cardinal or diagonal expansion has its matching directional blocker
+- **THEN** the pathfinder SHALL not enqueue that direct expansion
+
+### Requirement: Variable-size traversal queues its validated anchor
+`SmartPathFinder` SHALL enqueue the adjacent anchor that matches the collision geometry it validated for a variable-size diagonal expansion.
+
+#### Scenario: Southwest anchor is validated
+- **WHEN** a size-three or size-four mover has only a clear southwest incoming footprint
+- **THEN** the reconstructed direct route SHALL end at the southwest adjacent anchor
+
+#### Scenario: Southeast anchor is validated
+- **WHEN** a size-three or size-four mover has only a clear southeast incoming footprint
+- **THEN** the reconstructed direct route SHALL end at the southeast adjacent anchor
+
+### Requirement: Variable-size traversal remains within the local route graph
+`SmartPathFinder` SHALL only enqueue a positive-X or positive-Y variable-size expansion when the resulting full footprint remains inside the 104x104 local route graph.
+
+#### Scenario: Positive edge expansion would exceed the graph
+- **WHEN** a size-three or size-four mover at the final valid east, north, north-east, north-west, or south-east anchor requests the next expansion beyond the graph
+- **THEN** the pathfinder SHALL return no route and SHALL not read clipping data outside the local graph

--- a/openspec/changes/fix-smart-pathfinder-directional-traversal/tasks.md
+++ b/openspec/changes/fix-smart-pathfinder-directional-traversal/tasks.md
@@ -1,0 +1,16 @@
+## 1. Direction-specific regression coverage
+
+- [x] 1.1 Add focused size-one tests for all eight directions, matching blockers, and non-matching blockers.
+- [x] 1.2 Add focused size-two tests for all eight incoming footprints and direction-specific blockers.
+- [x] 1.3 Add size-three and size-four southwest/southeast queue-coordinate and reconstructed-path regressions.
+- [x] 1.4 Add size-three and size-four positive-edge graph-boundary regressions for east, north, north-east, north-west, and south-east.
+
+## 2. Smart pathfinder corrections
+
+- [x] 2.1 Correct the size-one southeast mask, size-two west cells, and size-two north right-edge mask.
+- [x] 2.2 Correct variable-size southwest and southeast queued anchors and positive-direction bounds.
+
+## 3. Verification
+
+- [x] 3.1 Confirm the focused regressions fail before the production correction and pass afterward.
+- [x] 3.2 Run the GameWorld test project, solution build, strict OpenSpec validation, and `git diff --check`.


### PR DESCRIPTION
## Summary

- Correct directional collision masks, coordinates, and graph bounds in `SmartPathFinder`
- Add route-level MSTest regressions for size-1, size-2, and variable-size traversal
- Cover positive graph-boundary behavior for larger movers
- Closes #366

## Testing

Not run (not requested)