### PR TITLE
Fix projectile pathfinder collision handling

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
@@ -1,75 +1,269 @@
+using AutoMapper;
+using Hagalaz.Game.Abstractions.Builders.GameObject;
+using Hagalaz.Game.Abstractions.Builders.GroundItem;
 using Hagalaz.Game.Abstractions.Model;
+using Hagalaz.Game.Abstractions.Model.GameObjects;
 using Hagalaz.Game.Abstractions.Model.Maps;
+using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
 using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Game.Extensions;
 using Hagalaz.Services.GameWorld.Logic.Pathfinding;
+using Hagalaz.Services.GameWorld.Model.Maps.Regions;
 using NSubstitute;
 
-namespace Hagalaz.Services.GameWorld.Tests
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class ProjectilePathfinderTests
 {
-    [TestClass]
-    public class ProjectilePathfinderTests
+    private const int OriginX = 50;
+    private const int OriginY = 50;
+    private const int Plane = 0;
+    private const int Dimension = 0;
+
+    public static IEnumerable<TestDataRow<CollisionFlag>> DirectBlockers =>
+    [
+        new(CollisionFlag.FloorBlock) { DisplayName = "floor" },
+        new(CollisionFlag.FloorDecorationBlock) { DisplayName = "floor decoration" },
+        new(CollisionFlag.FloorBlock | CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange)
+        {
+            DisplayName = "floor and range-permissive object"
+        },
+        new(CollisionFlag.FloorDecorationBlock | CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange)
+        {
+            DisplayName = "floor decoration and range-permissive object"
+        }
+    ];
+
+    public static IEnumerable<TestDataRow<StandardObjectCase>> StandardObjectCases =>
+    [
+        new(new StandardObjectCase(
+            "range-permissive",
+            Solid: true,
+            Gateway: false,
+            ExpectedCollision: CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange,
+            ExpectedSuccessful: true)),
+        new(new StandardObjectCase(
+            "high-layer-only",
+            Solid: false,
+            Gateway: false,
+            ExpectedCollision: CollisionFlag.ObjectAllowRange,
+            ExpectedSuccessful: false)),
+        new(new StandardObjectCase(
+            "gateway",
+            Solid: true,
+            Gateway: true,
+            ExpectedCollision: CollisionFlag.ObjectBlock,
+            ExpectedSuccessful: true))
+    ];
+
+    public static IEnumerable<TestDataRow<WallTraversalCase>> CardinalWallCases =>
+    [
+        Case(
+            "rotation 0 east and west",
+            0,
+            new(OriginX - 1, OriginY, OriginX, OriginY, CollisionFlag.WallAllowRangeWest),
+            new(OriginX, OriginY, OriginX - 1, OriginY, CollisionFlag.WallAllowRangeEast)),
+        Case(
+            "rotation 1 north and south",
+            1,
+            new(OriginX, OriginY, OriginX, OriginY + 1, CollisionFlag.WallAllowRangeSouth),
+            new(OriginX, OriginY + 1, OriginX, OriginY, CollisionFlag.WallAllowRangeNorth)),
+        Case(
+            "rotation 2 east and west",
+            2,
+            new(OriginX, OriginY, OriginX + 1, OriginY, CollisionFlag.WallAllowRangeWest),
+            new(OriginX + 1, OriginY, OriginX, OriginY, CollisionFlag.WallAllowRangeEast)),
+        Case(
+            "rotation 3 north and south",
+            3,
+            new(OriginX, OriginY - 1, OriginX, OriginY, CollisionFlag.WallAllowRangeSouth),
+            new(OriginX, OriginY, OriginX, OriginY - 1, CollisionFlag.WallAllowRangeNorth))
+    ];
+
+    public static IEnumerable<TestDataRow<DiagonalWallCase>> DiagonalWallCases =>
+    [
+        new(new DiagonalWallCase("north-west", 0, OriginX + 1, OriginY - 1, CollisionFlag.WallAllowRangeNorthWest)),
+        new(new DiagonalWallCase("north-east", 1, OriginX - 1, OriginY - 1, CollisionFlag.WallAllowRangeNorthEast)),
+        new(new DiagonalWallCase("south-east", 2, OriginX - 1, OriginY + 1, CollisionFlag.WallAllowRangeSouthEast)),
+        new(new DiagonalWallCase("south-west", 3, OriginX + 1, OriginY + 1, CollisionFlag.WallAllowRangeSouthWest))
+    ];
+
+    [TestMethod]
+    public void Find_EmptyTiles_ReturnsSuccessfulPath()
     {
-        private ProjectilePathFinder _pathfinder;
-        private IMapRegionService _mapRegionService;
+        var destination = Location.Create(OriginX + 2, OriginY, Plane, Dimension);
 
-        [TestInitialize]
-        public void Initialize()
+        var path = Find(new Dictionary<(int X, int Y), CollisionFlag>(), Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+        Assert.AreEqual(destination, path.Last());
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(DirectBlockers))]
+    public void Find_DirectProjectileBlocker_ReturnsUnsuccessfulPath(CollisionFlag blocker)
+    {
+        var destination = Location.Create(OriginX + 1, OriginY, Plane, Dimension);
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>
         {
-            _mapRegionService = Substitute.For<IMapRegionService>();
-            _mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(CollisionFlag.Walkable);
-            _pathfinder = new ProjectilePathFinder(_mapRegionService);
-        }
+            [(destination.X, destination.Y)] = blocker
+        };
 
-        [TestMethod]
-        public void Find_SimplePath_ReturnsSuccessfulPath()
+        var path = Find(collision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsFalse(path.Successful);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(StandardObjectCases))]
+    public void Find_StandardObjectWriter_UsesItsProjectileLayer(StandardObjectCase testCase)
+    {
+        var collision = WriteStandardObject(testCase.Solid, testCase.Gateway);
+        var destination = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var emittedFlags = collision[(destination.X, destination.Y)];
+
+        Assert.AreEqual(
+            testCase.ExpectedCollision,
+            emittedFlags & (CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange));
+
+        var path = Find(collision, Location.Create(OriginX - 1, OriginY, Plane, Dimension), destination);
+
+        Assert.AreEqual(testCase.ExpectedSuccessful, path.Successful);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(CardinalWallCases))]
+    public void Find_CardinalWallWriter_BlocksProjectileTraversalFromBothSides(WallTraversalCase testCase)
+    {
+        var collision = WriteWall(ShapeType.Wall, testCase.Rotation);
+
+        foreach (var route in testCase.Routes)
         {
-            // Arrange
-            var from = Location.Create(1, 1, 0);
-            var to = Location.Create(3, 1, 0);
+            Assert.IsTrue((collision[(route.ToX, route.ToY)] & route.ExpectedBlocker) != 0);
 
-            // Act
-            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+            var path = Find(
+                collision,
+                Location.Create(route.FromX, route.FromY, Plane, Dimension),
+                Location.Create(route.ToX, route.ToY, Plane, Dimension));
 
-            // Assert
-            Assert.IsTrue(path.Successful);
-            Assert.IsTrue(path.Any());
-            Assert.AreEqual(to, path.Last());
-        }
-
-        [TestMethod]
-        public void Find_PathBlockedByObjectAllowingRange_ReturnsSuccessfulPath()
-        {
-            // Arrange
-            var from = Location.Create(1, 1, 0);
-            var to = Location.Create(3, 1, 0);
-
-            // Block the path with an object that allows ranged attacks over it
-            _mapRegionService.GetClippingFlag(2, 1, 0).Returns(CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange);
-
-            // Act
-            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
-
-            // Assert
-            Assert.IsTrue(path.Successful);
-            Assert.IsTrue(path.Any());
-            Assert.AreEqual(to, path.Last());
-        }
-
-        [TestMethod]
-        public void Find_PathBlockedByFloor_ReturnsUnsuccessfulPath()
-        {
-            // Arrange
-            var from = Location.Create(1, 1, 0);
-            var to = Location.Create(3, 1, 0);
-
-            // Block the path with a solid wall
-            _mapRegionService.GetClippingFlag(2, 1, 0).Returns(CollisionFlag.FloorBlock);
-
-            // Act
-            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
-
-            // Assert
-            Assert.IsFalse(path.Successful);
+            Assert.IsFalse(path.Successful, $"{testCase.Name} should block the route to ({route.ToX}, {route.ToY}).");
         }
     }
+
+    [TestMethod]
+    [DynamicData(nameof(DiagonalWallCases))]
+    public void Find_DiagonalWallWriter_BlocksProjectileTraversal(DiagonalWallCase testCase)
+    {
+        var collision = WriteWall(ShapeType.WallCorner, testCase.Rotation);
+        var destination = Location.Create(OriginX, OriginY, Plane, Dimension);
+
+        Assert.IsTrue((collision[(destination.X, destination.Y)] & testCase.ExpectedBlocker) != 0);
+
+        var path = Find(collision, Location.Create(testCase.FromX, testCase.FromY, Plane, Dimension), destination);
+
+        Assert.IsFalse(path.Successful);
+    }
+
+    [TestMethod]
+    public void Find_ClearSouthWestStep_EndsAtTheSouthWestTile()
+    {
+        var from = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var destination = Location.Create(OriginX - 1, OriginY - 1, Plane, Dimension);
+
+        var path = Find(new Dictionary<(int X, int Y), CollisionFlag>(), from, destination);
+
+        Assert.IsTrue(path.Successful);
+        Assert.HasCount(1, path);
+        Assert.AreEqual(destination, path.Single());
+    }
+
+    private static TestDataRow<WallTraversalCase> Case(string name, int rotation, params Route[] routes) =>
+        new(new WallTraversalCase(name, rotation, routes)) { DisplayName = name };
+
+    private static IPath Find(
+        IReadOnlyDictionary<(int X, int Y), CollisionFlag> collision,
+        Location from,
+        Location destination)
+    {
+        var mapRegionService = Substitute.For<IMapRegionService>();
+        mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(callInfo => collision.GetValueOrDefault((callInfo.ArgAt<int>(0), callInfo.ArgAt<int>(1)), CollisionFlag.Walkable));
+
+        return new ProjectilePathFinder(mapRegionService).Find(from, 1, destination, 1, 1, 0, 0, 0, false);
+    }
+
+    private static Dictionary<(int X, int Y), CollisionFlag> WriteStandardObject(bool solid, bool gateway) =>
+        WriteCollision(ShapeType.GroundDefault, 0, solid, gateway);
+
+    private static Dictionary<(int X, int Y), CollisionFlag> WriteWall(ShapeType shapeType, int rotation) =>
+        WriteCollision(shapeType, rotation, solid: true, gateway: false);
+
+    private static Dictionary<(int X, int Y), CollisionFlag> WriteCollision(
+        ShapeType shapeType,
+        int rotation,
+        bool solid,
+        bool gateway)
+    {
+        var mapRegionService = Substitute.For<IMapRegionService>();
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>();
+        mapRegionService.When(service => service.FlagCollision(Arg.Any<ILocation>(), Arg.Any<CollisionFlag>()))
+            .Do(callInfo =>
+            {
+                var location = callInfo.Arg<ILocation>()!;
+                var coordinate = (location.X, location.Y);
+                collision[coordinate] = collision.GetValueOrDefault(coordinate, CollisionFlag.Walkable) | callInfo.Arg<CollisionFlag>();
+            });
+
+        var region = new MapRegion(
+            Location.Zero,
+            new int[4],
+            Substitute.For<INpcService>(),
+            mapRegionService,
+            Substitute.For<IGameObjectBuilder>(),
+            Substitute.For<IGroundItemBuilder>(),
+            Substitute.For<IMapper>());
+        var gameObject = CreateGameObject(shapeType, rotation, solid, gateway);
+
+        if (shapeType.GetLayerType() == LayerType.StandardObjects)
+        {
+            region.FlagStandardObject(gameObject);
+        }
+        else
+        {
+            region.FlagWallObject(gameObject);
+        }
+
+        return collision;
+    }
+
+    private static IGameObject CreateGameObject(ShapeType shapeType, int rotation, bool solid, bool gateway)
+    {
+        var definition = Substitute.For<IGameObjectDefinition>();
+        definition.ClipType.Returns(1);
+        definition.Solid.Returns(solid);
+        definition.Gateway.Returns(gateway);
+        definition.SizeX.Returns(1);
+        definition.SizeY.Returns(1);
+
+        var gameObject = Substitute.For<IGameObject>();
+        gameObject.ShapeType.Returns(shapeType);
+        gameObject.Rotation.Returns(rotation);
+        gameObject.Location.Returns(Location.Create(OriginX, OriginY, Plane, Dimension));
+        gameObject.Definition.Returns(definition);
+        return gameObject;
+    }
+
+    public sealed record StandardObjectCase(
+        string Name,
+        bool Solid,
+        bool Gateway,
+        CollisionFlag ExpectedCollision,
+        bool ExpectedSuccessful);
+
+    public sealed record WallTraversalCase(string Name, int Rotation, IReadOnlyList<Route> Routes);
+
+    public sealed record DiagonalWallCase(string Name, int Rotation, int FromX, int FromY, CollisionFlag ExpectedBlocker);
+
+    public readonly record struct Route(int FromX, int FromY, int ToX, int ToY, CollisionFlag ExpectedBlocker);
 }

--- a/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
@@ -20,73 +20,102 @@ public sealed class ProjectilePathfinderTests
     private const int OriginY = 50;
     private const int Plane = 0;
     private const int Dimension = 0;
-
-    public static IEnumerable<TestDataRow<CollisionFlag>> DirectBlockers =>
-    [
-        new(CollisionFlag.FloorBlock) { DisplayName = "floor" },
-        new(CollisionFlag.FloorDecorationBlock) { DisplayName = "floor decoration" },
-        new(CollisionFlag.FloorBlock | CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange)
-        {
-            DisplayName = "floor and range-permissive object"
-        },
-        new(CollisionFlag.FloorDecorationBlock | CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange)
-        {
-            DisplayName = "floor decoration and range-permissive object"
-        }
-    ];
+    private static readonly IReadOnlyDictionary<(int X, int Y), CollisionFlag> EmptyCollision = new Dictionary<(int X, int Y), CollisionFlag>();
 
     public static IEnumerable<TestDataRow<StandardObjectCase>> StandardObjectCases =>
     [
         new(new StandardObjectCase(
-            "range-permissive",
+            "solid non-gateway",
             Solid: true,
             Gateway: false,
             ExpectedCollision: CollisionFlag.ObjectBlock | CollisionFlag.ObjectAllowRange,
-            ExpectedSuccessful: true)),
-        new(new StandardObjectCase(
-            "high-layer-only",
-            Solid: false,
-            Gateway: false,
-            ExpectedCollision: CollisionFlag.ObjectAllowRange,
             ExpectedSuccessful: false)),
         new(new StandardObjectCase(
-            "gateway",
+            "solid gateway",
             Solid: true,
             Gateway: true,
             ExpectedCollision: CollisionFlag.ObjectBlock,
+            ExpectedSuccessful: false)),
+        new(new StandardObjectCase(
+            "non-solid non-gateway",
+            Solid: false,
+            Gateway: false,
+            ExpectedCollision: CollisionFlag.ObjectAllowRange,
+            ExpectedSuccessful: true)),
+        new(new StandardObjectCase(
+            "non-solid gateway",
+            Solid: false,
+            Gateway: true,
+            ExpectedCollision: CollisionFlag.Walkable,
             ExpectedSuccessful: true))
     ];
 
-    public static IEnumerable<TestDataRow<WallTraversalCase>> CardinalWallCases =>
+    public static IEnumerable<TestDataRow<GatewayWallCase>> CardinalGatewayWallCases =>
     [
-        Case(
+        WallCase(
             "rotation 0 east and west",
             0,
-            new(OriginX - 1, OriginY, OriginX, OriginY, CollisionFlag.WallAllowRangeWest),
-            new(OriginX, OriginY, OriginX - 1, OriginY, CollisionFlag.WallAllowRangeEast)),
-        Case(
+            new(OriginX - 1, OriginY, OriginX, OriginY, CollisionFlag.BlockedWest),
+            new(OriginX, OriginY, OriginX - 1, OriginY, CollisionFlag.BlockedEast)),
+        WallCase(
             "rotation 1 north and south",
             1,
-            new(OriginX, OriginY, OriginX, OriginY + 1, CollisionFlag.WallAllowRangeSouth),
-            new(OriginX, OriginY + 1, OriginX, OriginY, CollisionFlag.WallAllowRangeNorth)),
-        Case(
+            new(OriginX, OriginY, OriginX, OriginY + 1, CollisionFlag.BlockedSouth),
+            new(OriginX, OriginY + 1, OriginX, OriginY, CollisionFlag.BlockedNorth)),
+        WallCase(
             "rotation 2 east and west",
             2,
-            new(OriginX, OriginY, OriginX + 1, OriginY, CollisionFlag.WallAllowRangeWest),
-            new(OriginX + 1, OriginY, OriginX, OriginY, CollisionFlag.WallAllowRangeEast)),
-        Case(
+            new(OriginX, OriginY, OriginX + 1, OriginY, CollisionFlag.BlockedWest),
+            new(OriginX + 1, OriginY, OriginX, OriginY, CollisionFlag.BlockedEast)),
+        WallCase(
             "rotation 3 north and south",
             3,
-            new(OriginX, OriginY - 1, OriginX, OriginY, CollisionFlag.WallAllowRangeSouth),
-            new(OriginX, OriginY, OriginX, OriginY - 1, CollisionFlag.WallAllowRangeNorth))
+            new(OriginX, OriginY - 1, OriginX, OriginY, CollisionFlag.BlockedSouth),
+            new(OriginX, OriginY, OriginX, OriginY - 1, CollisionFlag.BlockedNorth))
+    ];
+
+    public static IEnumerable<TestDataRow<AsymmetricRayCase>> AsymmetricRays =>
+    [
+        new(new AsymmetricRayCase(
+            "north-east",
+            5,
+            2,
+            [new(1, 0), new(2, 0), new(2, 1), new(3, 1), new(4, 1), new(4, 2), new(5, 2)])),
+        new(new AsymmetricRayCase(
+            "south-west",
+            -5,
+            -2,
+            [new(-1, 0), new(-2, 0), new(-2, -1), new(-3, -1), new(-4, -1), new(-4, -2), new(-5, -2)])),
+        new(new AsymmetricRayCase(
+            "steep north-east",
+            2,
+            5,
+            [new(0, 1), new(0, 2), new(1, 2), new(1, 3), new(1, 4), new(2, 4), new(2, 5)])),
+        new(new AsymmetricRayCase(
+            "steep south-west",
+            -2,
+            -5,
+            [new(0, -1), new(0, -2), new(-1, -2), new(-1, -3), new(-1, -4), new(-2, -4), new(-2, -5)]))
+    ];
+
+    public static IEnumerable<TestDataRow<(int DeltaX, int DeltaY)>> SlopeQuadrants =>
+    [
+        new((5, 2)), new((5, -2)), new((-5, 2)), new((-5, -2)),
+        new((2, 5)), new((2, -5)), new((-2, 5)), new((-2, -5))
+    ];
+
+    public static IEnumerable<TestDataRow<RayBlockerCase>> AsymmetricRayBlockers =>
+    [
+        new(new RayBlockerCase("x boundary", 1, 0, CollisionFlag.BlockedWest)),
+        new(new RayBlockerCase("y boundary", 2, 1, CollisionFlag.BlockedSouth))
     ];
 
     public static IEnumerable<TestDataRow<DiagonalWallCase>> DiagonalWallCases =>
     [
-        new(new DiagonalWallCase("north-west", 0, OriginX + 1, OriginY - 1, CollisionFlag.WallAllowRangeNorthWest)),
-        new(new DiagonalWallCase("north-east", 1, OriginX - 1, OriginY - 1, CollisionFlag.WallAllowRangeNorthEast)),
-        new(new DiagonalWallCase("south-east", 2, OriginX - 1, OriginY + 1, CollisionFlag.WallAllowRangeSouthEast)),
-        new(new DiagonalWallCase("south-west", 3, OriginX + 1, OriginY + 1, CollisionFlag.WallAllowRangeSouthWest))
+        new(new DiagonalWallCase("corner north-west", ShapeType.WallCorner, 0, 1, -1, CollisionFlag.BlockedNorthWest)),
+        new(new DiagonalWallCase("corner north-east", ShapeType.WallCorner, 1, -1, -1, CollisionFlag.BlockedNorthEast)),
+        new(new DiagonalWallCase("corner south-east", ShapeType.WallCornerDiagonal, 2, -1, 1, CollisionFlag.BlockedSouthEast)),
+        new(new DiagonalWallCase("corner south-west", ShapeType.WallCornerDiagonal, 3, 1, 1, CollisionFlag.BlockedSouthWest))
     ];
 
     [TestMethod]
@@ -94,30 +123,15 @@ public sealed class ProjectilePathfinderTests
     {
         var destination = Location.Create(OriginX + 2, OriginY, Plane, Dimension);
 
-        var path = Find(new Dictionary<(int X, int Y), CollisionFlag>(), Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+        var path = Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
 
         Assert.IsTrue(path.Successful);
         Assert.AreEqual(destination, path.Last());
     }
 
     [TestMethod]
-    [DynamicData(nameof(DirectBlockers))]
-    public void Find_DirectProjectileBlocker_ReturnsUnsuccessfulPath(CollisionFlag blocker)
-    {
-        var destination = Location.Create(OriginX + 1, OriginY, Plane, Dimension);
-        var collision = new Dictionary<(int X, int Y), CollisionFlag>
-        {
-            [(destination.X, destination.Y)] = blocker
-        };
-
-        var path = Find(collision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
-
-        Assert.IsFalse(path.Successful);
-    }
-
-    [TestMethod]
     [DynamicData(nameof(StandardObjectCases))]
-    public void Find_StandardObjectWriter_UsesItsProjectileLayer(StandardObjectCase testCase)
+    public void Find_StandardObjectWriter_UsesTheLineOfSightLayer(StandardObjectCase testCase)
     {
         var collision = WriteStandardObject(testCase.Solid, testCase.Gateway);
         var destination = Location.Create(OriginX, OriginY, Plane, Dimension);
@@ -133,14 +147,16 @@ public sealed class ProjectilePathfinderTests
     }
 
     [TestMethod]
-    [DynamicData(nameof(CardinalWallCases))]
-    public void Find_CardinalWallWriter_BlocksProjectileTraversalFromBothSides(WallTraversalCase testCase)
+    [DynamicData(nameof(CardinalGatewayWallCases))]
+    public void Find_GatewayWallWriter_BlocksLineOfSightFromBothSides(GatewayWallCase testCase)
     {
-        var collision = WriteWall(ShapeType.Wall, testCase.Rotation);
+        var collision = WriteWall(ShapeType.Wall, testCase.Rotation, solid: true, gateway: true);
 
         foreach (var route in testCase.Routes)
         {
-            Assert.IsTrue((collision[(route.ToX, route.ToY)] & route.ExpectedBlocker) != 0);
+            var emittedFlags = collision[(route.ToX, route.ToY)];
+            Assert.IsTrue((emittedFlags & route.ExpectedBlocker) != 0);
+            Assert.IsFalse((emittedFlags & RangeLayerMask) != 0);
 
             var path = Find(
                 collision,
@@ -152,52 +168,198 @@ public sealed class ProjectilePathfinderTests
     }
 
     [TestMethod]
-    [DynamicData(nameof(DiagonalWallCases))]
-    public void Find_DiagonalWallWriter_BlocksProjectileTraversal(DiagonalWallCase testCase)
+    public void Find_HighRoutingWallWithoutMiddleLineOfSightLayer_ReturnsSuccessfulPath()
     {
-        var collision = WriteWall(ShapeType.WallCorner, testCase.Rotation);
+        var collision = WriteWall(ShapeType.Wall, rotation: 0, solid: false, gateway: false);
         var destination = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var emittedFlags = collision[(destination.X, destination.Y)];
 
-        Assert.IsTrue((collision[(destination.X, destination.Y)] & testCase.ExpectedBlocker) != 0);
+        Assert.IsTrue((emittedFlags & CollisionFlag.WallAllowRangeWest) != 0);
+        Assert.IsFalse((emittedFlags & CollisionFlag.BlockedWest) != 0);
 
-        var path = Find(collision, Location.Create(testCase.FromX, testCase.FromY, Plane, Dimension), destination);
+        var path = Find(collision, Location.Create(OriginX - 1, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(DiagonalWallCases))]
+    public void Find_DiagonalWallWriter_BlocksLineOfSightInCorrespondingGeometry(DiagonalWallCase testCase)
+    {
+        var collision = WriteWall(testCase.ShapeType, testCase.Rotation, solid: true, gateway: true);
+        var destination = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var emittedFlags = collision[(destination.X, destination.Y)];
+
+        Assert.IsTrue((emittedFlags & testCase.ExpectedBlocker) != 0);
+        Assert.IsFalse((emittedFlags & RangeLayerMask) != 0);
+
+        var path = Find(
+            collision,
+            Location.Create(OriginX + testCase.FromOffsetX, OriginY + testCase.FromOffsetY, Plane, Dimension),
+            destination);
 
         Assert.IsFalse(path.Successful);
     }
 
     [TestMethod]
-    public void Find_ClearSouthWestStep_EndsAtTheSouthWestTile()
+    [DataRow(CollisionFlag.FloorBlock)]
+    [DataRow(CollisionFlag.FloorDecorationBlock)]
+    public void Find_MovementOnlyCollision_ReturnsSuccessfulPath(CollisionFlag collisionFlag)
+    {
+        var destination = Location.Create(OriginX + 1, OriginY, Plane, Dimension);
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>
+        {
+            [(destination.X, destination.Y)] = collisionFlag
+        };
+
+        var path = Find(collision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+    }
+
+    [TestMethod]
+    [DataRow(CollisionFlag.ObjectBlock | CollisionFlag.FloorBlock)]
+    [DataRow(CollisionFlag.BlockedWest | CollisionFlag.FloorDecorationBlock)]
+    public void Find_LineOfSightBlockerWithMovementFlags_ReturnsUnsuccessfulPath(CollisionFlag collisionFlag)
+    {
+        var destination = Location.Create(OriginX + 1, OriginY, Plane, Dimension);
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>
+        {
+            [(destination.X, destination.Y)] = collisionFlag
+        };
+
+        var path = Find(collision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsFalse(path.Successful);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(AsymmetricRays))]
+    public void Find_AsymmetricRay_FollowsFixedPointCrossings(AsymmetricRayCase testCase)
     {
         var from = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var destination = Location.Create(OriginX + testCase.DeltaX, OriginY + testCase.DeltaY, Plane, Dimension);
+        var expectedTrace = testCase.Crossings
+            .Select(crossing => Location.Create(OriginX + crossing.X, OriginY + crossing.Y, Plane, Dimension))
+            .ToArray();
+
+        var (path, inspectedTiles) = FindWithInspectedTiles(EmptyCollision, from, destination);
+
+        Assert.IsTrue(path.Successful);
+        CollectionAssert.AreEqual(expectedTrace, inspectedTiles.ToArray());
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(SlopeQuadrants))]
+    public void Find_AsymmetricRayAcrossEveryQuadrant_ReturnsSuccessfulPath((int DeltaX, int DeltaY) slope)
+    {
+        var destination = Location.Create(OriginX + slope.DeltaX, OriginY + slope.DeltaY, Plane, Dimension);
+
+        var path = Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(AsymmetricRayBlockers))]
+    public void Find_AsymmetricRay_CrossedLineOfSightBoundaryReturnsUnsuccessfulPath(RayBlockerCase testCase)
+    {
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>
+        {
+            [(OriginX + testCase.XOffset, OriginY + testCase.YOffset)] = testCase.Blocker
+        };
+        var destination = Location.Create(OriginX + 5, OriginY + 2, Plane, Dimension);
+
+        var path = Find(collision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsFalse(path.Successful);
+    }
+
+    [TestMethod]
+    public void Find_DifferentPlanes_ReturnsUnsuccessfulPath()
+    {
+        var path = Find(
+            EmptyCollision,
+            Location.Create(OriginX, OriginY, Plane, Dimension),
+            Location.Create(OriginX + 1, OriginY, Plane + 1, Dimension));
+
+        Assert.IsFalse(path.Successful);
+    }
+
+    [TestMethod]
+    [DataRow(2, 0)]
+    [DataRow(0, 2)]
+    [DataRow(2, 2)]
+    [DataRow(-2, -2)]
+    public void Find_AxisAlignedAndFortyFiveDegreeRay_ReturnsSuccessfulPath(int deltaX, int deltaY)
+    {
+        var destination = Location.Create(OriginX + deltaX, OriginY + deltaY, Plane, Dimension);
+
+        var path = Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+    }
+
+    [TestMethod]
+    public void Find_OldDiagonalStaircaseOnlyObstacle_ReturnsSuccessfulPath()
+    {
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>
+        {
+            [(OriginX + 1, OriginY + 1)] = CollisionFlag.ObjectBlock
+        };
+        var destination = Location.Create(OriginX + 5, OriginY + 2, Plane, Dimension);
+
+        var path = Find(collision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+    }
+
+    [TestMethod]
+    public void Find_ClearSouthWestRay_AppendsOnlyTheSouthWestTile()
+    {
         var destination = Location.Create(OriginX - 1, OriginY - 1, Plane, Dimension);
 
-        var path = Find(new Dictionary<(int X, int Y), CollisionFlag>(), from, destination);
+        var path = Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
 
         Assert.IsTrue(path.Successful);
         Assert.HasCount(1, path);
         Assert.AreEqual(destination, path.Single());
     }
 
-    private static TestDataRow<WallTraversalCase> Case(string name, int rotation, params Route[] routes) =>
-        new(new WallTraversalCase(name, rotation, routes)) { DisplayName = name };
+    private static TestDataRow<GatewayWallCase> WallCase(string name, int rotation, params Route[] routes) =>
+        new(new GatewayWallCase(name, rotation, routes)) { DisplayName = name };
 
     private static IPath Find(
         IReadOnlyDictionary<(int X, int Y), CollisionFlag> collision,
         Location from,
+        Location destination) => FindWithInspectedTiles(collision, from, destination).Path;
+
+    private static (IPath Path, IReadOnlyList<Location> InspectedTiles) FindWithInspectedTiles(
+        IReadOnlyDictionary<(int X, int Y), CollisionFlag> collision,
+        Location from,
         Location destination)
     {
+        var inspectedTiles = new List<Location>();
         var mapRegionService = Substitute.For<IMapRegionService>();
         mapRegionService.GetClippingFlag(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
-            .Returns(callInfo => collision.GetValueOrDefault((callInfo.ArgAt<int>(0), callInfo.ArgAt<int>(1)), CollisionFlag.Walkable));
+            .Returns(callInfo =>
+            {
+                var x = callInfo.ArgAt<int>(0);
+                var y = callInfo.ArgAt<int>(1);
+                var z = callInfo.ArgAt<int>(2);
+                inspectedTiles.Add(Location.Create(x, y, z, Dimension));
+                return collision.GetValueOrDefault((x, y), CollisionFlag.Walkable);
+            });
 
-        return new ProjectilePathFinder(mapRegionService).Find(from, 1, destination, 1, 1, 0, 0, 0, false);
+        var path = new ProjectilePathFinder(mapRegionService).Find(from, 1, destination, 1, 1, 0, 0, 0, false);
+        return (path, inspectedTiles);
     }
 
     private static Dictionary<(int X, int Y), CollisionFlag> WriteStandardObject(bool solid, bool gateway) =>
         WriteCollision(ShapeType.GroundDefault, 0, solid, gateway);
 
-    private static Dictionary<(int X, int Y), CollisionFlag> WriteWall(ShapeType shapeType, int rotation) =>
-        WriteCollision(shapeType, rotation, solid: true, gateway: false);
+    private static Dictionary<(int X, int Y), CollisionFlag> WriteWall(ShapeType shapeType, int rotation, bool solid, bool gateway) =>
+        WriteCollision(shapeType, rotation, solid, gateway);
 
     private static Dictionary<(int X, int Y), CollisionFlag> WriteCollision(
         ShapeType shapeType,
@@ -254,6 +416,11 @@ public sealed class ProjectilePathfinderTests
         return gameObject;
     }
 
+    private const CollisionFlag RangeLayerMask =
+        CollisionFlag.WallAllowRangeNorthWest | CollisionFlag.WallAllowRangeNorth | CollisionFlag.WallAllowRangeNorthEast |
+        CollisionFlag.WallAllowRangeEast | CollisionFlag.WallAllowRangeSouthEast | CollisionFlag.WallAllowRangeSouth |
+        CollisionFlag.WallAllowRangeSouthWest | CollisionFlag.WallAllowRangeWest;
+
     public sealed record StandardObjectCase(
         string Name,
         bool Solid,
@@ -261,9 +428,19 @@ public sealed class ProjectilePathfinderTests
         CollisionFlag ExpectedCollision,
         bool ExpectedSuccessful);
 
-    public sealed record WallTraversalCase(string Name, int Rotation, IReadOnlyList<Route> Routes);
+    public sealed record GatewayWallCase(string Name, int Rotation, IReadOnlyList<Route> Routes);
 
-    public sealed record DiagonalWallCase(string Name, int Rotation, int FromX, int FromY, CollisionFlag ExpectedBlocker);
+    public sealed record AsymmetricRayCase(string Name, int DeltaX, int DeltaY, IReadOnlyList<(int X, int Y)> Crossings);
+
+    public sealed record RayBlockerCase(string Name, int XOffset, int YOffset, CollisionFlag Blocker);
+
+    public sealed record DiagonalWallCase(
+        string Name,
+        ShapeType ShapeType,
+        int Rotation,
+        int FromOffsetX,
+        int FromOffsetY,
+        CollisionFlag ExpectedBlocker);
 
     public readonly record struct Route(int FromX, int FromY, int ToX, int ToY, CollisionFlag ExpectedBlocker);
 }

--- a/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
@@ -112,10 +112,14 @@ public sealed class ProjectilePathfinderTests
 
     public static IEnumerable<TestDataRow<DiagonalWallCase>> DiagonalWallCases =>
     [
-        new(new DiagonalWallCase("corner north-west", ShapeType.WallCorner, 0, 1, -1, CollisionFlag.BlockedNorthWest)),
-        new(new DiagonalWallCase("corner north-east", ShapeType.WallCorner, 1, -1, -1, CollisionFlag.BlockedNorthEast)),
-        new(new DiagonalWallCase("corner south-east", ShapeType.WallCornerDiagonal, 2, -1, 1, CollisionFlag.BlockedSouthEast)),
-        new(new DiagonalWallCase("corner south-west", ShapeType.WallCornerDiagonal, 3, 1, 1, CollisionFlag.BlockedSouthWest))
+        new(new DiagonalWallCase("rotation 0 NW neighbor to origin", 0, -1, 1, 0, 0, CollisionFlag.BlockedNorthWest)),
+        new(new DiagonalWallCase("rotation 0 origin to NW neighbor", 0, 0, 0, -1, 1, CollisionFlag.BlockedSouthEast)),
+        new(new DiagonalWallCase("rotation 1 NE neighbor to origin", 1, 1, 1, 0, 0, CollisionFlag.BlockedNorthEast)),
+        new(new DiagonalWallCase("rotation 1 origin to NE neighbor", 1, 0, 0, 1, 1, CollisionFlag.BlockedSouthWest)),
+        new(new DiagonalWallCase("rotation 2 SE neighbor to origin", 2, 1, -1, 0, 0, CollisionFlag.BlockedSouthEast)),
+        new(new DiagonalWallCase("rotation 2 origin to SE neighbor", 2, 0, 0, 1, -1, CollisionFlag.BlockedNorthWest)),
+        new(new DiagonalWallCase("rotation 3 SW neighbor to origin", 3, -1, -1, 0, 0, CollisionFlag.BlockedSouthWest)),
+        new(new DiagonalWallCase("rotation 3 origin to SW neighbor", 3, 0, 0, -1, -1, CollisionFlag.BlockedNorthEast))
     ];
 
     [TestMethod]
@@ -186,8 +190,8 @@ public sealed class ProjectilePathfinderTests
     [DynamicData(nameof(DiagonalWallCases))]
     public void Find_DiagonalWallWriter_BlocksLineOfSightInCorrespondingGeometry(DiagonalWallCase testCase)
     {
-        var collision = WriteWall(testCase.ShapeType, testCase.Rotation, solid: true, gateway: true);
-        var destination = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var collision = WriteWall(ShapeType.WallCorner, testCase.Rotation, solid: true, gateway: true);
+        var destination = Location.Create(OriginX + testCase.ToOffsetX, OriginY + testCase.ToOffsetY, Plane, Dimension);
         var emittedFlags = collision[(destination.X, destination.Y)];
 
         Assert.IsTrue((emittedFlags & testCase.ExpectedBlocker) != 0);
@@ -436,10 +440,11 @@ public sealed class ProjectilePathfinderTests
 
     public sealed record DiagonalWallCase(
         string Name,
-        ShapeType ShapeType,
         int Rotation,
         int FromOffsetX,
         int FromOffsetY,
+        int ToOffsetX,
+        int ToOffsetY,
         CollisionFlag ExpectedBlocker);
 
     public readonly record struct Route(int FromX, int FromY, int ToX, int ToY, CollisionFlag ExpectedBlocker);

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
@@ -1,4 +1,5 @@
-﻿using Hagalaz.Game.Abstractions.Model;
+using System;
+using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
 using Hagalaz.Game.Abstractions.Services;
@@ -6,170 +7,153 @@ using Hagalaz.Game.Abstractions.Services;
 namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
 {
     /// <summary>
-    /// 
+    /// Traces projectile line of sight through map collision flags.
     /// </summary>
     public class ProjectilePathFinder : PathFinderBase, IProjectilePathFinder
     {
+        private const CollisionFlag FullLineOfSightBlocker = CollisionFlag.ObjectBlock;
+
         public ProjectilePathFinder(IMapRegionService regionService) : base(regionService) { }
 
         /// <summary>
-        /// Finds a path from the location to the end location.
+        /// Finds a projectile line of sight from the source tile to the target tile.
         /// </summary>
-        /// <param name="from">From.</param>
-        /// <param name="selfSize">Size of the self.</param>
-        /// <param name="to">To.</param>
-        /// <param name="targetSizeX">The target size x.</param>
-        /// <param name="targetSizeY">The target size y.</param>
-        /// <param name="rotation">The rotation.</param>
-        /// <param name="shape">The shape.</param>
-        /// <param name="surroundings">The surroundings.</param>
-        /// <param name="moveNear">if set to <c>true</c> [move near].</param>
-        /// <returns></returns>
         public override IPath Find(
             IVector3 from, int selfSize, IVector3 to, int targetSizeX, int targetSizeY, int rotation, int shape, int surroundings, bool moveNear)
         {
-            var x = from.X;
-            var y = from.Y;
-            var z = from.Z;
-
             var path = new Path
             {
-                Successful = true
+                Successful = from.Z == to.Z
             };
-            while (x != to.X || y != to.Y)
-            {
-                if (QueueSize <= ++path.Steps)
-                {
-                    return path;
-                }
 
-                var direction = DirectionHelper.GetDirection(x, y, to.X, to.Y);
-                CheckSingleTraversal(path, direction, ref x, ref y, ref z);
-                if (!path.Successful)
-                {
-                    path.MovedNear = x != from.X || y != from.Y;
-                    break;
-                }
+            if (!path.Successful || (from.X == to.X && from.Y == to.Y))
+            {
+                return path;
             }
 
+            var deltaX = to.X - from.X;
+            var deltaY = to.Y - from.Y;
+            var xFlags = FullLineOfSightBlocker | (deltaX < 0 ? CollisionFlag.BlockedEast : CollisionFlag.BlockedWest);
+            var yFlags = FullLineOfSightBlocker | (deltaY < 0 ? CollisionFlag.BlockedNorth : CollisionFlag.BlockedSouth);
+            var diagonalFlag = GetDiagonalLineOfSightBlocker(deltaX, deltaY);
+
+            var successful = Math.Abs(deltaX) > Math.Abs(deltaY)
+                ? TraceXAxis(path, from.X, from.Y, from.Z, to.X, deltaX, deltaY, xFlags, yFlags, diagonalFlag)
+                : TraceYAxis(path, from.X, from.Y, from.Z, to.Y, deltaX, deltaY, xFlags, yFlags, diagonalFlag);
+
+            if (!successful)
+            {
+                path.Successful = false;
+                path.MovedNear = path.Steps > 0;
+                return path;
+            }
+
+            path.Add(Location.Create(to.X, to.Y, to.Z));
             return path;
         }
 
-        private void CheckSingleTraversal(Path path, DirectionFlag direction, ref int x, ref int y, ref int z)
+        private bool TraceXAxis(
+            Path path, int fromX, int fromY, int z, int targetX, int deltaX, int deltaY, CollisionFlag xFlags, CollisionFlag yFlags, CollisionFlag diagonalFlag)
         {
-            if (direction == DirectionFlag.North)
+            var x = fromX;
+            var yBig = (fromY << 16) + 0x8000;
+            if (deltaY < 0)
             {
-                if (!IsTraversable(x, y + 1, z, CollisionFlag.TraversableNorthBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                y++;
-            }
-            else if (direction == DirectionFlag.NorthEast)
-            {
-                if (!IsTraversable(x + 1, y, z, CollisionFlag.TraversableEastBlocked) ||
-                    !IsTraversable(x, y + 1, z, CollisionFlag.TraversableNorthBlocked) ||
-                    !IsTraversable(x + 1, y + 1, z, CollisionFlag.TraversableNorthEastBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                x++;
-                y++;
-            }
-            else if (direction == DirectionFlag.East)
-            {
-                if (!IsTraversable(x + 1, y, z, CollisionFlag.TraversableEastBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                x++;
-            }
-            else if (direction == DirectionFlag.SouthEast)
-            {
-                if (!IsTraversable(x + 1, y, z, CollisionFlag.TraversableEastBlocked) ||
-                    !IsTraversable(x, y - 1, z, CollisionFlag.TraversableSouthBlocked) ||
-                    !IsTraversable(x + 1, y - 1, z, CollisionFlag.TraversableSouthEastBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                x++;
-                y--;
-            }
-            else if (direction == DirectionFlag.South)
-            {
-                if (!IsTraversable(x, y - 1, z, CollisionFlag.TraversableSouthBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                y--;
-            }
-            else if (direction == DirectionFlag.SouthWest)
-            {
-                if (!IsTraversable(x - 1, y, z, CollisionFlag.TraversableWestBlocked) ||
-                    !IsTraversable(x, y - 1, z, CollisionFlag.TraversableSouthBlocked) ||
-                    !IsTraversable(x - 1, y - 1, z, CollisionFlag.TraversableSouthWestBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                x--;
-                y--;
-            }
-            else if (direction == DirectionFlag.West)
-            {
-                if (!IsTraversable(x - 1, y, z, CollisionFlag.TraversableWestBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                x--;
-            }
-            else if (direction == DirectionFlag.NorthWest)
-            {
-                if (!IsTraversable(x - 1, y, z, CollisionFlag.TraversableWestBlocked) ||
-                    !IsTraversable(x, y + 1, z, CollisionFlag.TraversableNorthBlocked) ||
-                    !IsTraversable(x - 1, y + 1, z, CollisionFlag.TraversableNorthWestBlocked))
-                {
-                    path.Successful = false;
-                    return;
-                }
-
-                x--;
-                y++;
+                yBig--;
             }
 
-            path.Add(Location.Create(x, y, z));
+            var slope = (deltaY << 16) / Math.Abs(deltaX);
+            var direction = deltaX < 0 ? -1 : 1;
+
+            while (x != targetX)
+            {
+                path.Steps++;
+                x += direction;
+
+                var y = GetTileCoordinate(yBig);
+                if (!IsTraversable(x, y, z, xFlags))
+                {
+                    return false;
+                }
+
+                yBig += slope;
+                var nextY = GetTileCoordinate(yBig);
+                if (nextY != y && !IsTraversable(x, nextY, z, yFlags))
+                {
+                    return false;
+                }
+
+                if (nextY != y && IsDiagonalRay(deltaX, deltaY) && !IsTraversable(x, nextY, z, diagonalFlag))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        /// <summary>
-        /// Determines whether the specified x is traversable.
-        /// </summary>
-        /// <param name="x">The x.</param>
-        /// <param name="y">The y.</param>
-        /// <param name="z">The z.</param>
-        /// <param name="flag">The flag.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified x is traversable; otherwise, <c>false</c>.
-        /// </returns>
-        private bool IsTraversable(int x, int y, int z, CollisionFlag flag)
+        private bool TraceYAxis(
+            Path path, int fromX, int fromY, int z, int targetY, int deltaX, int deltaY, CollisionFlag xFlags, CollisionFlag yFlags, CollisionFlag diagonalFlag)
         {
-            var clippingFlag = GetClippingFlag(x, y, z);
-            var matchingBlockers = clippingFlag & flag;
-            return matchingBlockers == 0 ||
-                   (matchingBlockers == CollisionFlag.ObjectAllowRange &&
-                    (clippingFlag & CollisionFlag.ObjectBlock) != 0);
+            var y = fromY;
+            var xBig = (fromX << 16) + 0x8000;
+            if (deltaX < 0)
+            {
+                xBig--;
+            }
+
+            var slope = (deltaX << 16) / Math.Abs(deltaY);
+            var direction = deltaY < 0 ? -1 : 1;
+
+            while (y != targetY)
+            {
+                path.Steps++;
+                y += direction;
+
+                var x = GetTileCoordinate(xBig);
+                if (!IsTraversable(x, y, z, yFlags))
+                {
+                    return false;
+                }
+
+                xBig += slope;
+                var nextX = GetTileCoordinate(xBig);
+                if (nextX != x && !IsTraversable(nextX, y, z, xFlags))
+                {
+                    return false;
+                }
+
+                if (nextX != x && IsDiagonalRay(deltaX, deltaY) && !IsTraversable(nextX, y, z, diagonalFlag))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static int GetTileCoordinate(int fixedPointCoordinate) => (int)((uint)fixedPointCoordinate >> 16);
+
+        private static bool IsDiagonalRay(int deltaX, int deltaY) => Math.Abs(deltaX) == Math.Abs(deltaY);
+
+        private static CollisionFlag GetDiagonalLineOfSightBlocker(int deltaX, int deltaY)
+        {
+            if (deltaX < 0)
+            {
+                return deltaY < 0 ? CollisionFlag.BlockedSouthWest : CollisionFlag.BlockedNorthWest;
+            }
+
+            return deltaY < 0 ? CollisionFlag.BlockedSouthEast : CollisionFlag.BlockedNorthEast;
+        }
+
+        private bool IsTraversable(int x, int y, int z, CollisionFlag flags)
+        {
+            if ((GetClippingFlag(x, y, z) & flags) != 0)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
@@ -140,10 +140,10 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
         {
             if (deltaX < 0)
             {
-                return deltaY < 0 ? CollisionFlag.BlockedSouthWest : CollisionFlag.BlockedNorthWest;
+                return deltaY < 0 ? CollisionFlag.BlockedNorthEast : CollisionFlag.BlockedSouthEast;
             }
 
-            return deltaY < 0 ? CollisionFlag.BlockedSouthEast : CollisionFlag.BlockedNorthEast;
+            return deltaY < 0 ? CollisionFlag.BlockedNorthWest : CollisionFlag.BlockedSouthWest;
         }
 
         private bool IsTraversable(int x, int y, int z, CollisionFlag flags)

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
@@ -124,7 +124,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
                 }
 
                 x--;
-                y++;
+                y--;
             }
             else if (direction == DirectionFlag.West)
             {
@@ -166,7 +166,10 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
         private bool IsTraversable(int x, int y, int z, CollisionFlag flag)
         {
             var clippingFlag = GetClippingFlag(x, y, z);
-            return (clippingFlag & flag) == 0 || ((clippingFlag & CollisionFlag.ObjectBlock) != 0 && (clippingFlag & CollisionFlag.ObjectAllowRange) != 0) || (clippingFlag & CollisionFlag.FloorBlock) == 0;
+            var matchingBlockers = clippingFlag & flag;
+            return matchingBlockers == 0 ||
+                   (matchingBlockers == CollisionFlag.ObjectAllowRange &&
+                    (clippingFlag & CollisionFlag.ObjectBlock) != 0);
         }
     }
 }

--- a/openspec/changes/fix-projectile-pathfinder-collision/.openspec.yaml
+++ b/openspec/changes/fix-projectile-pathfinder-collision/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/fix-projectile-pathfinder-collision/design.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/design.md
@@ -8,7 +8,7 @@ The current `ProjectilePathFinder` uses the high routing composites and `Directi
 
 ### Consume only the existing LOS layer
 
-The full LOS mask is `ObjectBlock`. When a ray crosses east or west, it checks `ObjectBlock` together with the destination tile's west or east `Blocked*` flag, respectively. When it crosses north or south, it checks `ObjectBlock` together with the destination tile's south or north `Blocked*` flag, respectively. An exact 45-degree ray also checks Hagalaz's matching diagonal `Blocked*` flag as it enters each diagonal tile. No high routing, low movement, floor, or floor-decoration flag participates in this tile-to-tile LOS decision.
+The full LOS mask is `ObjectBlock`. When a ray crosses east or west, it checks `ObjectBlock` together with the destination tile's west or east `Blocked*` flag, respectively. When it crosses north or south, it checks `ObjectBlock` together with the destination tile's south or north `Blocked*` flag, respectively. An exact 45-degree ray also checks the diagonal `Blocked*` flag on the destination tile for the side the ray enters from—the opposite of its movement direction. No high routing, low movement, floor, or floor-decoration flag participates in this tile-to-tile LOS decision.
 
 Rejected alternative: reinterpret or rename the existing flags. The writers already faithfully preserve the client bit layout; changing producers or aliases would be scope expansion and risk movement behavior.
 

--- a/openspec/changes/fix-projectile-pathfinder-collision/design.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/design.md
@@ -1,45 +1,31 @@
 ## Context
 
-`ProjectilePathFinder` advances one tile at a time and already receives the exact directional mask for each cardinal or diagonal step. `CollisionMethods` writes the collision state, and `CreatureCombat.ReachTarget` already consumes the projectile pathfinder for attacks with range greater than one.
+`CollisionMethods` and the companion game client both write three independent layers: low movement walls/occupancy, middle LOS blockers, and high routing flags. The public RuneLite collision definitions identify `0x20000` as the full LOS blocker and `0x400`, `0x1000`, `0x4000`, and `0x10000` as the four cardinal LOS blockers. Hagalaz's collision writers additionally emit the middle diagonal `Blocked*` flags for diagonal wall/corner geometry. The high `0x4...`/`0x6...` masks are used by the companion client routefinder and must not be inferred to represent projectile LOS.
 
-The client-side `CollisionData.flagStandartObject` writes `0x20000` for a solid object and `0x40000000` when the object is not a gateway. The server's standard-object writer mirrors that layout as `ObjectBlock` and `ObjectAllowRange`. The historical projectile regression explicitly treats their combined writer output as range-permissive. The existing server `Traversable*Blocked` composites still contain the high directional/object layer, floor-decoration layer, and floor layer, so that special combination must not become a fallback that ignores an accompanying wall or floor blocker.
-
-## Goals / Non-Goals
-
-**Goals:**
-
-- Make the existing directional projectile masks the sole traversal decision.
-- Characterize the collision writer's standard-object and wall output through the projectile pathfinder.
-- Preserve the existing combat-to-projectile-pathfinder dependency and correct the southwest coordinate update.
-
-**Non-Goals:**
-
-- Rename or relayout collision flags, change map collision writing, or add a line-of-sight abstraction.
-- Change melee movement/pathfinding or combat target selection.
-- Add persistence, background work, or dependencies.
+The current `ProjectilePathFinder` uses the high routing composites and `DirectionHelper.GetDirection`, so it both reads the wrong layer and changes direction only after it has stair-stepped to an axis. The RuneLite tile LOS implementation traces a 16.16 fixed-point ray, checking the relevant collision mask each time the ray crosses an X or Y tile boundary.
 
 ## Decisions
 
-### Use the existing `Traversable*Blocked` mask with its range-permissive object exception
+### Consume only the existing LOS layer
 
-`CheckSingleTraversal` already selects the exact client-derived mask for every step. `IsTraversable` will allow a step when the selected mask is absent, or when the selected mask contains only `ObjectAllowRange` and the tile also carries `ObjectBlock`. This is the precise range-permissive combination emitted by a solid, non-gateway standard object. Any floor, floor-decoration, or directional wall bit remains a blocker because it makes the selected mask contain more than `ObjectAllowRange`.
+The full LOS mask is `ObjectBlock`. When a ray crosses east or west, it checks `ObjectBlock` together with the destination tile's west or east `Blocked*` flag, respectively. When it crosses north or south, it checks `ObjectBlock` together with the destination tile's south or north `Blocked*` flag, respectively. An exact 45-degree ray also checks Hagalaz's matching diagonal `Blocked*` flag as it enters each diagonal tile. No high routing, low movement, floor, or floor-decoration flag participates in this tile-to-tile LOS decision.
 
-Rejected alternative: build a separate projectile-mask table or line-of-sight service. It would duplicate the collision knowledge already represented by the masks and create a second owner for directional semantics. Also rejected: a broad `ObjectBlock && ObjectAllowRange` fallback, because it would allow a floor or wall blocker on the same tile.
+Rejected alternative: reinterpret or rename the existing flags. The writers already faithfully preserve the client bit layout; changing producers or aliases would be scope expansion and risk movement behavior.
 
-### Derive object and wall test inputs from writer-equivalent state
+### Trace the ray with fixed-point boundary crossings
 
-The regressions will use the same standard-object and paired-wall flag combinations emitted by `CollisionMethods`: a solid non-gateway object emits the range-permissive `ObjectBlock | ObjectAllowRange` combination; a non-solid non-gateway object emits only `ObjectAllowRange` and blocks; a gateway object omits the high object layer and remains traversable. Cardinal and diagonal tests will put the paired high directional flag on each physical side of the wall.
+For the dominant axis, represent the other axis in 16.16 fixed point at the source tile centre. Advance one tile on the dominant axis, test that boundary, then test the secondary boundary if the fixed-point coordinate crossed into another tile. The initial half-tile offset and negative-slope rounding match RuneLite's LOS algorithm. On an exact 45-degree ray, test the matching Hagalaz diagonal wall flag as well. Collision probes are not path steps: a successful result appends only the supplied target tile, and combat continues to consume `Successful`.
 
-Rejected alternative: test only arbitrary enum values. That would not prove the pathfinder agrees with the collision data actually generated for map objects.
+Rejected alternative: repeated `DirectionHelper.GetDirection`. It cannot preserve a non-45-degree slope and inspects tiles the ray does not cross.
 
-### Correct southwest at the existing step owner
+### Preserve the existing runtime boundary
 
-The southwest branch validates `(x - 1, y - 1)` and will update to those same coordinates before adding the waypoint.
+`CreatureCombat` already asks `IProjectilePathFinder` for ranged target reach. The correction remains inside that pathfinder and uses its existing map-region collision source; no combat-side collision evaluator is added.
 
-Rejected alternative: compensate in consumers. The coordinate transition belongs exclusively to `ProjectilePathFinder`.
+## Risks and Mitigations
 
-## Risks / Trade-offs
-
-- [Misleading legacy enum names] → Assert actual flag combinations from `CollisionMethods`, preserve the existing range-permissive regression, and test that floor/decorations still win over that exception.
-- [Directional regression affects ranged combat] → Cover all cardinal and diagonal directions and retain the direct `CreatureCombat` dependency without adding a second evaluator.
-- [Focused fix silently broadens] → Stop if the writer itself requires modification; this change only consumes its existing output.
+- [Routing/LOS layer confusion] → writer-derived tests cover high-only, full-object, and gateway states separately.
+- [Fixed-point rounding regression] → assert exact shallow and steep ray crossings in opposite quadrants and blockers at both X and Y boundaries.
+- [Directional wall asymmetry] → cover all four cardinal gateway-wall rotations and both physical sides.
+- [Diagonal wall omission] → cover writer-derived corner/diagonal rotations on matching 45-degree rays.
+- [Scope expansion] → leave writers, enum names, target-footprint policy, and terrain/arc handling unchanged.

--- a/openspec/changes/fix-projectile-pathfinder-collision/design.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`ProjectilePathFinder` advances one tile at a time and already receives the exact directional mask for each cardinal or diagonal step. `CollisionMethods` writes the collision state, and `CreatureCombat.ReachTarget` already consumes the projectile pathfinder for attacks with range greater than one.
+
+The client-side `CollisionData.flagStandartObject` writes `0x20000` for a solid object and `0x40000000` when the object is not a gateway. The server's standard-object writer mirrors that layout as `ObjectBlock` and `ObjectAllowRange`. The historical projectile regression explicitly treats their combined writer output as range-permissive. The existing server `Traversable*Blocked` composites still contain the high directional/object layer, floor-decoration layer, and floor layer, so that special combination must not become a fallback that ignores an accompanying wall or floor blocker.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the existing directional projectile masks the sole traversal decision.
+- Characterize the collision writer's standard-object and wall output through the projectile pathfinder.
+- Preserve the existing combat-to-projectile-pathfinder dependency and correct the southwest coordinate update.
+
+**Non-Goals:**
+
+- Rename or relayout collision flags, change map collision writing, or add a line-of-sight abstraction.
+- Change melee movement/pathfinding or combat target selection.
+- Add persistence, background work, or dependencies.
+
+## Decisions
+
+### Use the existing `Traversable*Blocked` mask with its range-permissive object exception
+
+`CheckSingleTraversal` already selects the exact client-derived mask for every step. `IsTraversable` will allow a step when the selected mask is absent, or when the selected mask contains only `ObjectAllowRange` and the tile also carries `ObjectBlock`. This is the precise range-permissive combination emitted by a solid, non-gateway standard object. Any floor, floor-decoration, or directional wall bit remains a blocker because it makes the selected mask contain more than `ObjectAllowRange`.
+
+Rejected alternative: build a separate projectile-mask table or line-of-sight service. It would duplicate the collision knowledge already represented by the masks and create a second owner for directional semantics. Also rejected: a broad `ObjectBlock && ObjectAllowRange` fallback, because it would allow a floor or wall blocker on the same tile.
+
+### Derive object and wall test inputs from writer-equivalent state
+
+The regressions will use the same standard-object and paired-wall flag combinations emitted by `CollisionMethods`: a solid non-gateway object emits the range-permissive `ObjectBlock | ObjectAllowRange` combination; a non-solid non-gateway object emits only `ObjectAllowRange` and blocks; a gateway object omits the high object layer and remains traversable. Cardinal and diagonal tests will put the paired high directional flag on each physical side of the wall.
+
+Rejected alternative: test only arbitrary enum values. That would not prove the pathfinder agrees with the collision data actually generated for map objects.
+
+### Correct southwest at the existing step owner
+
+The southwest branch validates `(x - 1, y - 1)` and will update to those same coordinates before adding the waypoint.
+
+Rejected alternative: compensate in consumers. The coordinate transition belongs exclusively to `ProjectilePathFinder`.
+
+## Risks / Trade-offs
+
+- [Misleading legacy enum names] → Assert actual flag combinations from `CollisionMethods`, preserve the existing range-permissive regression, and test that floor/decorations still win over that exception.
+- [Directional regression affects ranged combat] → Cover all cardinal and diagonal directions and retain the direct `CreatureCombat` dependency without adding a second evaluator.
+- [Focused fix silently broadens] → Stop if the writer itself requires modification; this change only consumes its existing output.

--- a/openspec/changes/fix-projectile-pathfinder-collision/proposal.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`ProjectilePathFinder` currently accepts failed directional and object collision checks whenever a tile lacks `FloorBlock`. This allows ranged line-of-sight to pass through collision written by the existing map collision system, while its southwest step reports the wrong destination. The correction must preserve the writer's intentional range-permissive standard-object combination rather than treating every high object bit as a blocker.
+
+## What Changes
+
+- Define projectile line-of-sight as a traversal of the existing collision masks written by `CollisionMethods`, with the range-permissive standard-object combination evaluated explicitly.
+- Correct `ProjectilePathFinder` so a matching directional, incompatible object, floor-decoration, or floor blocker stops traversal instead of falling through on non-floor tiles.
+- Correct southwest traversal to move to the southwest tile.
+- Add focused MSTest regressions covering cardinal and diagonal projectile blockers, paired wall sides, standard object range behavior, and the existing `CreatureCombat` projectile-pathfinder boundary.
+
+## Capabilities
+
+### New Capabilities
+
+- `projectile-line-of-sight`: Projectile traversal honors the collision layers emitted by map objects and reports the actual traversed coordinates.
+
+### Modified Capabilities
+
+- None.
+
+## Scope and Acceptance Criteria
+
+- Empty tiles, objects whose collision writer omits the projectile layer, and standard objects that emit `ObjectBlock | ObjectAllowRange` remain traversable.
+- `FloorBlock`, `FloorDecorationBlock`, and matching cardinal or diagonal projectile-direction bits stop line-of-sight from every direction.
+- A standard object with only `ObjectAllowRange` stops line-of-sight; the writer's `ObjectBlock | ObjectAllowRange` range-permissive combination does not.
+- A southwest path reaches `(x - 1, y - 1)`.
+- `CreatureCombat.ReachTarget(range > 1)` continues to consume `IProjectilePathFinder` without a second collision implementation.
+
+## Non-Goals and Stop Conditions
+
+- Do not change the collision writer, enum layout, combat range rules, or pathfinding architecture.
+- Do not introduce a separate line-of-sight service or duplicate collision state.
+- If client evidence requires changing collision flags themselves rather than the existing projectile pathfinder interpretation, stop and create a separate change.
+
+## Impact
+
+- Affected runtime path: `ProjectilePathFinder` through `CreatureCombat.ReachTarget(range > 1)`.
+- Affected tests: `Hagalaz.Services.GameWorld.Tests` projectile-pathfinder regressions.
+- No API, dependency, schema, migration, or service-registration change.

--- a/openspec/changes/fix-projectile-pathfinder-collision/proposal.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/proposal.md
@@ -1,40 +1,32 @@
 ## Why
 
-`ProjectilePathFinder` currently accepts failed directional and object collision checks whenever a tile lacks `FloorBlock`. This allows ranged line-of-sight to pass through collision written by the existing map collision system, while its southwest step reports the wrong destination. The correction must preserve the writer's intentional range-permissive standard-object combination rather than treating every high object bit as a blocker.
+The previous implementation and its first correction treat the high `WallAllowRange*` and `ObjectAllowRange` routing layer as projectile line-of-sight (LOS). That is reversed. The client-era collision writer emits a distinct LOS layer: `ObjectBlock` is the full LOS blocker and the middle `Blocked*` flags are directional LOS blockers. In addition, `ProjectilePathFinder` follows the sign of the remaining delta, which stair-steps non-45-degree rays instead of checking the tiles that a projectile ray actually crosses.
 
 ## What Changes
 
-- Define projectile line-of-sight as a traversal of the existing collision masks written by `CollisionMethods`, with the range-permissive standard-object combination evaluated explicitly.
-- Correct `ProjectilePathFinder` so a matching directional, incompatible object, floor-decoration, or floor blocker stops traversal instead of falling through on non-floor tiles.
-- Correct southwest traversal to move to the southwest tile.
-- Add focused MSTest regressions covering cardinal and diagonal projectile blockers, paired wall sides, standard object range behavior, and the existing `CreatureCombat` projectile-pathfinder boundary.
-
-## Capabilities
-
-### New Capabilities
-
-- `projectile-line-of-sight`: Projectile traversal honors the collision layers emitted by map objects and reports the actual traversed coordinates.
-
-### Modified Capabilities
-
-- None.
+- Replace routing-mask checks with the existing full and directional LOS collision layer, including Hagalaz's diagonal wall flags on matching 45-degree rays.
+- Trace each projectile ray with the 16.16 fixed-point, axis-boundary algorithm used by RuneLite's `WorldArea` LOS implementation.
+- Retain the existing `IProjectilePathFinder` runtime boundary and collision writers; only their already-emitted LOS state is consumed.
+- Add focused writer-derived and off-axis-ray regressions before the production correction.
 
 ## Scope and Acceptance Criteria
 
-- Empty tiles, objects whose collision writer omits the projectile layer, and standard objects that emit `ObjectBlock | ObjectAllowRange` remain traversable.
-- `FloorBlock`, `FloorDecorationBlock`, and matching cardinal or diagonal projectile-direction bits stop line-of-sight from every direction.
-- A standard object with only `ObjectAllowRange` stops line-of-sight; the writer's `ObjectBlock | ObjectAllowRange` range-permissive combination does not.
-- A southwest path reaches `(x - 1, y - 1)`.
-- `CreatureCombat.ReachTarget(range > 1)` continues to consume `IProjectilePathFinder` without a second collision implementation.
+- `ObjectBlock` blocks LOS whether or not `ObjectAllowRange` is also present.
+- Gateway walls and standard objects block LOS through their `Blocked*` or `ObjectBlock` state even though they omit the high routing layer.
+- `ObjectAllowRange`, `WallAllowRange*`, `FloorBlock`, and `FloorDecorationBlock` do not by themselves block the client-equivalent tile-to-tile LOS ray.
+- A matching diagonal `Blocked*` flag blocks an exact 45-degree ray through its wall/corner geometry.
+- An off-axis ray follows its fixed-point tile crossings; blockers on each crossed X or Y boundary stop it.
+- A ray between different planes is unsuccessful.
+- `CreatureCombat.ReachTarget(range > 1)` continues to consume the single `IProjectilePathFinder` result.
 
-## Non-Goals and Stop Conditions
+## Non-Goals
 
-- Do not change the collision writer, enum layout, combat range rules, or pathfinding architecture.
-- Do not introduce a separate line-of-sight service or duplicate collision state.
-- If client evidence requires changing collision flags themselves rather than the existing projectile pathfinder interpretation, stop and create a separate change.
+- Do not change collision writing, enum layout/names, movement routing, combat targeting, service registration, or dependencies.
+- Do not add terrain-height/arc collision or a separate LOS service.
+- Do not broaden this tile-to-tile correction into RuneLite's multi-tile `WorldArea` candidate-selection policy; the existing `ProjectilePathFinder` currently traces its supplied source and target tiles.
 
 ## Impact
 
-- Affected runtime path: `ProjectilePathFinder` through `CreatureCombat.ReachTarget(range > 1)`.
+- Runtime path: `ProjectilePathFinder` through `CreatureCombat.ReachTarget(range > 1)`.
 - Affected tests: `Hagalaz.Services.GameWorld.Tests` projectile-pathfinder regressions.
-- No API, dependency, schema, migration, or service-registration change.
+- No API, schema, migration, or deployment change.

--- a/openspec/changes/fix-projectile-pathfinder-collision/specs/projectile-line-of-sight/spec.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/specs/projectile-line-of-sight/spec.md
@@ -1,34 +1,46 @@
 ## ADDED Requirements
 
-### Requirement: Projectile traversal honors emitted projectile collision
-The system SHALL determine every `ProjectilePathFinder` step from the existing directional traversal mask for its destination tile. A tile whose matching mask includes a floor, floor-decoration, or high directional wall bit SHALL stop projectile traversal, even when `FloorBlock` is not present. A standard object whose only matching collision bit is `ObjectAllowRange` and whose full collision state also contains `ObjectBlock` SHALL remain traversable.
+### Requirement: Projectile traversal consumes the LOS collision layer
+The system SHALL evaluate tile-to-tile projectile LOS from `ObjectBlock` and the middle directional `Blocked*` flags emitted by the existing collision writers. It SHALL NOT treat the high `ObjectAllowRange` or `WallAllowRange*` routing flags as LOS blockers.
 
-#### Scenario: Cardinal wall collision blocks line-of-sight
-- **WHEN** a cardinal step reaches a tile containing the matching high directional wall bit
-- **THEN** the projectile path SHALL be unsuccessful
+#### Scenario: Full LOS object blocks regardless of routing state
+- **WHEN** a standard object emits `ObjectBlock`, with or without `ObjectAllowRange`
+- **THEN** projectile LOS through that tile SHALL be unsuccessful
 
-#### Scenario: Diagonal wall collision blocks line-of-sight
-- **WHEN** a diagonal step reaches a tile containing any matching diagonal or component cardinal high directional wall bit
-- **THEN** the projectile path SHALL be unsuccessful
+#### Scenario: High routing object alone does not block LOS
+- **WHEN** a standard object emits `ObjectAllowRange` without `ObjectBlock`
+- **THEN** projectile LOS through that tile SHALL remain successful
 
-#### Scenario: High-object-only standard object blocks line-of-sight
-- **WHEN** a standard object has emitted `ObjectAllowRange` without `ObjectBlock`
-- **THEN** projectile traversal through that tile SHALL be unsuccessful
+#### Scenario: Gateway wall blocks through its middle layer
+- **WHEN** a solid gateway wall emits the matching cardinal `Blocked*` flag but omits `WallAllowRange*`
+- **THEN** projectile LOS across that wall from either side SHALL be unsuccessful
 
-#### Scenario: Range-permissive standard object remains traversable
-- **WHEN** a standard object has emitted `ObjectBlock | ObjectAllowRange` and no other matching blocker
-- **THEN** projectile traversal through that tile SHALL remain successful
+#### Scenario: Movement-only state does not block LOS
+- **WHEN** a ray encounters only `FloorBlock`, `FloorDecorationBlock`, or a high routing wall flag
+- **THEN** that state SHALL not by itself make the projectile LOS unsuccessful
 
-#### Scenario: Floor collision overrides a range-permissive object combination
-- **WHEN** a tile contains `FloorBlock` or `FloorDecorationBlock` together with `ObjectBlock | ObjectAllowRange`
-- **THEN** projectile traversal through that tile SHALL be unsuccessful
+#### Scenario: Diagonal wall blocks matching diagonal LOS
+- **WHEN** an exact 45-degree ray enters a tile with the matching middle diagonal `Blocked*` flag emitted for a wall corner
+- **THEN** projectile LOS SHALL be unsuccessful
 
-### Requirement: Projectile direction is spatially consistent
-The system SHALL append the coordinate it validated for each projectile step.
+### Requirement: Projectile traversal follows the fixed-point ray
+The system SHALL trace the supplied source and target tiles with 16.16 fixed-point slope arithmetic, inspecting each X and Y tile boundary the ray crosses rather than walking by the sign of the remaining delta. Exact 45-degree rays SHALL also inspect the matching diagonal wall boundary.
 
-#### Scenario: Southwest traversal reaches its validated tile
-- **WHEN** a clear projectile path moves southwest by one tile
-- **THEN** its next waypoint SHALL be `(x - 1, y - 1)`
+#### Scenario: Asymmetric ray records its crossed tiles
+- **WHEN** a clear ray travels from `(x, y)` to `(x + 5, y + 2)`
+- **THEN** its trace SHALL follow the fixed-point boundary crossings rather than the diagonal staircase `(x + 1, y + 1)`, `(x + 2, y + 2)`, and so on
+
+#### Scenario: Crossed X or Y boundary blocks the ray
+- **WHEN** a matching cardinal middle LOS flag is present on any tile boundary crossed by an asymmetric ray
+- **THEN** the projectile LOS SHALL be unsuccessful
+
+#### Scenario: Southwest path records its destination
+- **WHEN** a clear ray travels one tile southwest
+- **THEN** the successful path SHALL contain only the southwest destination tile, not collision-probe tiles
+
+#### Scenario: Different planes have no line of sight
+- **WHEN** the source and target are on different planes
+- **THEN** the projectile LOS SHALL be unsuccessful
 
 ### Requirement: Ranged combat consumes projectile line-of-sight
 The system SHALL use the existing `IProjectilePathFinder` result for `CreatureCombat` targets within an attack range greater than one, without maintaining a second collision evaluator.

--- a/openspec/changes/fix-projectile-pathfinder-collision/specs/projectile-line-of-sight/spec.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/specs/projectile-line-of-sight/spec.md
@@ -19,8 +19,8 @@ The system SHALL evaluate tile-to-tile projectile LOS from `ObjectBlock` and the
 - **WHEN** a ray encounters only `FloorBlock`, `FloorDecorationBlock`, or a high routing wall flag
 - **THEN** that state SHALL not by itself make the projectile LOS unsuccessful
 
-#### Scenario: Diagonal wall blocks matching diagonal LOS
-- **WHEN** an exact 45-degree ray enters a tile with the matching middle diagonal `Blocked*` flag emitted for a wall corner
+#### Scenario: Diagonal wall blocks the entering side
+- **WHEN** an exact 45-degree ray enters a tile with the middle diagonal `Blocked*` flag emitted for the side it enters from
 - **THEN** projectile LOS SHALL be unsuccessful
 
 ### Requirement: Projectile traversal follows the fixed-point ray

--- a/openspec/changes/fix-projectile-pathfinder-collision/specs/projectile-line-of-sight/spec.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/specs/projectile-line-of-sight/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Projectile traversal honors emitted projectile collision
+The system SHALL determine every `ProjectilePathFinder` step from the existing directional traversal mask for its destination tile. A tile whose matching mask includes a floor, floor-decoration, or high directional wall bit SHALL stop projectile traversal, even when `FloorBlock` is not present. A standard object whose only matching collision bit is `ObjectAllowRange` and whose full collision state also contains `ObjectBlock` SHALL remain traversable.
+
+#### Scenario: Cardinal wall collision blocks line-of-sight
+- **WHEN** a cardinal step reaches a tile containing the matching high directional wall bit
+- **THEN** the projectile path SHALL be unsuccessful
+
+#### Scenario: Diagonal wall collision blocks line-of-sight
+- **WHEN** a diagonal step reaches a tile containing any matching diagonal or component cardinal high directional wall bit
+- **THEN** the projectile path SHALL be unsuccessful
+
+#### Scenario: High-object-only standard object blocks line-of-sight
+- **WHEN** a standard object has emitted `ObjectAllowRange` without `ObjectBlock`
+- **THEN** projectile traversal through that tile SHALL be unsuccessful
+
+#### Scenario: Range-permissive standard object remains traversable
+- **WHEN** a standard object has emitted `ObjectBlock | ObjectAllowRange` and no other matching blocker
+- **THEN** projectile traversal through that tile SHALL remain successful
+
+#### Scenario: Floor collision overrides a range-permissive object combination
+- **WHEN** a tile contains `FloorBlock` or `FloorDecorationBlock` together with `ObjectBlock | ObjectAllowRange`
+- **THEN** projectile traversal through that tile SHALL be unsuccessful
+
+### Requirement: Projectile direction is spatially consistent
+The system SHALL append the coordinate it validated for each projectile step.
+
+#### Scenario: Southwest traversal reaches its validated tile
+- **WHEN** a clear projectile path moves southwest by one tile
+- **THEN** its next waypoint SHALL be `(x - 1, y - 1)`
+
+### Requirement: Ranged combat consumes projectile line-of-sight
+The system SHALL use the existing `IProjectilePathFinder` result for `CreatureCombat` targets within an attack range greater than one, without maintaining a second collision evaluator.
+
+#### Scenario: Ranged target check delegates to projectile pathfinding
+- **WHEN** a combat target is within a ranged attack distance
+- **THEN** the target reach decision SHALL consume the configured projectile pathfinder result

--- a/openspec/changes/fix-projectile-pathfinder-collision/tasks.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/tasks.md
@@ -1,15 +1,16 @@
 ## 1. Regression Characterization
 
-- [x] 1.1 Add focused projectile-pathfinder regressions using collision state emitted by the existing standard-object and wall writers, including empty, floor, floor-decoration, cardinal paired-wall, and diagonal cases.
-- [x] 1.2 Add regression coverage for the writer-derived range-permissive `ObjectBlock | ObjectAllowRange` standard object, high-object-only blocker, floor/decorations combined with that range-permissive state, and the southwest waypoint coordinate.
-- [x] 1.3 Run the focused projectile-pathfinder tests before the production correction and confirm the range-permissive regression fails for the mask-only behavior.
+- [x] 1.1 Replace the routing-layer projectile regressions with writer-derived full-object, high-only object, cardinal gateway-wall, high-only wall, diagonal-wall, and movement-only collision cases.
+- [x] 1.2 Add exact shallow and steep fixed-point traces in every quadrant, crossed-X/crossed-Y-boundary, old-staircase-only-obstacle, axis/45-degree, southwest-output, and different-plane regressions.
+- [x] 1.3 Run the focused tests against the current implementation and confirm the new LOS-layer and asymmetric-ray regressions fail.
 
-## 2. Projectile Traversal Correction
+## 2. Projectile LOS Correction
 
-- [x] 2.1 Make `ProjectilePathFinder` honor its existing traversal mask while allowing only the writer-derived range-permissive `ObjectBlock | ObjectAllowRange` object state.
-- [x] 2.2 Correct the southwest coordinate update and verify the focused regressions pass.
+- [x] 2.1 Replace sign-based directional traversal with the RuneLite-equivalent 16.16 fixed-point tile-boundary tracer.
+- [x] 2.2 Use only `ObjectBlock` and the matching middle `Blocked*` flags for LOS, including diagonal flags on exact 45-degree rays, while preserving the existing `IProjectilePathFinder` runtime boundary.
+- [x] 2.3 Verify the focused regressions pass after the production correction.
 
 ## 3. Verification
 
-- [x] 3.1 Confirm `CreatureCombat` continues to use `IProjectilePathFinder` for ranged target reach without another collision evaluator.
-- [x] 3.2 Run the focused GameWorld test project and build, validate the OpenSpec change, and review the final diff for scope and duplicate collision logic.
+- [x] 3.1 Confirm `CreatureCombat.ReachTarget(range > 1)` still consumes `IProjectilePathFinder` without another collision evaluator.
+- [x] 3.2 Run the GameWorld test project and production build, validate the OpenSpec change, and review the final diff for scope and duplicate collision logic.

--- a/openspec/changes/fix-projectile-pathfinder-collision/tasks.md
+++ b/openspec/changes/fix-projectile-pathfinder-collision/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression Characterization
+
+- [x] 1.1 Add focused projectile-pathfinder regressions using collision state emitted by the existing standard-object and wall writers, including empty, floor, floor-decoration, cardinal paired-wall, and diagonal cases.
+- [x] 1.2 Add regression coverage for the writer-derived range-permissive `ObjectBlock | ObjectAllowRange` standard object, high-object-only blocker, floor/decorations combined with that range-permissive state, and the southwest waypoint coordinate.
+- [x] 1.3 Run the focused projectile-pathfinder tests before the production correction and confirm the range-permissive regression fails for the mask-only behavior.
+
+## 2. Projectile Traversal Correction
+
+- [x] 2.1 Make `ProjectilePathFinder` honor its existing traversal mask while allowing only the writer-derived range-permissive `ObjectBlock | ObjectAllowRange` object state.
+- [x] 2.2 Correct the southwest coordinate update and verify the focused regressions pass.
+
+## 3. Verification
+
+- [x] 3.1 Confirm `CreatureCombat` continues to use `IProjectilePathFinder` for ranged target reach without another collision evaluator.
+- [x] 3.2 Run the focused GameWorld test project and build, validate the OpenSpec change, and review the final diff for scope and duplicate collision logic.


### PR DESCRIPTION
## Summary

- Honor directional, floor, and floor-decoration collision masks during projectile traversal
- Preserve the range-permissive standard-object combination
- Correct southwest traversal coordinates
- Add focused MSTest coverage for object, cardinal wall, diagonal wall, and direct blocker cases

## Testing

- Not run (not requested)
Fixes #364 