### PR TITLE
Speed up C# CodeQL analysis with no-build mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-on-github
+    #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,6 @@ jobs:
       actions: read
       contents: read
 
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
     strategy:
       fail-fast: false
       matrix:
@@ -49,14 +46,12 @@ jobs:
           - language: actions
             build-mode: none
           - language: csharp
-            build-mode: manual
-            dotnet-version: "10.0.x"
+            build-mode: none
           - language: javascript-typescript
             build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # Use 'java-kotlin' to analyze code written in JavaScript, TypeScript or both
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
@@ -64,20 +59,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Install .NET SDK ${{ matrix.dotnet-version }}
-        if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-          cache: true
-          cache-dependency-path: "**/packages.lock*.json"
-
-      # Add any setup steps before running the `github/codeql-action/init` action.
-      # This includes steps like installing compilers or runtimes (`actions/setup-node`
-      # or others). This is typically only required for manual builds.
-      # - name: Setup runtime (example)
-      #   uses: actions/setup-example@v1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -92,18 +73,6 @@ jobs:
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-
-      - name: Restore .NET solution
-        if: matrix.language == 'csharp'
-        run: dotnet restore Hagalaz.sln --locked-mode
-
-      - name: Build .NET solution
-        if: matrix.language == 'csharp'
-        run: >
-          dotnet build Hagalaz.sln
-          --configuration Release
-          --no-restore
-          --no-incremental
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/supported-runners-on-github
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
@@ -51,7 +51,8 @@ jobs:
             build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in JavaScript, TypeScript or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how


### PR DESCRIPTION
## Summary

Switch the C# CodeQL job from `manual` build mode to the supported `none` build mode and remove the explicit .NET setup, restore, and full Release solution build from the CodeQL workflow.

## Why

The existing CodeQL job spends most of its runtime tracing a complete `dotnet build Hagalaz.sln` before query evaluation. In the investigated run, the CodeQL-traced build took roughly 5m33s and analysis another 4m43s, while the normal CI build of the solution was around 53s.

For C#, CodeQL supports no-build analysis. Using `build-mode: none` avoids duplicating the normal CI compilation solely for CodeQL extraction and allows CodeQL's supported incremental/overlay analysis path to be used on pull requests.

## Changes

- Change C# `build-mode` from `manual` to `none`.
- Remove the C#-only `actions/setup-dotnet` step.
- Remove the explicit `dotnet restore` step.
- Remove the explicit full Release `dotnet build` step.
- Remove the workflow-level `NUGET_PACKAGES` setting that was only used by those steps.
- Keep the existing `security-and-quality` query suite unchanged, so this PR does not reduce configured query coverage.

## Impact

Normal CI remains responsible for compiling and testing Hagalaz. CodeQL remains responsible for static analysis, but no longer performs a second traced full-solution build just to construct the C# database.

This should substantially reduce the C# CodeQL job time, especially on pull requests where CodeQL can use its incremental analysis mechanisms.

## Validation

The workflow structure and language matrix remain unchanged apart from the C# build mode. The PR's CodeQL run itself is the relevant end-to-end validation for the no-build configuration.