### PR TITLE
Fix pathfinder cap result semantics

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs
@@ -85,10 +85,9 @@ namespace Hagalaz.Services.GameWorld.Tests
             var from = Location.Create(1, 1, 0);
             var to = Location.Create(2, 1, 0);
 
-            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
 
             Assert.IsTrue(path.Successful);
-            Assert.AreEqual(0, path.Steps);
             Assert.IsTrue(path.ReachedDestination);
             Assert.IsFalse(path.MovedNearDestination);
         }
@@ -99,12 +98,11 @@ namespace Hagalaz.Services.GameWorld.Tests
             var from = Location.Create(1, 1, 0);
             var to = Location.Create(from.X + QueueSize + 1, from.Y, from.Z);
 
-            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
 
             Assert.IsFalse(path.Successful);
             Assert.AreEqual(QueueSize, path.Count());
             Assert.AreEqual(Location.Create(from.X + QueueSize, from.Y, from.Z), path.Last());
-            Assert.AreEqual(QueueSize, path.Steps);
             Assert.IsTrue(path.MovedNear);
             Assert.IsFalse(path.ReachedDestination);
             Assert.IsFalse(path.MovedNearDestination);
@@ -116,12 +114,11 @@ namespace Hagalaz.Services.GameWorld.Tests
             var from = Location.Create(1, 1, 0);
             var to = Location.Create(from.X + QueueSize, from.Y, from.Z);
 
-            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
 
             Assert.IsTrue(path.Successful);
             Assert.AreEqual(QueueSize, path.Count());
             Assert.AreEqual(to, path.Last());
-            Assert.AreEqual(QueueSize - 1, path.Steps);
             Assert.IsFalse(path.MovedNear);
             Assert.IsFalse(path.ReachedDestination);
             Assert.IsFalse(path.MovedNearDestination);
@@ -134,12 +131,11 @@ namespace Hagalaz.Services.GameWorld.Tests
             var to = Location.Create(4, 1, 0);
             _mapRegionService.GetClippingFlag(3, 1, 0).Returns(CollisionFlag.FloorBlock);
 
-            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+            var path = _pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
 
             Assert.IsFalse(path.Successful);
             Assert.AreEqual(1, path.Count());
             Assert.AreEqual(Location.Create(2, 1, 0), path.Last());
-            Assert.AreEqual(1, path.Steps);
             Assert.IsTrue(path.MovedNear);
             Assert.IsFalse(path.ReachedDestination);
             Assert.IsFalse(path.MovedNearDestination);

--- a/Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs
@@ -10,6 +10,7 @@ namespace Hagalaz.Services.GameWorld.Tests
     [TestClass]
     public class DumbPathfinderTests
     {
+        private const int QueueSize = 4096;
         private DumbPathFinder _pathfinder;
         private IMapRegionService _mapRegionService;
 
@@ -76,6 +77,72 @@ namespace Hagalaz.Services.GameWorld.Tests
 
             // Assert
             Assert.IsFalse(path.Successful);
+        }
+
+        [TestMethod]
+        public void Find_SingleStepPath_SetsDestinationFlags()
+        {
+            var from = Location.Create(1, 1, 0);
+            var to = Location.Create(2, 1, 0);
+
+            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            Assert.IsTrue(path.Successful);
+            Assert.AreEqual(0, path.Steps);
+            Assert.IsTrue(path.ReachedDestination);
+            Assert.IsFalse(path.MovedNearDestination);
+        }
+
+        [TestMethod]
+        public void Find_PathExceedsStepLimit_ReturnsUnsuccessfulPartialPath()
+        {
+            var from = Location.Create(1, 1, 0);
+            var to = Location.Create(from.X + QueueSize + 1, from.Y, from.Z);
+
+            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            Assert.IsFalse(path.Successful);
+            Assert.AreEqual(QueueSize, path.Count());
+            Assert.AreEqual(Location.Create(from.X + QueueSize, from.Y, from.Z), path.Last());
+            Assert.AreEqual(QueueSize, path.Steps);
+            Assert.IsTrue(path.MovedNear);
+            Assert.IsFalse(path.ReachedDestination);
+            Assert.IsFalse(path.MovedNearDestination);
+        }
+
+        [TestMethod]
+        public void Find_PathReachingFinalPermittedStep_RemainsSuccessful()
+        {
+            var from = Location.Create(1, 1, 0);
+            var to = Location.Create(from.X + QueueSize, from.Y, from.Z);
+
+            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            Assert.IsTrue(path.Successful);
+            Assert.AreEqual(QueueSize, path.Count());
+            Assert.AreEqual(to, path.Last());
+            Assert.AreEqual(QueueSize - 1, path.Steps);
+            Assert.IsFalse(path.MovedNear);
+            Assert.IsFalse(path.ReachedDestination);
+            Assert.IsFalse(path.MovedNearDestination);
+        }
+
+        [TestMethod]
+        public void Find_PathBlockedBeforeStepLimit_PreservesCollisionFailureState()
+        {
+            var from = Location.Create(1, 1, 0);
+            var to = Location.Create(4, 1, 0);
+            _mapRegionService.GetClippingFlag(3, 1, 0).Returns(CollisionFlag.FloorBlock);
+
+            var path = (Path)_pathfinder.Find(from, 1, to, 1, 1, 0, 0, 0, false);
+
+            Assert.IsFalse(path.Successful);
+            Assert.AreEqual(1, path.Count());
+            Assert.AreEqual(Location.Create(2, 1, 0), path.Last());
+            Assert.AreEqual(1, path.Steps);
+            Assert.IsTrue(path.MovedNear);
+            Assert.IsFalse(path.ReachedDestination);
+            Assert.IsFalse(path.MovedNearDestination);
         }
 
         [TestMethod]

--- a/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
@@ -10,7 +10,6 @@ using Hagalaz.Game.Extensions;
 using Hagalaz.Services.GameWorld.Logic.Pathfinding;
 using Hagalaz.Services.GameWorld.Model.Maps.Regions;
 using NSubstitute;
-using Path = Hagalaz.Services.GameWorld.Logic.Pathfinding.Path;
 
 namespace Hagalaz.Services.GameWorld.Tests;
 
@@ -140,10 +139,9 @@ public sealed class ProjectilePathfinderTests
     {
         var destination = Location.Create(OriginX + 1, OriginY, Plane, Dimension);
 
-        var path = (Path)Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+        var path = Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
 
         Assert.IsTrue(path.Successful);
-        Assert.AreEqual(0, path.Steps);
         Assert.IsTrue(path.ReachedDestination);
         Assert.IsFalse(path.MovedNearDestination);
     }
@@ -156,11 +154,10 @@ public sealed class ProjectilePathfinderTests
         var from = Location.Create(OriginX, OriginY, Plane, Dimension);
         var destination = Location.Create(OriginX + deltaX, OriginY + deltaY, Plane, Dimension);
 
-        var path = (Path)Find(EmptyCollision, from, destination);
+        var path = Find(EmptyCollision, from, destination);
 
         Assert.IsFalse(path.Successful);
         Assert.AreEqual(0, path.Count());
-        Assert.AreEqual(QueueSize, path.Steps);
         Assert.IsTrue(path.MovedNear);
         Assert.IsFalse(path.ReachedDestination);
         Assert.IsFalse(path.MovedNearDestination);
@@ -174,12 +171,11 @@ public sealed class ProjectilePathfinderTests
         var from = Location.Create(OriginX, OriginY, Plane, Dimension);
         var destination = Location.Create(OriginX + deltaX, OriginY + deltaY, Plane, Dimension);
 
-        var path = (Path)Find(EmptyCollision, from, destination);
+        var path = Find(EmptyCollision, from, destination);
 
         Assert.IsTrue(path.Successful);
         Assert.HasCount(1, path);
         Assert.AreEqual(destination, path.Single());
-        Assert.AreEqual(QueueSize - 1, path.Steps);
         Assert.IsFalse(path.MovedNear);
         Assert.IsFalse(path.ReachedDestination);
         Assert.IsFalse(path.MovedNearDestination);
@@ -195,11 +191,10 @@ public sealed class ProjectilePathfinderTests
             [(OriginX + 2, OriginY)] = CollisionFlag.ObjectBlock
         };
 
-        var path = (Path)Find(collision, from, destination);
+        var path = Find(collision, from, destination);
 
         Assert.IsFalse(path.Successful);
         Assert.AreEqual(0, path.Count());
-        Assert.AreEqual(1, path.Steps);
         Assert.IsTrue(path.MovedNear);
         Assert.IsFalse(path.ReachedDestination);
         Assert.IsFalse(path.MovedNearDestination);

--- a/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs
@@ -10,12 +10,14 @@ using Hagalaz.Game.Extensions;
 using Hagalaz.Services.GameWorld.Logic.Pathfinding;
 using Hagalaz.Services.GameWorld.Model.Maps.Regions;
 using NSubstitute;
+using Path = Hagalaz.Services.GameWorld.Logic.Pathfinding.Path;
 
 namespace Hagalaz.Services.GameWorld.Tests;
 
 [TestClass]
 public sealed class ProjectilePathfinderTests
 {
+    private const int QueueSize = 4096;
     private const int OriginX = 50;
     private const int OriginY = 50;
     private const int Plane = 0;
@@ -131,6 +133,76 @@ public sealed class ProjectilePathfinderTests
 
         Assert.IsTrue(path.Successful);
         Assert.AreEqual(destination, path.Last());
+    }
+
+    [TestMethod]
+    public void Find_SingleStepPath_SetsDestinationFlags()
+    {
+        var destination = Location.Create(OriginX + 1, OriginY, Plane, Dimension);
+
+        var path = (Path)Find(EmptyCollision, Location.Create(OriginX, OriginY, Plane, Dimension), destination);
+
+        Assert.IsTrue(path.Successful);
+        Assert.AreEqual(0, path.Steps);
+        Assert.IsTrue(path.ReachedDestination);
+        Assert.IsFalse(path.MovedNearDestination);
+    }
+
+    [TestMethod]
+    [DataRow(QueueSize + 1, 0)]
+    [DataRow(0, QueueSize + 1)]
+    public void Find_PathExceedsStepLimit_ReturnsUnsuccessfulTrace(int deltaX, int deltaY)
+    {
+        var from = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var destination = Location.Create(OriginX + deltaX, OriginY + deltaY, Plane, Dimension);
+
+        var path = (Path)Find(EmptyCollision, from, destination);
+
+        Assert.IsFalse(path.Successful);
+        Assert.AreEqual(0, path.Count());
+        Assert.AreEqual(QueueSize, path.Steps);
+        Assert.IsTrue(path.MovedNear);
+        Assert.IsFalse(path.ReachedDestination);
+        Assert.IsFalse(path.MovedNearDestination);
+    }
+
+    [TestMethod]
+    [DataRow(QueueSize, 0)]
+    [DataRow(0, QueueSize)]
+    public void Find_PathReachingFinalPermittedStep_RemainsSuccessful(int deltaX, int deltaY)
+    {
+        var from = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var destination = Location.Create(OriginX + deltaX, OriginY + deltaY, Plane, Dimension);
+
+        var path = (Path)Find(EmptyCollision, from, destination);
+
+        Assert.IsTrue(path.Successful);
+        Assert.HasCount(1, path);
+        Assert.AreEqual(destination, path.Single());
+        Assert.AreEqual(QueueSize - 1, path.Steps);
+        Assert.IsFalse(path.MovedNear);
+        Assert.IsFalse(path.ReachedDestination);
+        Assert.IsFalse(path.MovedNearDestination);
+    }
+
+    [TestMethod]
+    public void Find_PathBlockedBeforeStepLimit_PreservesCollisionFailureState()
+    {
+        var from = Location.Create(OriginX, OriginY, Plane, Dimension);
+        var destination = Location.Create(OriginX + 3, OriginY, Plane, Dimension);
+        var collision = new Dictionary<(int X, int Y), CollisionFlag>
+        {
+            [(OriginX + 2, OriginY)] = CollisionFlag.ObjectBlock
+        };
+
+        var path = (Path)Find(collision, from, destination);
+
+        Assert.IsFalse(path.Successful);
+        Assert.AreEqual(0, path.Count());
+        Assert.AreEqual(1, path.Steps);
+        Assert.IsTrue(path.MovedNear);
+        Assert.IsFalse(path.ReachedDestination);
+        Assert.IsFalse(path.MovedNearDestination);
     }
 
     [TestMethod]

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/DumbPathFinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/DumbPathFinder.cs
@@ -41,6 +41,8 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
             {
                 if (QueueSize <= ++path.Steps)
                 {
+                    path.Successful = false;
+                    path.MovedNear = x != from.X || y != from.Y;
                     return path;
                 }
                 var direction = DirectionHelper.GetDirection(x, y, to.X, to.Y);

--- a/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs
@@ -67,7 +67,11 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
 
             while (x != targetX)
             {
-                path.Steps++;
+                if (QueueSize <= ++path.Steps)
+                {
+                    return false;
+                }
+
                 x += direction;
 
                 var y = GetTileCoordinate(yBig);
@@ -107,7 +111,11 @@ namespace Hagalaz.Services.GameWorld.Logic.Pathfinding
 
             while (y != targetY)
             {
-                path.Steps++;
+                if (QueueSize <= ++path.Steps)
+                {
+                    return false;
+                }
+
                 y += direction;
 
                 var x = GetTileCoordinate(xBig);

--- a/openspec/changes/fix-pathfinder-cap-result-semantics/.openspec.yaml
+++ b/openspec/changes/fix-pathfinder-cap-result-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/fix-pathfinder-cap-result-semantics/design.md
+++ b/openspec/changes/fix-pathfinder-cap-result-semantics/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`PathFinderBase` already owns the shared `QueueSize` safety limit. `DumbPathFinder` counts simple traversal steps from an initial `Path.Steps` value of `-1`, but returns its initially successful result when the limit is reached before the destination. The current projectile finder uses the same `Path` result type and increments `Steps` while tracing, but does not apply the shared limit. `Path.ReachedDestination` and `Path.MovedNearDestination` are derived from the existing `Successful`, `MovedNear`, and `Steps` values, so the correction must preserve that contract.
+
+The projectile finder intentionally does not expose collision-probe tiles as movement points: it adds only the requested destination after a complete successful trace. A capped projectile trace therefore returns no points, just as a collision failure does, while the result status records the failed operation and progress.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make cap exhaustion an unsuccessful result in both affected finders.
+- Enforce the existing `QueueSize` limit in both projectile trace loops without changing ray geometry or collision checks.
+- Preserve meaningful progress state and existing point/derived-property semantics.
+- Add deterministic MSTest regressions for cap boundaries and existing pre-cap failures.
+
+**Non-Goals:**
+
+- No new result abstraction, path state, or public API.
+- No changes to `Path`, `IPath`, collision flags, traversal direction, fixed-point ray calculations, or consumers.
+- No change to the cap value or to SmartPathFinder's independently owned reconstruction behavior.
+
+## Decisions
+
+### Use the existing cap and result type
+
+Each finder will use `PathFinderBase.QueueSize` as its only safety limit. On a cap check that occurs before the next traversal, the finder will set `Successful = false` and return. `DumbPathFinder` will set `MovedNear` from whether its current coordinates differ from the source, matching its existing collision-failure progress behavior. `ProjectilePathFinder` will retain its existing `MovedNear = path.Steps > 0` failure rule, which distinguishes a first-probe failure from a trace that made progress.
+
+Adding a new cap-specific result state or changing `Path` derived properties would duplicate state and expand the public contract without being necessary to distinguish success from an unreached target.
+
+### Apply the projectile guard inside both axis tracers
+
+The X- and Y-dominant trace loops each increment `path.Steps` and then check the shared cap before advancing or reading collision. This preserves the existing off-axis fixed-point sequence and ensures the exact final permitted step succeeds, while the next attempted step fails before any additional movement or collision probe.
+
+Centralizing the guard in `Find` is rejected because the number of iterations is owned by the two private trace loops and a post-trace check cannot prevent unbounded tracing.
+
+### Test the boundary with deterministic coordinate distances
+
+Focused tests will use clear, deliberately distant horizontal routes to require exactly the permitted number of steps or one more. They will also retain short-path and pre-cap collision cases. Assertions will inspect point contents/count, `Successful`, `MovedNear`, `Steps`, and both derived destination properties so the cap result cannot regress into a superficially successful partial route.
+
+## Risks / Trade-offs
+
+- [Existing consumers may rely on false-success partial routes] → The result contract explicitly defines success as reaching the requested operation; consumers already inspect `Successful`, and no consumer-side change is needed.
+- [Projectile cap failures expose no partial points] → Preserve the existing projectile convention that only a fully successful trace adds the destination; use `Steps` and `MovedNear` to report progress.
+- [Boundary off-by-one] → Test a target at exactly the permitted traversal count separately from a target one step beyond it.
+
+## Migration Plan
+
+No data or deployment migration is required. Deploy the code and tests together; rollback is a normal code revert if needed.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-pathfinder-cap-result-semantics/proposal.md
+++ b/openspec/changes/fix-pathfinder-cap-result-semantics/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`DumbPathFinder` returns its initially successful `Path` when the safety step cap is reached before the requested destination, allowing a partial path to be consumed as a successful route. `ProjectilePathFinder` has the same result risk because its ray tracing does not enforce the shared safety cap. Both finders must report whether the requested operation actually reached its target.
+
+## What Changes
+
+- Mark capped `DumbPathFinder` routes unsuccessful when the target has not been reached, while preserving whether traversal made progress.
+- Apply the existing `PathFinderBase.QueueSize` cap to projectile ray tracing and return an unsuccessful result when it is exhausted before the target.
+- Add test-first MSTest coverage for normal success, cap exhaustion, final permitted step, collision failure, returned points, step counts, and derived destination flags.
+
+### Non-goals
+
+- Do not change either pathfinding algorithm, collision masks, ray geometry, or the numerical cap.
+- Do not change `Path`, `IPath`, movement execution, consumers, or introduce a new result type.
+- Do not duplicate or address directional traversal defects tracked by other issues.
+
+### Acceptance Criteria
+
+- Neither `DumbPathFinder` nor `ProjectilePathFinder` reports `Successful == true` after its cap is exhausted without reaching the requested target.
+- A target reached on the final permitted traversal remains successful and has the existing step/result semantics.
+- Normal short paths and pre-cap collision failures retain their current behavior.
+- Cap results have deterministic `MovedNear`, `Steps`, point-count, `ReachedDestination`, and `MovedNearDestination` behavior covered by focused tests.
+- Existing consumers continue receiving the existing `IPath` contract without a new architecture.
+
+### Stop Conditions
+
+Pause and record follow-up work if satisfying these criteria requires changing `Path` or `IPath`, movement/consumer behavior, collision writers, or either finder’s traversal geometry.
+
+## Capabilities
+
+### New Capabilities
+
+- `pathfinder-cap-result-semantics`: Report coherent unsuccessful results when simple or projectile traversal exhausts its safety cap before reaching the target.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/DumbPathFinder.cs`
+- `Hagalaz.Services.GameWorld/Logic/Pathfinding/ProjectilePathfinder.cs`
+- `Hagalaz.Services.GameWorld.Tests/DumbPathfinderTests.cs`
+- `Hagalaz.Services.GameWorld.Tests/ProjectilePathfinderTests.cs`
+- Reuses `PathFinderBase.QueueSize`, `Path`, `IMapRegionService`, and the existing MSTest/NSubstitute fixtures; no API, dependency, persistence, deployment, or migration changes.

--- a/openspec/changes/fix-pathfinder-cap-result-semantics/specs/pathfinder-cap-result-semantics/spec.md
+++ b/openspec/changes/fix-pathfinder-cap-result-semantics/specs/pathfinder-cap-result-semantics/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Dumb path cap exhaustion is unsuccessful
+`DumbPathFinder` SHALL report an unsuccessful `IPath` when its safety step limit is reached before the requested X/Y destination, and SHALL preserve the traversed points and progress state accumulated before the limit.
+
+#### Scenario: A short clear simple path reaches its destination
+- **WHEN** a clear simple path requires fewer than the safety limit of steps
+- **THEN** the result SHALL be successful and its final point SHALL equal the requested destination
+
+#### Scenario: A simple path exceeds the safety limit
+- **WHEN** a clear simple path requires more steps than the safety limit
+- **THEN** the result SHALL be unsuccessful, SHALL contain only the points traversed before the rejected step, SHALL report the safety-limit step count, and SHALL report `MovedNear` as true when traversal moved from the source
+
+#### Scenario: A simple path reaches the destination on the final permitted step
+- **WHEN** a clear simple path requires exactly the safety limit of steps
+- **THEN** the result SHALL be successful and SHALL contain the requested destination as its final point
+
+### Requirement: Projectile path cap exhaustion is unsuccessful
+`ProjectilePathFinder` SHALL enforce the existing pathfinder safety step limit while tracing either dominant axis and SHALL report an unsuccessful `IPath` when the limit is reached before the requested target tile.
+
+#### Scenario: A short clear projectile trace reaches its target
+- **WHEN** a same-plane projectile trace requires fewer than the safety limit of steps and encounters no LOS blocker
+- **THEN** the result SHALL be successful and SHALL contain only the requested target tile
+
+#### Scenario: A projectile trace exceeds the safety limit
+- **WHEN** a same-plane projectile trace requires more steps than the safety limit
+- **THEN** the result SHALL be unsuccessful, SHALL not append the target tile, SHALL report the safety-limit step count, and SHALL report `MovedNear` as true after more than one trace step
+
+#### Scenario: A projectile trace reaches the target on the final permitted step
+- **WHEN** a same-plane projectile trace requires exactly the safety limit of steps and encounters no LOS blocker
+- **THEN** the result SHALL be successful and SHALL contain the requested target tile
+
+### Requirement: Existing path result semantics remain coherent
+Cap handling SHALL use the existing `Path` fields and SHALL not change pre-cap collision behavior or the derived destination properties.
+
+#### Scenario: Collision failure occurs before the cap
+- **WHEN** either finder encounters its existing blocking collision condition before the safety limit
+- **THEN** the result SHALL remain unsuccessful with the existing points, step count, and progress indication for that collision failure
+
+#### Scenario: A successful one-step path reaches its destination
+- **WHEN** either finder completes a one-step path without collision
+- **THEN** `Successful` SHALL be true, `Steps` SHALL be zero, `ReachedDestination` SHALL be true, and `MovedNearDestination` SHALL be false
+
+#### Scenario: A capped path has not reached its destination
+- **WHEN** either finder exhausts its safety limit before reaching the requested destination
+- **THEN** `ReachedDestination` and `MovedNearDestination` SHALL both be false because `Successful` is false

--- a/openspec/changes/fix-pathfinder-cap-result-semantics/tasks.md
+++ b/openspec/changes/fix-pathfinder-cap-result-semantics/tasks.md
@@ -1,0 +1,16 @@
+## 1. Test-first cap regressions
+
+- [x] 1.1 Add `DumbPathFinder` regressions for short success, pre-cap collision failure, exact final permitted step, cap exhaustion, traversed points, `MovedNear`, `Steps`, and derived destination flags.
+- [x] 1.2 Add `ProjectilePathFinder` regressions for short success, pre-cap LOS collision failure, exact final permitted step, cap exhaustion, destination-point behavior, `MovedNear`, `Steps`, and derived destination flags.
+- [x] 1.3 Run the focused pathfinder tests before production changes and confirm the new cap regressions fail against the current implementation.
+
+## 2. Cap result correction
+
+- [x] 2.1 Mark `DumbPathFinder` cap exhaustion unsuccessful and preserve its existing progress/point semantics.
+- [x] 2.2 Enforce `PathFinderBase.QueueSize` in both projectile trace loops and return the existing unsuccessful failure shape when the target is not reached.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused `DumbPathFinder` and `ProjectilePathFinder` tests after the corrections.
+- [x] 3.2 Run the complete `Hagalaz.Services.GameWorld.Tests` project and a production build.
+- [x] 3.3 Validate the OpenSpec change strictly and review `git diff --check` plus the final diff for scope and duplicate mechanisms.


### PR DESCRIPTION
## Summary

- Fixes #369
- Mark capped dumb paths as unsuccessful when the destination is not reached
- Enforce the existing step limit during projectile tracing
- Add regression coverage for cap boundaries, collision failures, progress state, and destination flags

## Testing

- Added focused MSTest coverage for `DumbPathFinder` and `ProjectilePathFinder`