### PR TITLE
Fix DumbPathFinder directional traversal for issue #367

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs
@@ -17,8 +17,18 @@ namespace Hagalaz.Services.GameWorld.Tests
         public void Initialize()
         {
             _mapRegionService = Substitute.For<IMapRegionService>();
+            _mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(CollisionFlag.Walkable);
             _pathfinder = new DumbPathFinder(_mapRegionService);
         }
+
+        public static IEnumerable<TestDataRow<TraversalCase>> SingleTraversalCases =>
+            CreateSingleTraversalCases()
+                .Select(testCase => new TestDataRow<TraversalCase>(testCase) { DisplayName = testCase.Name });
+
+        public static IEnumerable<TestDataRow<SizeTwoTraversalCase>> SizeTwoTraversalCases =>
+            CreateSizeTwoTraversalCases()
+                .Select(testCase => new TestDataRow<SizeTwoTraversalCase>(testCase) { DisplayName = testCase.Name });
 
         [TestMethod]
         public void Find_SameStartAndEnd_ReturnsSuccessfulPath()
@@ -137,5 +147,152 @@ namespace Hagalaz.Services.GameWorld.Tests
             Assert.AreEqual(6, y); // Moved north
             Assert.IsTrue(path.Any());
         }
+
+        [TestMethod]
+        [DynamicData(nameof(SingleTraversalCases))]
+        public void Find_SizeOneClearDirection_ReachesRequestedNeighbor(TraversalCase testCase)
+        {
+            // Arrange
+            var from = Location.Create(10, 10, 0);
+            var to = Location.Create(from.X + testCase.DeltaX, from.Y + testCase.DeltaY, from.Z);
+
+            // Act
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            // Assert
+            Assert.IsTrue(path.Successful, testCase.Name);
+            Assert.AreEqual(1, path.Count(), testCase.Name);
+            Assert.AreEqual(to, path.Single(), testCase.Name);
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(SingleTraversalCases))]
+        public void Find_SizeOneMatchingDirectionalBlocker_ReturnsUnsuccessfulPath(TraversalCase testCase)
+        {
+            // Arrange
+            var from = Location.Create(10, 10, 0);
+            var to = Location.Create(from.X + testCase.DeltaX, from.Y + testCase.DeltaY, from.Z);
+            _mapRegionService.GetClippingFlag(to.X, to.Y, to.Z).Returns(testCase.MatchingBlocker);
+
+            // Act
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            // Assert
+            Assert.IsFalse(path.Successful, testCase.Name);
+            Assert.AreEqual(0, path.Count(), testCase.Name);
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(SingleTraversalCases))]
+        public void Find_SizeOneUnrelatedDirectionalBlocker_ReachesRequestedNeighbor(TraversalCase testCase)
+        {
+            // Arrange
+            var from = Location.Create(10, 10, 0);
+            var to = Location.Create(from.X + testCase.DeltaX, from.Y + testCase.DeltaY, from.Z);
+            _mapRegionService.GetClippingFlag(to.X, to.Y, to.Z).Returns(testCase.UnrelatedBlocker);
+
+            // Act
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            // Assert
+            Assert.IsTrue(path.Successful, testCase.Name);
+            Assert.AreEqual(1, path.Count(), testCase.Name);
+            Assert.AreEqual(to, path.Single(), testCase.Name);
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(SizeTwoTraversalCases))]
+        public void Find_SizeTwoClearDirection_ReachesRequestedNeighbor(SizeTwoTraversalCase testCase)
+        {
+            // Arrange
+            var from = Location.Create(10, 10, 0);
+            var to = Location.Create(from.X + testCase.DeltaX, from.Y + testCase.DeltaY, from.Z);
+
+            // Act
+            var path = _pathfinder.Find(from, 2, to, 1, 1, 0, 0, 0, false);
+
+            // Assert
+            Assert.IsTrue(path.Successful, testCase.Name);
+            Assert.AreEqual(1, path.Count(), testCase.Name);
+            Assert.AreEqual(to, path.Single(), testCase.Name);
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(SizeTwoTraversalCases))]
+        public void Find_SizeTwoNewlyOccupiedFootprintBlocker_ReturnsUnsuccessfulPath(SizeTwoTraversalCase testCase)
+        {
+            // Arrange
+            var from = Location.Create(10, 10, 0);
+            var to = Location.Create(from.X + testCase.DeltaX, from.Y + testCase.DeltaY, from.Z);
+            _mapRegionService.GetClippingFlag(
+                    from.X + testCase.CollisionDeltaX,
+                    from.Y + testCase.CollisionDeltaY,
+                    from.Z)
+                .Returns(testCase.BlockingFlag);
+
+            // Act
+            var path = _pathfinder.Find(from, 2, to, 1, 1, 0, 0, 0, false);
+
+            // Assert
+            Assert.IsFalse(path.Successful, testCase.Name);
+            Assert.AreEqual(0, path.Count(), testCase.Name);
+        }
+
+        [TestMethod]
+        [DataRow(3)]
+        [DataRow(4)]
+        public void Find_SizeThreeOrLargerSouthWest_ReachesRequestedNeighbor(int size)
+        {
+            // Arrange
+            var from = Location.Create(10, 10, 0);
+            var to = Location.Create(9, 9, 0);
+
+            // Act
+            var path = _pathfinder.Find(from, size, to, 1, 1, 0, 0, 0, false);
+
+            // Assert
+            Assert.IsTrue(path.Successful);
+            Assert.AreEqual(1, path.Count());
+            Assert.AreEqual(to, path.Single());
+        }
+
+        private static IEnumerable<TraversalCase> CreateSingleTraversalCases()
+        {
+            yield return new TraversalCase("north", 0, 1, CollisionFlag.WallAllowRangeSouth, CollisionFlag.WallAllowRangeNorth);
+            yield return new TraversalCase("north-east", 1, 1, CollisionFlag.WallAllowRangeNorthEast, CollisionFlag.WallAllowRangeNorthWest);
+            yield return new TraversalCase("east", 1, 0, CollisionFlag.WallAllowRangeWest, CollisionFlag.WallAllowRangeEast);
+            yield return new TraversalCase("south-east", 1, -1, CollisionFlag.WallAllowRangeSouthEast, CollisionFlag.WallAllowRangeSouthWest);
+            yield return new TraversalCase("south", 0, -1, CollisionFlag.WallAllowRangeNorth, CollisionFlag.WallAllowRangeSouth);
+            yield return new TraversalCase("south-west", -1, -1, CollisionFlag.WallAllowRangeSouthWest, CollisionFlag.WallAllowRangeSouthEast);
+            yield return new TraversalCase("west", -1, 0, CollisionFlag.WallAllowRangeEast, CollisionFlag.WallAllowRangeWest);
+            yield return new TraversalCase("north-west", -1, 1, CollisionFlag.WallAllowRangeNorthWest, CollisionFlag.WallAllowRangeNorthEast);
+        }
+
+        private static IEnumerable<SizeTwoTraversalCase> CreateSizeTwoTraversalCases()
+        {
+            yield return new SizeTwoTraversalCase("north", 0, 1, 0, 2, CollisionFlag.WallAllowRangeNorthWest);
+            yield return new SizeTwoTraversalCase("north-east", 1, 1, 1, 2, CollisionFlag.WallAllowRangeNorthWest);
+            yield return new SizeTwoTraversalCase("east", 1, 0, 2, 0, CollisionFlag.WallAllowRangeSouthEast);
+            yield return new SizeTwoTraversalCase("south-east", 1, -1, 1, -1, CollisionFlag.WallAllowRangeSouthWest);
+            yield return new SizeTwoTraversalCase("south", 0, -1, 0, -1, CollisionFlag.WallAllowRangeSouthWest);
+            yield return new SizeTwoTraversalCase("south-west", -1, -1, -1, -1, CollisionFlag.WallAllowRangeSouthWest);
+            yield return new SizeTwoTraversalCase("west", -1, 0, -1, 0, CollisionFlag.WallAllowRangeSouthWest);
+            yield return new SizeTwoTraversalCase("north-west", -1, 1, -1, 1, CollisionFlag.WallAllowRangeSouthWest);
+        }
+
+        public sealed record TraversalCase(
+            string Name,
+            int DeltaX,
+            int DeltaY,
+            CollisionFlag MatchingBlocker,
+            CollisionFlag UnrelatedBlocker);
+
+        public sealed record SizeTwoTraversalCase(
+            string Name,
+            int DeltaX,
+            int DeltaY,
+            int CollisionDeltaX,
+            int CollisionDeltaY,
+            CollisionFlag BlockingFlag);
     }
 }

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/DumbPathFinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/DumbPathFinder.cs
@@ -83,7 +83,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
             {
                 if (!IsTraversable(x + 1, y, z, CollisionFlag.TraversableEastBlocked) ||
                     !IsTraversable(x, y + 1, z, CollisionFlag.TraversableNorthBlocked) ||
-                    !IsTraversable(x + 1, y + 1, z, CollisionFlag.TraversableNorthWestBlocked))
+                    !IsTraversable(x + 1, y + 1, z, CollisionFlag.TraversableNorthEastBlocked))
                 {
                     path.Successful = false;
                     return;
@@ -237,7 +237,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
 
                 x--;
-                y++;
+                y--;
             }
             else if (direction == DirectionFlag.West)
             {

--- a/openspec/changes/fix-dumb-pathfinder-directional-traversal/.openspec.yaml
+++ b/openspec/changes/fix-dumb-pathfinder-directional-traversal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/fix-dumb-pathfinder-directional-traversal/proposal.md
+++ b/openspec/changes/fix-dumb-pathfinder-directional-traversal/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+`DumbPathFinder` has localized directional traversal defects: its size-two southwest branch validates southwest geometry but advances northwest, and its size-one northeast branch applies the northwest diagonal collision mask. The current size-one southwest branch already advances to the correct coordinate, but lacks targeted coverage to preserve that behavior. These inconsistencies can create incorrect simple paths and are not detected by the broad empty-diagonal tests.
+
+## What Changes
+
+- Correct the size-two southwest coordinate update and the size-one northeast diagonal mask in the existing `DumbPathFinder`.
+- Add test-first, direction-specific MSTest regressions for size-one traversal and focused size-two footprint checks, while retaining characterization coverage for the existing variable-size southwest behavior.
+- Validate direction and mask semantics against the original GameClient routefinders.
+
+### Non-goals
+
+- Do not change collision flag definitions, `SmartPathFinder`, `PathFinderBase`, movement execution, route representation, or client protocol behavior.
+- Do not introduce a pathfinding abstraction, replacement algorithm, dependency, or public API.
+- Do not correct any directional branch beyond the issue's confirmed defects without recording a separate follow-up.
+
+### Acceptance Criteria
+
+- Size-one southwest resolves to `(x - 1, y - 1)` and remains protected by an explicit regression.
+- Size-two southwest resolves to `(x - 1, y - 1)` after its southwest footprint checks pass.
+- Size-one northeast blocks on `TraversableNorthEastBlocked`, while a northwest-only diagonal blocker does not block it.
+- All eight size-one directions have explicit destination-coordinate, matching-mask, and opposite-mask regressions.
+- Size-two directional movement is covered on empty collision and targeted newly occupied footprint blockers, including southwest.
+- Existing size-three-or-larger southwest behavior remains characterized as `(x - 1, y - 1)`.
+
+### Stop Conditions
+
+Pause and record follow-up work if satisfying these criteria requires changing collision flag definitions, `SmartPathFinder`, route reconstruction, movement execution, or a pathfinding implementation other than `DumbPathFinder`.
+
+## Capabilities
+
+### New Capabilities
+
+- `dumb-pathfinder-directional-traversal`: Correct and regression-test direction-specific simple-path traversal geometry and collision masks.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/DumbPathFinder.cs`
+- `Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs`
+- Reuses `DumbPathFinder`, `CollisionFlag`, `IMapRegionService`, and the existing MSTest/NSubstitute fixture; no API, dependency, persistence, deployment, or migration changes.

--- a/openspec/changes/fix-dumb-pathfinder-directional-traversal/specs/dumb-pathfinder-directional-traversal/spec.md
+++ b/openspec/changes/fix-dumb-pathfinder-directional-traversal/specs/dumb-pathfinder-directional-traversal/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Single-tile traversal preserves compass geometry
+The system SHALL produce the adjacent compass-neighbor point requested by each of the eight `DumbPathFinder` size-one directions when the relevant traversal tiles are clear. A traversal SHALL fail when its matching directional collision composite blocks a required tile and SHALL not fail solely because the opposite directional composite is present on the diagonal destination tile.
+
+#### Scenario: Each clear size-one compass direction reaches its requested neighbor
+- **WHEN** a size-one mover starts one tile from its target in any compass direction and all traversal tiles are clear
+- **THEN** the resulting path SHALL be successful and contain exactly that target coordinate
+
+#### Scenario: Matching size-one directional collision blocks traversal
+- **WHEN** a matching directional collision composite is placed on a required traversal tile for a size-one compass direction
+- **THEN** the resulting path SHALL be unsuccessful and SHALL not add the target coordinate
+
+#### Scenario: Opposite diagonal collision does not control northeast traversal
+- **WHEN** a size-one mover traverses northeast and the northeast destination has only the northwest-exclusive collision bit
+- **THEN** the resulting path SHALL remain successful
+
+#### Scenario: Northeast collision blocks northeast traversal
+- **WHEN** a size-one mover traverses northeast and the northeast destination has the northeast-exclusive collision bit
+- **THEN** the resulting path SHALL be unsuccessful
+
+### Requirement: Size-two traversal advances from the validated footprint
+The system SHALL advance a size-two mover's anchor by the requested compass delta after all newly occupied footprint tiles pass their direction-specific collision checks. In particular, southwest traversal SHALL advance its anchor to `(x - 1, y - 1)`.
+
+#### Scenario: Clear size-two movement reaches each requested neighbor
+- **WHEN** a size-two mover starts one tile from its target in any compass direction and the newly occupied footprint is clear
+- **THEN** the resulting path SHALL be successful and contain exactly that target anchor
+
+#### Scenario: A newly occupied size-two footprint tile blocks traversal
+- **WHEN** a direction-specific collision composite is placed on a newly occupied footprint tile for a size-two movement direction
+- **THEN** the resulting path SHALL be unsuccessful
+
+#### Scenario: Clear size-two southwest advances southwest
+- **WHEN** a size-two mover at `(x, y)` traverses southwest with a clear incoming footprint
+- **THEN** the resulting anchor SHALL be `(x - 1, y - 1)`
+
+### Requirement: Existing variable-size southwest behavior is preserved
+The system SHALL preserve the existing southwest anchor update for movers with size three or larger.
+
+#### Scenario: Clear variable-size southwest advances southwest
+- **WHEN** a size-three-or-larger mover at `(x, y)` traverses southwest with a clear incoming footprint
+- **THEN** the resulting anchor SHALL be `(x - 1, y - 1)`

--- a/openspec/changes/fix-dumb-pathfinder-directional-traversal/tasks.md
+++ b/openspec/changes/fix-dumb-pathfinder-directional-traversal/tasks.md
@@ -1,0 +1,15 @@
+## 1. Test-first directional regressions
+
+- [x] 1.1 Add table-driven size-one `DumbPathFinder` cases for all eight clear compass targets, matching directional blockers, and opposite diagonal blockers using exclusive collision bits.
+- [x] 1.2 Add size-two cases for all eight clear compass targets and targeted blockers on their newly occupied footprint, including the southwest anchor regression.
+- [x] 1.3 Add a size-three-or-larger southwest characterization regression that preserves the current `(x - 1, y - 1)` anchor update.
+
+## 2. Local traversal corrections
+
+- [x] 2.1 Correct the size-one northeast destination check to use the northeast directional collision composite.
+- [x] 2.2 Correct the size-two southwest anchor mutation to decrement both X and Y after validation.
+
+## 3. Verification
+
+- [x] 3.1 Confirm the focused regressions fail before the production corrections and pass afterward.
+- [x] 3.2 Run the GameWorld test project, solution build, strict OpenSpec validation, and `git diff --check`.


### PR DESCRIPTION
## Summary

- Fix northeast diagonal collision-mask validation
- Correct size-two southwest anchor movement
- Add directional regressions for sizes one, two, and larger

Closes #367

## Testing

- GameWorld test project passed
- Solution build passed
- Strict OpenSpec validation passed
- `git diff --check` passed