### PR TITLE
Document web 3D rendering, codec, and deobfuscation foundation

### DIFF
--- a/docs/3d-rendering/README.md
+++ b/docs/3d-rendering/README.md
@@ -9,10 +9,19 @@ The analysis was performed against:
 
 ## Documents
 
-- [Game client renderer](game-client-renderer.md) maps the partially deobfuscated client classes to stable rendering concepts and records verified terrain, object, model, scene, coordinate, and backend behavior.
+- [Rendering deobfuscation map](client-rendering-deobfuscation.md) defines the canonical human-readable names for the terrain, scene, floor-material, occlusion, entity, light and model concepts found in the decompiled client, including confidence and source locators.
+- [Game client renderer](game-client-renderer.md) records the verified terrain, object, model, scene, coordinate and renderer-backend behavior using those semantic names.
 - [Map cache decode/encode guide](cache-map-codecs.md) gives byte-level implementation instructions for cache containers, `mX_Y` terrain, `lX_Y` object placements, smart/huge-smart delta coding, XTEA, canonical writing, corruption guards, round-trip tests, and the current Hagalaz codec gaps.
 - [Implicit terrain height generation](terrain-height-generation.md) records the exact opcode-`0` plane-0 height algorithm, including deterministic raw noise, smoothing, cosine interpolation, client lookup-table generation, coordinate offsets, scaling, encoder implications, and required parity tests.
 - [Web renderer foundation](web-renderer-foundation.md) describes the current Hagalaz gaps, target data contracts, web architecture, rendering-engine choice, phased implementation, and verification strategy.
+
+## Naming rule
+
+The GameClient is only partially deobfuscated, but generated names such as `Class274`, `Class356`, `Class491` and `method6416` are **not architecture**.
+
+The documents in this directory use stable semantic names such as `TerrainBuilder`, `SceneGraph`, `FloorUnderlayDefinition`, `OcclusionManager`, `TerrainSurface` and `SceneLight`. The generated identifiers belong only in the [deobfuscation source-locator map](client-rendering-deobfuscation.md) so somebody can find the current decompiled source until the source-level rename is completed.
+
+Do not copy a generated GameClient identifier into a new Hagalaz API, DTO, service, TypeScript type or renderer abstraction. If a client concept is not sufficiently understood to name, keep it internal and document the uncertainty instead of exporting an obfuscated name.
 
 ## Current status
 
@@ -33,6 +42,7 @@ This means the first implementation work belongs at the cache/render-data bounda
 7. **Do not make MapLibre the core scene renderer.** It is useful for geographic-style overview/navigation surfaces, but its Mercator/globe camera and custom-layer model do not solve RuneScape scene decoding, model assembly, or plane semantics.
 8. **Keep cache payload and container encoding separate.** Terrain and location payload codecs must not know about compression, XTEA, CRC, Whirlpool, reference-table mutation, or Hagalaz's internal synthetic `MapCodec` stream.
 9. **Preserve source semantics needed for writing.** Runtime/effective values such as bridge-adjusted planes must not overwrite the raw source plane or original height encoding if later cache encoding depends on it.
+10. **Use semantic names, never generated decompiler names, in new architecture.** Generated source identifiers exist only as temporary source locators and must not become permanent server/web vocabulary.
 
 ## Terminology
 

--- a/docs/3d-rendering/README.md
+++ b/docs/3d-rendering/README.md
@@ -11,6 +11,7 @@ The analysis was performed against:
 
 - [Game client renderer](game-client-renderer.md) maps the partially deobfuscated client classes to stable rendering concepts and records verified terrain, object, model, scene, coordinate, and backend behavior.
 - [Map cache decode/encode guide](cache-map-codecs.md) gives byte-level implementation instructions for cache containers, `mX_Y` terrain, `lX_Y` object placements, smart/huge-smart delta coding, XTEA, canonical writing, corruption guards, round-trip tests, and the current Hagalaz codec gaps.
+- [Implicit terrain height generation](terrain-height-generation.md) records the exact opcode-`0` plane-0 height algorithm, including deterministic raw noise, smoothing, cosine interpolation, client lookup-table generation, coordinate offsets, scaling, encoder implications, and required parity tests.
 - [Web renderer foundation](web-renderer-foundation.md) describes the current Hagalaz gaps, target data contracts, web architecture, rendering-engine choice, phased implementation, and verification strategy.
 
 ## Current status

--- a/docs/3d-rendering/README.md
+++ b/docs/3d-rendering/README.md
@@ -2,15 +2,18 @@
 
 This directory records the verified RuneScape scene-rendering behavior that is relevant to Hagalaz and the target architecture for rendering those scenes in the web UI.
 
-The analysis was performed against:
+The primary local analysis was performed against:
 
 - `frankvdb7/Hagalaz` `main` at `ba134cbcd531a6cd3b35c19b20404084e926bbfc`.
 - `frankvdb7/Hagalaz.GameClient` `main` at `6eac3762cc46cec484131369691b5221fd1277bf`.
 
+Public revision-adjacent sources are used only as additional evidence. In particular, `LostCityRS/RS742` is a strong structural/naming reference but documents itself as 742.1, while the historically circulated client was 742.2 and has different packet read/write alternative methods.
+
 ## Documents
 
-- [Rendering deobfuscation map](client-rendering-deobfuscation.md) defines the canonical human-readable names for the terrain, scene, floor-material, occlusion, entity, light and model concepts found in the decompiled client, including confidence and source locators.
-- [Game client renderer](game-client-renderer.md) records the verified terrain, object, model, scene, coordinate and renderer-backend behavior using those semantic names.
+- [Rendering deobfuscation map](client-rendering-deobfuscation.md) records the local source locators, first-pass semantic mappings, confidence and evidence for the terrain, scene, floor-material, occlusion, entity, light and model concepts.
+- [External revision-742 references](external-742-reference.md) records the public 742 cross-check, revision caveats, stronger revision-specific names, renderer backend vocabulary and the evidence hierarchy used when those names supersede a first-pass alias.
+- [Game client renderer](game-client-renderer.md) records the verified terrain, object, model, scene, coordinate and renderer-backend behavior.
 - [Map cache decode/encode guide](cache-map-codecs.md) gives byte-level implementation instructions for cache containers, `mX_Y` terrain, `lX_Y` object placements, smart/huge-smart delta coding, XTEA, canonical writing, corruption guards, round-trip tests, and the current Hagalaz codec gaps.
 - [Implicit terrain height generation](terrain-height-generation.md) records the exact opcode-`0` plane-0 height algorithm, including deterministic raw noise, smoothing, cosine interpolation, client lookup-table generation, coordinate offsets, scaling, encoder implications, and required parity tests.
 - [Web renderer foundation](web-renderer-foundation.md) describes the current Hagalaz gaps, target data contracts, web architecture, rendering-engine choice, phased implementation, and verification strategy.
@@ -19,9 +22,39 @@ The analysis was performed against:
 
 The GameClient is only partially deobfuscated, but generated names such as `Class274`, `Class356`, `Class491` and `method6416` are **not architecture**.
 
-The documents in this directory use stable semantic names such as `TerrainBuilder`, `SceneGraph`, `FloorUnderlayDefinition`, `OcclusionManager`, `TerrainSurface` and `SceneLight`. The generated identifiers belong only in the [deobfuscation source-locator map](client-rendering-deobfuscation.md) so somebody can find the current decompiled source until the source-level rename is completed.
+Use the local source mapping together with the public 742 cross-check. Several initial generic names now have stronger revision-specific equivalents, for example:
+
+- `Class274` -> `MapLoader`;
+- current `Map` -> `ClientMapLoader`;
+- `Class356` -> `Scene`;
+- `Class340` -> `Tile`;
+- `Class_xa` -> `FloorModel`;
+- `GraphicsToolkit` -> `RendererToolkit`;
+- `Entity_Sub1` -> `GraphEntity`;
+- `Class80` -> `ScreenBoundingBox`;
+- `Class348` -> `EntityBounds`;
+- `Class338` -> `PickableEntityList`;
+- `Class353` -> `PickableEntity`;
+- `Node_Sub14` -> `Light`;
+- `MapFlickeringEffect` -> `StaticPointLight`;
+- floor cache records follow `FloorUnderlayType` / `FloorOverlayType` and `*TypeList` terminology in the public 742 reference.
+
+The exact mapping, evidence and revision caveats are in [External revision-742 references](external-742-reference.md). Generated identifiers belong only in source-locator material so somebody can find the current decompiled source until the source-level rename is completed.
 
 Do not copy a generated GameClient identifier into a new Hagalaz API, DTO, service, TypeScript type or renderer abstraction. If a client concept is not sufficiently understood to name, keep it internal and document the uncertainty instead of exporting an obfuscated name.
+
+Source-level GameClient terminology and public Hagalaz API terminology do not have to be identical. A name such as `FloorModel` is useful for matching the original client subsystem, while a server/web rendering DTO may still use clearer renderer-neutral terrain terminology.
+
+## Evidence rule
+
+When deobfuscating or documenting a GameClient concept, use evidence in this order:
+
+1. local `Hagalaz.GameClient` construction, fields, inheritance, algorithms and call sites;
+2. a structurally matching class in `LostCityRS/RS742`;
+3. adjacent RuneTek clients with stronger canonical/Jagex naming evidence, such as 2011Scape;
+4. editors/RSPS implementations only as secondary triangulation.
+
+Never replace a local codec or protocol operation solely because an external project does it differently. The 742.1/742.2 packet-read/write distinction is a concrete example of why structural naming evidence and byte-level protocol evidence must remain separate.
 
 ## Current status
 
@@ -35,7 +68,7 @@ This means the first implementation work belongs at the cache/render-data bounda
 
 1. **Decode RuneScape cache semantics once on the server.** The browser should consume a documented rendering contract rather than implement a second cache decoder.
 2. **Keep gameplay and rendering contracts separate.** `IMapType` and `IObjectType` should not grow into rendering-engine DTOs. Rendering projections can reuse the same underlying cache providers/codecs while exposing the extra scene data deliberately.
-3. **Keep scene assembly independent from the graphics backend.** The original client follows this principle through `GraphicsToolkit`. The web implementation only needs a small renderer boundary, not a port of that large API.
+3. **Keep scene assembly independent from the graphics backend.** The original client follows this principle through its renderer toolkit abstraction. The web implementation only needs a small renderer boundary, not a port of that large API.
 4. **Convert coordinate systems exactly once.** RuneScape cache/client coordinates remain authoritative in transport/domain data. A scene assembler converts them to the selected web-engine axes/units at one boundary.
 5. **Preserve region and chunk semantics.** A normal map region is 64×64 tiles, has four planes, and dynamic map parts are assembled from rotated 8×8 chunks.
 6. **Fidelity before effects.** Correct heights, floor shapes/materials, object models, shape selection, rotation, and transforms come before shadows, atmosphere, animation, water, or post-processing.
@@ -43,6 +76,7 @@ This means the first implementation work belongs at the cache/render-data bounda
 8. **Keep cache payload and container encoding separate.** Terrain and location payload codecs must not know about compression, XTEA, CRC, Whirlpool, reference-table mutation, or Hagalaz's internal synthetic `MapCodec` stream.
 9. **Preserve source semantics needed for writing.** Runtime/effective values such as bridge-adjusted planes must not overwrite the raw source plane or original height encoding if later cache encoding depends on it.
 10. **Use semantic names, never generated decompiler names, in new architecture.** Generated source identifiers exist only as temporary source locators and must not become permanent server/web vocabulary.
+11. **External names require a local structural match.** Public deobfuscated clients are evidence, not authority over a different subrevision.
 
 ## Terminology
 
@@ -51,9 +85,9 @@ This means the first implementation work belongs at the cache/render-data bounda
 - **Chunk / region part**: an 8×8 subsection of a region used when assembling dynamic maps.
 - **Tile scale**: the legacy client uses 512 scene units per tile (`1 << 9`).
 - **Terrain flags**: collision/bridge/plane-related tile metadata; these are not the terrain height or floor material.
-- **Overlay / underlay**: floor definitions used together with tile shape/rotation and height data to construct visible terrain.
+- **Overlay / underlay**: floor types used together with tile shape/rotation and height data to construct visible terrain.
 - **Object placement**: object ID + shape + rotation + local X/Y/Z.
 - **Source plane**: plane encoded in the raw location payload before bridge/effective-plane adjustment.
 - **Effective plane**: runtime plane after terrain/bridge semantics have been applied.
 - **Object render definition**: model IDs selected by shape plus recolor/retexture, scale, offset, contouring, transform, animation, and related render metadata.
-- **Model definition**: decoded vertex/triangle/texture data from the cache before conversion to a backend-specific render model.
+- **Raw/unlit model**: decoded vertex/triangle/texture data from the cache before conversion to a backend-specific render `Model`; the public 742 reference names this concept `ModelUnlit`.

--- a/docs/3d-rendering/README.md
+++ b/docs/3d-rendering/README.md
@@ -1,0 +1,43 @@
+# 3D rendering
+
+This directory records the verified RuneScape scene-rendering behavior that is relevant to Hagalaz and the target architecture for rendering those scenes in the web UI.
+
+The analysis was performed against:
+
+- `frankvdb7/Hagalaz` `main` at `ba134cbcd531a6cd3b35c19b20404084e926bbfc`.
+- `frankvdb7/Hagalaz.GameClient` `main` at `6eac3762cc46cec484131369691b5221fd1277bf`.
+
+## Documents
+
+- [Game client renderer](game-client-renderer.md) maps the partially deobfuscated client classes to stable rendering concepts and records verified terrain, object, model, scene, coordinate, and backend behavior.
+- [Web renderer foundation](web-renderer-foundation.md) describes the current Hagalaz gaps, target data contracts, web architecture, rendering-engine choice, phased implementation, and verification strategy.
+
+## Current status
+
+Hagalaz does not currently have a working 3D RuneScape scene renderer in `Hagalaz.Web.App` on `main`. `maplibre-gl` is installed, but there is no map route, no renderer feature, and no MapLibre/Three.js/Babylon scene implementation in the Angular source.
+
+The cache service is also not yet able to supply enough rendering data. The current map model is intentionally gameplay-oriented: it preserves terrain flags and object placements, but not the height, overlay, underlay, floor-material, object render-definition, model-geometry, or texture information needed to reproduce the client scene.
+
+This means the first implementation work belongs at the cache/render-data boundary rather than in a more sophisticated Angular canvas component.
+
+## Foundation rules
+
+1. **Decode RuneScape cache semantics once on the server.** The browser should consume a documented rendering contract rather than implement a second cache decoder.
+2. **Keep gameplay and rendering contracts separate.** `IMapType` and `IObjectType` should not grow into rendering-engine DTOs. Rendering projections can reuse the same underlying cache providers/codecs while exposing the extra scene data deliberately.
+3. **Keep scene assembly independent from the graphics backend.** The original client follows this principle through `GraphicsToolkit`. The web implementation only needs a small renderer boundary, not a port of that large API.
+4. **Convert coordinate systems exactly once.** RuneScape cache/client coordinates remain authoritative in transport/domain data. A scene assembler converts them to the selected web-engine axes/units at one boundary.
+5. **Preserve region and chunk semantics.** A normal map region is 64×64 tiles, has four planes, and dynamic map parts are assembled from rotated 8×8 chunks.
+6. **Fidelity before effects.** Correct heights, floor shapes/materials, object models, shape selection, rotation, and transforms come before shadows, atmosphere, animation, water, or post-processing.
+7. **Do not make MapLibre the core scene renderer.** It is useful for geographic-style overview/navigation surfaces, but its Mercator/globe camera and custom-layer model do not solve RuneScape scene decoding, model assembly, or plane semantics.
+
+## Terminology
+
+- **Region**: 64×64 map tiles addressed by a region ID.
+- **Plane**: one of the four RuneScape height/scene levels.
+- **Chunk / region part**: an 8×8 subsection of a region used when assembling dynamic maps.
+- **Tile scale**: the legacy client uses 512 scene units per tile (`1 << 9`).
+- **Terrain flags**: collision/bridge/plane-related tile metadata; these are not the terrain height or floor material.
+- **Overlay / underlay**: floor definitions used together with tile shape/rotation and height data to construct visible terrain.
+- **Object placement**: object ID + shape + rotation + local X/Y/Z.
+- **Object render definition**: model IDs selected by shape plus recolor/retexture, scale, offset, contouring, transform, animation, and related render metadata.
+- **Model definition**: decoded vertex/triangle/texture data from the cache before conversion to a backend-specific render model.

--- a/docs/3d-rendering/README.md
+++ b/docs/3d-rendering/README.md
@@ -10,6 +10,7 @@ The analysis was performed against:
 ## Documents
 
 - [Game client renderer](game-client-renderer.md) maps the partially deobfuscated client classes to stable rendering concepts and records verified terrain, object, model, scene, coordinate, and backend behavior.
+- [Map cache decode/encode guide](cache-map-codecs.md) gives byte-level implementation instructions for cache containers, `mX_Y` terrain, `lX_Y` object placements, smart/huge-smart delta coding, XTEA, canonical writing, corruption guards, round-trip tests, and the current Hagalaz codec gaps.
 - [Web renderer foundation](web-renderer-foundation.md) describes the current Hagalaz gaps, target data contracts, web architecture, rendering-engine choice, phased implementation, and verification strategy.
 
 ## Current status
@@ -29,6 +30,8 @@ This means the first implementation work belongs at the cache/render-data bounda
 5. **Preserve region and chunk semantics.** A normal map region is 64×64 tiles, has four planes, and dynamic map parts are assembled from rotated 8×8 chunks.
 6. **Fidelity before effects.** Correct heights, floor shapes/materials, object models, shape selection, rotation, and transforms come before shadows, atmosphere, animation, water, or post-processing.
 7. **Do not make MapLibre the core scene renderer.** It is useful for geographic-style overview/navigation surfaces, but its Mercator/globe camera and custom-layer model do not solve RuneScape scene decoding, model assembly, or plane semantics.
+8. **Keep cache payload and container encoding separate.** Terrain and location payload codecs must not know about compression, XTEA, CRC, Whirlpool, reference-table mutation, or Hagalaz's internal synthetic `MapCodec` stream.
+9. **Preserve source semantics needed for writing.** Runtime/effective values such as bridge-adjusted planes must not overwrite the raw source plane or original height encoding if later cache encoding depends on it.
 
 ## Terminology
 
@@ -39,5 +42,7 @@ This means the first implementation work belongs at the cache/render-data bounda
 - **Terrain flags**: collision/bridge/plane-related tile metadata; these are not the terrain height or floor material.
 - **Overlay / underlay**: floor definitions used together with tile shape/rotation and height data to construct visible terrain.
 - **Object placement**: object ID + shape + rotation + local X/Y/Z.
+- **Source plane**: plane encoded in the raw location payload before bridge/effective-plane adjustment.
+- **Effective plane**: runtime plane after terrain/bridge semantics have been applied.
 - **Object render definition**: model IDs selected by shape plus recolor/retexture, scale, offset, contouring, transform, animation, and related render metadata.
 - **Model definition**: decoded vertex/triangle/texture data from the cache before conversion to a backend-specific render model.

--- a/docs/3d-rendering/cache-map-codecs.md
+++ b/docs/3d-rendering/cache-map-codecs.md
@@ -1,0 +1,724 @@
+# RuneScape map cache decode and encode guide
+
+This document is the implementation reference for reading and writing the cache data needed by Hagalaz's 3D map renderer. It deliberately separates the **cache container format**, **terrain payload**, **location/object-placement payload**, and the higher-level render projection. Mixing these layers is a common source of corrupt cache files.
+
+Reference snapshots:
+
+- `frankvdb7/Hagalaz` `main` at `ba134cbcd531a6cd3b35c19b20404084e926bbfc`.
+- `frankvdb7/Hagalaz.GameClient` `main` at `6eac3762cc46cec484131369691b5221fd1277bf`.
+
+Primary Hagalaz sources:
+
+- `Hagalaz.Cache/Types/Providers/MapProvider.cs`
+- `Hagalaz.Cache/Logic/Codecs/MapCodec.cs`
+- `Hagalaz.Cache.Extensions/BigEndianMemoryStreamExtensions.cs`
+- `Hagalaz.Cache/CacheApi.cs`
+- `Hagalaz.Cache/Logic/CacheWriter.cs`
+- `Hagalaz.Cache/Utilities/XTEADecryptor.cs`
+
+Primary client sources:
+
+- `src/main/java/RegionManager.java`
+- `src/main/java/Map.java`
+- `src/main/java/Class274.java`
+- `src/main/java/ObjectDefinition.java`
+- `src/main/java/ModelDefinition.java`
+
+## 1. The four layers must stay separate
+
+A region is not stored as the stream currently accepted by `MapCodec.Decode`.
+
+The real cache contains two separately named index-5 files:
+
+```text
+m{regionX}_{regionY}   terrain/floor payload
+l{regionX}_{regionY}   location/object-placement payload
+```
+
+`MapProvider` reads those two files independently, then creates this **Hagalaz-internal synthetic stream** before calling `MapCodec.Decode`:
+
+```text
+[int32 terrainLength, big endian]
+[terrainLength bytes of mX_Y payload]
+[remaining bytes of lX_Y payload]
+```
+
+The four-byte terrain-length prefix therefore exists only to multiplex two already-decoded payloads into the current `MapCodec` API. It is **not part of either RuneScape cache file**.
+
+Never write the output of the current `MapCodec.Encode` directly to index 5 as either an `mX_Y` or `lX_Y` file.
+
+A correct long-term design should make this separation explicit, for example:
+
+```text
+RegionCacheData
+  TerrainPayload
+  LocationPayload
+
+TerrainCodec
+  Decode(mPayload, regionCoordinates)
+  Encode(terrain)
+
+LocationCodec
+  Decode(lPayload, terrainFlags)
+  Encode(locations)
+```
+
+A compatibility adapter may continue to implement `IMapCodec` while older callers exist.
+
+## 2. Region addressing
+
+A region ID packs its region coordinates as:
+
+```text
+regionId = (regionX << 8) | regionY
+regionX  = regionId >> 8
+regionY  = regionId & 0xFF
+```
+
+The region-local tile domain is:
+
+```text
+plane: 0..3
+x:     0..63
+y:     0..63
+```
+
+Absolute tile coordinates for a normal region are:
+
+```text
+absoluteX = regionX * 64 + localX
+absoluteY = regionY * 64 + localY
+```
+
+Absolute coordinates matter for plane-0 implicit terrain heights because opcode `0` uses the client's deterministic procedural height function. A decoder that knows only the raw `mX_Y` bytes but not the region coordinates cannot reproduce those heights correctly.
+
+## 3. Reading the cache container
+
+`MapProvider` resolves the index-5 file IDs through the reference table:
+
+```text
+terrainFileId  = GetFileId(5, $"m{regionX}_{regionY}")
+locationFileId = GetFileId(5, $"l{regionX}_{regionY}")
+```
+
+### Terrain container
+
+Terrain is currently read as:
+
+```text
+ReadContainer(5, terrainFileId)
+```
+
+The returned container's `Data` is the raw terrain opcode stream described below.
+
+### Location container and XTEA
+
+Location/object data is read as:
+
+```text
+ReadContainer(5, locationFileId, xteaKeys)
+```
+
+`CacheApi.ReadContainer(indexId, fileId, xteaKeys)` operates at the **container level**:
+
+1. Read the raw encoded cache container.
+2. If all four XTEA keys are zero, decode it normally.
+3. Otherwise decrypt from raw container byte offset `5`.
+4. Process only complete 8-byte XTEA blocks.
+5. Decode/decompress the resulting container.
+6. Return the container payload as `Data`.
+
+Do not XTEA-decrypt the already-decompressed `lX_Y` payload. The encryption wraps the encoded container body, not the semantic location stream.
+
+### XTEA algorithm
+
+Use four 32-bit keys and 32 rounds. Values are big-endian 32-bit words. The conventional encryption form is:
+
+```text
+for each complete 8-byte block:
+    v0 = readUInt32BE()
+    v1 = readUInt32BE()
+    sum = 0
+    delta = 0x9E3779B9
+
+    repeat 32 times:
+        v0 += (((v1 << 4) ^ (v1 >> 5)) + v1) ^ (sum + key[sum & 3])
+        sum += delta
+        v1 += (((v0 << 4) ^ (v0 >> 5)) + v0) ^ (sum + key[(sum >> 11) & 3])
+
+    writeUInt32BE(v0)
+    writeUInt32BE(v1)
+```
+
+Use unchecked 32-bit arithmetic. Decryption performs the inverse operations starting with `sum = delta * 32`.
+
+The current repository has a decryptor but no symmetric XTEA-aware cache write API. Therefore **writing an encrypted `lX_Y` container is not yet safely supported by `ICacheAPI.Write`**. Add and test that capability before exposing map mutation that persists location data.
+
+## 4. Terrain payload decoding (`mX_Y`)
+
+The terrain stream is a sequence of tile opcode lists. There is no tile-count header. Decode exactly this traversal order:
+
+```text
+for plane = 0..3
+    for localX = 0..63
+        for localY = 0..63
+            decode one tile until opcode 0 or 1 terminates it
+```
+
+Every tile consumes at least one byte because it must end with opcode `0` or `1`.
+
+### Required render representation
+
+Do not collapse terrain to one flag byte. Preserve at least:
+
+```text
+TerrainTile
+  SourcePlane
+  Height
+  HeightEncoding       // Implicit or Explicit; useful for lossless/canonical writing
+  ExplicitHeightByte?  // preserve when opcode 1 was used
+  OverlayId
+  OverlayShape
+  OverlayRotation
+  TerrainFlags
+  UnderlayId
+```
+
+For region-edge mesh generation also retain or derive a 65×65 corner-height grid per plane. Do not invent the east/north border by duplicating the last in-region value; use adjacent-region data or a deterministic client-parity derivation.
+
+### Tile decoder
+
+Initialize the tile's optional fields to zero/none, then repeatedly read an **unsigned opcode byte**:
+
+#### Opcode `0`: implicit/default height and end of tile
+
+This terminates the current tile.
+
+- Plane 0: compute the deterministic client terrain height using the tile's absolute coordinates and the exact client noise function.
+- Plane 1..3: `height = heightBelow - 960` legacy scene-height units.
+
+The exact plane-0 noise helper should be ported and covered by fixture tests before the renderer depends on opcode-0 height output. Do not substitute random noise or a generic Perlin implementation.
+
+If byte-preserving editing is desired, record that this tile used implicit height even after deriving its numeric height.
+
+#### Opcode `1`: explicit height byte and end of tile
+
+Read one unsigned byte `heightByte`, then terminate the current tile.
+
+The client treats encoded byte `1` as `0`.
+
+For this client revision, explicit height uses a 32-scene-unit step:
+
+```text
+if heightByte == 1:
+    heightByte = 0
+
+if plane == 0:
+    height = -(heightByte * 32)
+else:
+    height = heightBelow - (heightByte * 32)
+```
+
+Keep these legacy signed heights in the server transport/domain representation. Convert the sign exactly once in the web scene assembler.
+
+#### Opcodes `2..49`: overlay
+
+Read one overlay ID byte. The client stores the payload as a byte and later interprets IDs as unsigned where needed.
+
+Decode shape and rotation as:
+
+```text
+overlayId       = readBytePayload()
+overlayShape    = (opcode - 2) / 4
+overlayRotation = (opcode - 2 + partRotation) & 3
+```
+
+For a normal source region `partRotation` is `0`.
+
+For dynamic 8×8 assembly, `partRotation` is an assembly-time transform. Do not permanently write the dynamically rotated value back into the source region's `mX_Y` file.
+
+The opcode range gives shapes `0..11` and rotations `0..3`.
+
+#### Opcodes `50..81`: terrain flags
+
+```text
+terrainFlags = opcode - 49
+```
+
+This gives stored values `1..32`. Zero means no flag opcode occurred.
+
+These flags include bridge/plane-related semantics but are not the height, material or collision map themselves.
+
+#### Opcodes `82..255`: underlay
+
+```text
+underlayId = opcode - 81
+```
+
+Zero means no underlay opcode was present.
+
+### Multiple non-terminal opcodes
+
+A tile can contain overlay, terrain-flag and underlay opcodes before its final height opcode. The decoder must continue until `0` or `1`.
+
+Do not assume the first byte describes the entire tile.
+
+## 5. Terrain payload encoding
+
+Define the goal first:
+
+- **Semantic round trip**: `Decode(Encode(tile))` reproduces the same tile semantics. This should be mandatory.
+- **Byte-identical round trip**: output bytes exactly match the original archive. This requires preserving original opcode ordering and encoding choices and is not necessary for the web renderer.
+
+A canonical semantic encoder is easier to test and maintain.
+
+### Canonical tile opcode order
+
+A deterministic writer can emit:
+
+```text
+1. overlay, if present
+2. terrain flag, if non-zero
+3. underlay, if present
+4. height terminator: opcode 0 or opcode 1 + byte
+```
+
+The client decoder does not require that particular order, but canonical output makes tests and diffs stable.
+
+### Encode overlay
+
+Given shape `s` and source rotation `r`:
+
+```text
+validate 0 <= s <= 11
+validate 0 <= r <= 3
+opcode = 2 + (s * 4) + r
+writeByte(opcode)
+writeByte(overlayId)
+```
+
+Only emit an overlay opcode when an overlay is semantically present. Validate that the ID fits the one-byte cache representation.
+
+### Encode terrain flags
+
+```text
+if terrainFlags != 0:
+    validate 1 <= terrainFlags <= 32
+    writeByte(terrainFlags + 49)
+```
+
+### Encode underlay
+
+```text
+if underlayId != 0:
+    validate 1 <= underlayId <= 174
+    writeByte(underlayId + 81)
+```
+
+### Encode height
+
+If the original `HeightEncoding` is preserved and the tile has not changed, re-emitting the same `0` or `1` encoding is safest.
+
+For a canonical semantic writer:
+
+1. Compute the height that opcode `0` would produce for this tile.
+2. If the desired height equals that implicit value, emit `0`.
+3. Otherwise derive an explicit byte.
+
+For plane 0:
+
+```text
+delta = -height
+```
+
+For higher planes:
+
+```text
+delta = heightBelow - height
+```
+
+Then:
+
+```text
+require delta >= 0
+require delta % 32 == 0
+heightByte = delta / 32
+require 0 <= heightByte <= 255
+```
+
+If `heightByte == 1`, it cannot be represented distinctly because the client normalizes encoded `1` to zero. Either use implicit encoding when semantically equivalent or reject the write rather than silently changing height.
+
+Finally:
+
+```text
+writeByte(1)
+writeByte(heightByte)
+```
+
+Do not silently clamp unrepresentable heights.
+
+## 6. Location/object-placement payload decoding (`lX_Y`)
+
+The location stream is delta encoded first by object ID and then by packed location.
+
+### Smart integer primitives
+
+Hagalaz's `ReadSmart` is:
+
+```text
+peek first unsigned byte
+if first < 128:
+    value = readUnsignedByte()
+else:
+    value = readUnsignedShortBE() - 32768
+```
+
+Valid values for this format are `0..32767`.
+
+`ReadHugeSmart` chains smart values:
+
+```text
+total = 0
+value = ReadSmart()
+while value == 32767:
+    total += 32767
+    value = ReadSmart()
+return total + value
+```
+
+### Object/location decoder
+
+Start with:
+
+```text
+objectId = -1
+```
+
+Then:
+
+```text
+while true:
+    idDelta = ReadHugeSmart()
+    if idDelta == 0:
+        break
+
+    objectId += idDelta
+    packedLocation = 0
+
+    while true:
+        locationDelta = ReadSmart()
+        if locationDelta == 0:
+            break
+
+        packedLocation += locationDelta - 1
+
+        localY = packedLocation & 0x3F
+        localX = (packedLocation >> 6) & 0x3F
+        sourcePlane = packedLocation >> 12
+
+        attributes = readUnsignedByte()
+        shape = attributes >> 2
+        rotation = attributes & 0x3
+
+        emit placement
+```
+
+Packed location is therefore:
+
+```text
+packedLocation = (sourcePlane << 12) | (localX << 6) | localY
+```
+
+### Source plane versus effective plane
+
+This is critical for round-trip correctness.
+
+The current Hagalaz decoder applies the bridge flag immediately:
+
+```text
+if (terrainFlags[1, x, y] & 0x2) != 0:
+    z--
+```
+
+That adjusted plane is useful for gameplay placement, but it is **not the same thing as the source plane encoded in `lX_Y`**.
+
+A full-fidelity render/edit representation must preserve both concepts, for example:
+
+```text
+ObjectPlacement
+  Id
+  SourcePlane       // raw packed plane; use this when re-encoding lX_Y
+  EffectivePlane    // bridge-adjusted/runtime plane
+  X
+  Y
+  Shape
+  Rotation
+```
+
+If decode overwrites the source plane and encode later uses the adjusted plane, a decode/encode cycle moves bridged objects to a different raw plane.
+
+## 7. Location/object-placement payload encoding
+
+Canonical object encoding requires deterministic sorting.
+
+### Required sort order
+
+1. Group placements by object ID.
+2. Sort groups by object ID ascending.
+3. Within each group, compute the raw packed location from `SourcePlane`, X and Y.
+4. Sort placements by packed location ascending.
+
+The current `MapCodec.Encode` sorts groups by object ID but does **not** explicitly sort locations inside a group. That is unsafe if callers provide placements in arbitrary order because location deltas must never go backwards.
+
+### Encode object-ID group
+
+Initialize:
+
+```text
+previousObjectId = -1
+```
+
+For each object-ID group:
+
+```text
+idDelta = objectId - previousObjectId
+require idDelta > 0
+WriteHugeSmart(idDelta)
+previousObjectId = objectId
+```
+
+Then initialize:
+
+```text
+previousPackedLocation = 0
+```
+
+For each sorted placement:
+
+```text
+packed = (sourcePlane << 12) | (x << 6) | y
+locationDelta = packed - previousPackedLocation + 1
+require 1 <= locationDelta <= 32767
+WriteSmart(locationDelta)
+previousPackedLocation = packed
+
+attributes = (shape << 2) | rotation
+writeByte(attributes)
+```
+
+After the final placement for an object ID:
+
+```text
+WriteSmart(0)
+```
+
+After the final object-ID group:
+
+```text
+WriteHugeSmart(0)
+```
+
+### Correct huge-smart writer
+
+The inverse of `ReadHugeSmart` should be:
+
+```text
+function WriteHugeSmart(value):
+    require value >= 0
+
+    while value >= 32767:
+        WriteSmart(32767)
+        value -= 32767
+
+    WriteSmart(value)
+```
+
+The current `BigEndianMemoryStreamExtensions.WriteHugeSmart` should receive a regression test before it is trusted for arbitrary large deltas. Its current loop can overshoot the requested total for values just above `32767`, producing a negative remainder that is then passed to `WriteSmart`.
+
+Required boundary tests include at least:
+
+```text
+0
+1
+127
+128
+32766
+32767
+32768
+65534
+65535
+large real object-ID delta
+```
+
+## 8. Rebuilding cache files
+
+### Terrain write
+
+For an existing region:
+
+1. Read the existing `mX_Y` container so its compression/version policy is known.
+2. Encode only the raw terrain payload; do not prepend the Hagalaz synthetic terrain length.
+3. Construct a replacement container using the existing compression type.
+4. Write through the cache writer so version, CRC, Whirlpool digest and reference-table metadata are updated consistently.
+5. Read the file back and decode it as verification.
+
+### Location write
+
+For `lX_Y`:
+
+1. Encode only the raw location payload.
+2. Build the cache container with the intended compression/version behavior.
+3. XTEA-encrypt the encoded container body from byte offset `5`, using the region's four keys and complete 8-byte blocks only.
+4. Compute/store CRC and digest from the **final encrypted container bytes**, because that is what the cache contains.
+5. Persist the bytes and update the reference table atomically from the caller's perspective.
+6. Read back through `ReadContainer(..., xteaKeys)` and verify semantic equality.
+
+The existing `CacheWriter.Write` computes checksums and writes the unencrypted `container.Encode(false)` bytes. Therefore do not fake encrypted map writes by calling it and encrypting the store afterward: the reference-table checksum would describe different bytes. Add an XTEA-aware writer path that owns encode → encrypt → checksum/digest → store → reference-table update in that order.
+
+## 9. Dynamic 8×8 chunks
+
+Dynamic regions are an assembly operation over source cache regions, not a different `mX_Y`/`lX_Y` file format.
+
+For a source 8×8 chunk:
+
+- select source region, source plane and source chunk coordinates;
+- rotate tile coordinates by `partRotation`;
+- add `partRotation` to overlay rotation modulo 4;
+- rotate object local coordinates using object footprint semantics;
+- add placement rotation modulo 4;
+- copy/derive height borders consistently.
+
+Keep source cache data immutable during assembly. Do not encode an assembled dynamic chunk back into the source region merely because its rendered rotations differ.
+
+## 10. Object definitions, floor definitions and models
+
+Map placement data alone does not contain renderable models.
+
+### Object definitions
+
+Hagalaz already has `ObjectTypeCodec`; extend/reuse cache decoding rather than parsing object-definition opcodes in Angular. For rendering, expose a separate projection containing only verified render fields such as shape-to-model mappings, recolor/retexture pairs, scale, offsets, contouring and transform IDs.
+
+Round-trip tests for any newly exposed opcode must follow the same rule:
+
+```text
+raw fixture -> decode -> assert semantic fields -> encode -> decode -> assert semantic fields
+```
+
+Unknown opcodes must never be guessed. Either preserve their raw representation in an editing codec or reject mutation that cannot be safely re-encoded.
+
+### Floor definitions
+
+`OverlayType` and the client underlay definition (`Class491`) are separate config formats from `mX_Y`. The terrain payload stores their IDs, not their RGB/texture bodies. Implement floor-definition codecs independently and resolve IDs after region decode.
+
+### Models
+
+`ModelDefinition` supports at least two binary model variants: its constructor selects a newer decoder when the final two bytes are `0xFF 0xFF`, otherwise it uses the legacy decoder. It contains delta-compressed vertex/triangle streams, optional face attributes and texture-triangle data.
+
+Hagalaz currently has no server-side model codec. For the static-object milestone:
+
+1. Rename/decompose the client's `method1199` and `method1201` into documented legacy/new format layouts.
+2. Build immutable `DecodedModel` fixtures from real cache models covering untextured, textured, alpha, multiple texture-render types and combined models.
+3. Implement the decoder first and compare every vertex/index/material field with the client.
+4. Do not implement a model encoder merely by reversing observed reads inline.
+5. Define a canonical writer per model version only after every optional section offset and footer flag is understood.
+6. Add semantic round-trip plus client-load tests before allowing cache model mutation.
+
+The web map viewer does not need model **encoding** to render static objects, so model-writing support should remain a later capability unless an actual editor requires it.
+
+## 11. Validation and corruption guards
+
+Every decoder should reject or explicitly report malformed data rather than returning a half-valid region.
+
+Validate at minimum:
+
+- unexpected end-of-stream while decoding a tile;
+- missing tile terminator;
+- fewer/more than 4×64×64 terrain tiles when bytes remain in an impossible state;
+- overlay shape/rotation outside representable bounds when encoding;
+- terrain flag/underlay IDs outside byte-format bounds;
+- source plane outside `0..3`;
+- local X/Y outside `0..63`;
+- object shape that does not fit `attributes >> 2` expectations;
+- rotation outside `0..3`;
+- non-monotonic object IDs or packed locations during encoding;
+- smart/huge-smart overflow;
+- XTEA key count other than four;
+- invalid decrypted/decompressed container;
+- checksum/digest mismatch after persisted writes where validation data is available.
+
+Never catch a malformed map exception and silently substitute flat terrain. A visible failure is safer than a plausible but incorrect scene.
+
+## 12. Required test matrix
+
+### Terrain byte fixtures
+
+Cover individual and combined tile sequences:
+
+- opcode `0` on plane 0 with known absolute coordinates;
+- opcode `0` on planes 1..3 and exact `-960` spacing;
+- opcode `1` with height byte `0`, `1`, a normal value and `255`;
+- overlay shapes `0` and `11`, all four rotations;
+- terrain flags `1` and `32`;
+- minimum and maximum representable underlay IDs;
+- overlay + flag + underlay + explicit height on one tile;
+- canonical encode/decode semantic equality.
+
+### Region fixtures
+
+Use real cache fixtures for:
+
+- a flat/simple region;
+- strongly varying terrain;
+- bridges;
+- multiple planes;
+- many overlay shapes/rotations;
+- adjacent east/north/north-east regions for border-height tests;
+- an XTEA-protected location archive.
+
+### Location fixtures
+
+Cover:
+
+- one object;
+- multiple placements of the same ID;
+- multiple object IDs;
+- unsorted input passed to the encoder;
+- largest local coordinate and plane;
+- bridge tile preserving `SourcePlane` while deriving `EffectivePlane`;
+- huge-smart object-ID boundaries;
+- decode → encode → decode semantic equality.
+
+### Persisted-write verification
+
+For any future map editor test cache:
+
+```text
+read original container
+-> decode
+-> modify one known field
+-> encode
+-> persist
+-> reopen cache from disk
+-> decode again
+-> verify intended change
+-> verify unrelated region semantics unchanged
+-> verify reference-table CRC/version/digest
+```
+
+Never test destructive write paths against the canonical development cache fixture.
+
+## 13. Current Hagalaz codec gaps to fix before calling it a full map codec
+
+The existing implementation is useful for gameplay, but it is not a full-fidelity cache round-trip codec:
+
+1. `MapCodec.DecodeTerrainData` discards explicit height, overlay, overlay shape/rotation and underlay data.
+2. Plane-0 procedural heights are not represented.
+3. `MapCodec.Encode` can only recreate the reduced terrain-flag model; it cannot recreate a real `mX_Y` payload faithfully.
+4. `MapCodec.Encode` returns Hagalaz's synthetic combined stream, not one actual cache file.
+5. Location decode mutates the raw plane for bridge tiles and therefore loses source-plane information needed for correct re-encoding.
+6. Location encoding does not explicitly sort placements by packed location inside an object-ID group.
+7. `WriteHugeSmart` needs boundary regression coverage/correction before arbitrary object-ID deltas are safe.
+8. Cache writing has no XTEA-aware symmetric path for encrypted `lX_Y` containers.
+9. Existing round-trip tests prove only the reduced in-memory model round trips through itself; they do not prove parity with real terrain/location cache bytes.
+
+The 3D rendering foundation should address decoding first, preserve enough source semantics to make later encoding possible, and add cache mutation only behind separate explicit tests and APIs.

--- a/docs/3d-rendering/client-rendering-deobfuscation.md
+++ b/docs/3d-rendering/client-rendering-deobfuscation.md
@@ -2,59 +2,65 @@
 
 This document defines the **canonical human-readable names** used by Hagalaz documentation for the RuneScape client rendering subsystem.
 
-The source snapshot is `frankvdb7/Hagalaz.GameClient@6eac3762cc46cec484131369691b5221fd1277bf`.
+Source snapshot: `frankvdb7/Hagalaz.GameClient@6eac3762cc46cec484131369691b5221fd1277bf`.
+
+Source-level mechanical renaming is tracked in `frankvdb7/Hagalaz.GameClient#141`.
 
 ## Naming policy
 
-The decompiled client still contains many generated identifiers such as `Class274`, `Class356`, `Class_xa` and `method6416`. Those names are source-location artifacts, not architecture.
+The decompiled client still contains generated identifiers such as `Class274`, `Class356`, `Class_xa`, `Entity_Sub1_Sub5` and `method6416`. These are source-location artifacts, not architecture.
 
 For Hagalaz 3D work:
 
-1. **Use the semantic name in architecture, specifications, DTO discussions, tests and implementation notes.**
-2. **Keep the obfuscated identifier only in this source-locator document** until the GameClient source itself has been mechanically renamed.
-3. **Rename only when responsibility is supported by call sites and data flow.** Do not guess a precise name from one method or one opcode.
-4. **Separate class confidence from member confidence.** A class can have a clear role even when some of its fields remain unresolved.
-5. **Do not rename a miscellaneous class solely because one static helper in it has been understood.** Several Jagex classes contain unrelated static utility methods because of obfuscation. In those cases the method receives a semantic alias while the containing class remains only a source locator.
-6. **Prefer domain names over renderer-specific names.** `TerrainSurface`, `SceneGraph`, `Occluder` and `SceneLight` describe the RuneScape scene independently of OpenGL, Direct3D or Three.js.
+1. Use semantic names in architecture, specifications, DTO discussions, tests and implementation notes.
+2. Keep generated identifiers only in this source-locator document until the GameClient source itself has been renamed.
+3. Rename only when responsibility is supported by construction, fields, call sites and data flow.
+4. Separate class confidence from member confidence. A class can be understood while several fields remain unresolved.
+5. Do not rename a miscellaneous class solely because one unrelated static helper inside it is understood.
+6. Prefer domain names independent of renderer backend: `TerrainSurface`, `SceneGraph`, `Occluder`, `SceneLight`, etc.
+7. If a concept cannot yet be named accurately, keep it internal/unresolved instead of exporting an obfuscated or guessed name.
 
-Confidence levels:
+Confidence:
 
-- **Verified**: the class/member role is demonstrated directly by construction, fields and call sites.
-- **High**: behavior is strongly constrained by multiple call sites; the chosen name is unlikely to change materially.
-- **Medium**: the broad role is clear, but a more precise RuneScape/client term may emerge later.
-- **Unresolved**: keep the current source identifier in the source repository until more evidence exists; do not expose it in Hagalaz public contracts.
+- **Verified**: directly demonstrated by construction, data flow and call sites.
+- **High**: strongly constrained by multiple independent uses; terminology might be refined but the concept will not materially change.
+- **Medium**: broad role is understood but a more precise client/RuneScape term may still emerge.
+- **Unresolved**: do not freeze a semantic source/API name yet.
 
-## Core rendering class names
+## Canonical rendering vocabulary
 
-| Canonical name | Current source locator | Confidence | Evidence / responsibility |
+| Canonical name | Current GameClient source | Confidence | Responsibility |
 | --- | --- | --- | --- |
-| `TerrainBuilder` | `Class274` | Verified | Owns tile heights, overlays, underlays, overlay shape/rotation, terrain flags and camera-adjustment grids; decodes normal/dynamic landscape tiles and builds renderer-backed terrain surfaces. `Map` extends it. |
-| `SceneGraph` | `Class356` | Verified | Owns per-plane scene tiles, terrain surfaces, scene entities, map lights, visibility state and the occlusion subsystem; inserts/removes walls, decorations and standard objects. |
-| `SceneTile` | `Class340` | Verified | One tile/plane cell in the scene graph. Holds wall entities, wall decorations, floor decoration, linked multi-tile objects and a link to the tile below. |
-| `TerrainSurface` | `Class_xa` | Verified | Abstract renderer-backed terrain height/surface object. Owns the height grid and tile scale and supports exact/interpolated height queries plus backend terrain operations. |
-| `OcclusionManager` | `Class358` | Verified | Owns occluder collections, tile visibility cache and occlusion tests; created by and bound to the scene graph. |
-| `Occluder` | `Class385` | High | Stores occluder type/plane and polygon/corner coordinates; created, indexed and queried exclusively by the occlusion subsystem. |
-| `OcclusionRasterizer` | `Class347` | High | Rasterizes projected occlusion triangles/scanlines into the occlusion manager's depth/visibility buffer. |
-| `FloorUnderlayDefinition` | `Class491` | Verified | Decodes underlay RGB, texture, texture scale and rendering flags and derives HSL/hue-multiplier data used by terrain color/material construction. |
-| `FloorUnderlayDefinitionManager` | `Class499` | Verified | Cache-backed manager for floor-underlay definitions with an ID-keyed `NodeCache`; constructs/decodes/caches `FloorUnderlayDefinition`. |
-| `FloorOverlayDefinitionManager` | `Class418` | Verified | Cache-backed manager for overlay definitions; loads the overlay config archive and constructs/caches `OverlayType`. |
-| `FloorOverlayDefinition` | `OverlayType` | Verified concept | Source class is already partially named. It is the floor-overlay definition containing primary/secondary color, texture, hide-underlay and additional material parameters. |
-| `SceneEntity` | `Entity_Sub1` | High | Common abstract scene-renderable base. Owns scene/plane state, participates in visibility/bounds/render operations, and resolves nearby map lights. |
-| `MultiTileSceneEntity` | `Entity_Sub1_Sub1` | High | Scene entity with explicit start/end X/Y tile bounds and active state; represents entities spanning a tile rectangle. |
-| `SingleTileSceneEntity` | `Entity_Sub1_Sub2` | High | Position-based scene entity whose scene/light/visibility queries resolve from one current tile. Precise gameplay subtype remains intentionally generic. |
-| `WallDecorationEntity` | `Entity_Sub1_Sub3` | Verified | Constructed by `Map` for `ShapeType.wallDecoration*` placements and stored in the scene tile's wall-decoration slots. |
-| `FloorDecorationEntity` | `Entity_Sub1_Sub4` | Verified | Constructed for the floor-decoration scene layer and stored in the scene tile's floor-decoration slot. |
-| `WallEntity` | `Entity_Sub1_Sub5` | Verified | Constructed for wall/corner/unfinished-wall shapes and stored as one or two wall entities per scene tile. |
-| `SceneObjectLink` | `Class352` | High | Pooled linked node containing a `MultiTileSceneEntity`; used by scene tiles to reference multi-tile/standard objects without duplicating the object. |
-| `SceneLight` | `Node_Sub14` | High | Position-bearing light object used by map flickering effects, terrain and scene entities; exposes X/Y/Z, scalar/int light parameters and position mutation. |
-| `SceneEntityList` | `Class338` | Medium | Maintains ordered scene-entity entries, removes duplicates in one mode and releases pooled entries. Exact role in the render/picking pipeline needs more deobfuscation before a source rename. |
-| `SceneEntityEntry` | `Class353` | Medium | Pooled wrapper around a `SceneEntity` with bounds/hit-test behavior and ownership by `SceneEntityList`. |
+| `TerrainBuilder` | `Class274` | Verified | Base used by `Map`; decodes heights, overlays, underlays, shape/rotation and flags, handles dynamic chunks and builds terrain surfaces. |
+| `SceneGraph` | `Class356` | Verified | Owns scene tiles, terrain surfaces, entities, lights, visibility and occlusion; inserts/removes scene objects. |
+| `SceneTile` | `Class340` | Verified | One per-plane tile cell containing wall slots, wall decorations, floor decoration and object links. |
+| `TerrainSurface` | `Class_xa` | Verified | Renderer-backed terrain surface/height grid with exact and bilinear height queries. |
+| `FloorUnderlayDefinition` | `Class491` | Verified | Underlay RGB/HSL, texture, scale and rendering flags. |
+| `FloorUnderlayDefinitionManager` | `Class499` | Verified | Cache-backed underlay-definition lookup/cache. |
+| `FloorOverlayDefinitionManager` | `Class418` | Verified | Cache-backed manager for overlay definitions. |
+| `FloorOverlayDefinition` | `OverlayType` | Verified concept | Overlay colors, texture, hide-underlay and additional material parameters. |
+| `OcclusionManager` | `Class358` | Verified | Occluder storage, tile-visibility cache and occlusion tests. |
+| `Occluder` | `Class385` | High | Oriented occlusion geometry carrying plane/type and corner/projection data. |
+| `OcclusionRasterizer` | `Class347` | High | Rasterizes projected occlusion triangles/scanlines into the visibility/depth representation. |
+| `SceneEntity` | `Entity_Sub1` | High | Common abstract scene renderable; owns plane/scene state, bounds, light lookup and render/visibility behavior. |
+| `MultiTileSceneEntity` | `Entity_Sub1_Sub1` | High | Scene entity with explicit start/end tile X/Y footprint. |
+| `SingleTileSceneEntity` | `Entity_Sub1_Sub2` | High | Position-based scene entity resolved from one current scene tile; exact gameplay subtype remains intentionally broad. |
+| `WallDecorationEntity` | `Entity_Sub1_Sub3` | Verified | Created by all wall-decoration shape placement paths. |
+| `FloorDecorationEntity` | `Entity_Sub1_Sub4` | Verified | Created/stored for the floor-decoration scene layer. |
+| `WallEntity` | `Entity_Sub1_Sub5` | Verified | Created for wall/corner/unfinished-wall shapes; one tile can hold two wall pieces. |
+| `SceneObjectLink` | `Class352` | High | Pooled linked node referencing a multi-tile scene entity from scene tiles. |
+| `ScreenSpaceBounds` | `Class80` | Verified role | Active 2D capsule/pick bound with two projected endpoints and radius; supports screen-point hit testing. |
+| `SceneEntityBounds` | `Class348` | High | 3D entity bound with min/max axes plus horizontal radial test. |
+| `SceneEntityPickList` | `Class338` | High | Ordered list of scene pick entries built from rendered entities; optional duplicate suppression. |
+| `SceneEntityPickEntry` | `Class353` | High | Pooled entity picking entry that tests `ScreenSpaceBounds` and delegates detailed hit testing to the entity/model. |
+| `SceneLight` | `Node_Sub14` | Verified | Position, radius, color and intensity used by terrain/entities/map flicker effects. |
+| `FlickeringLightDefinition` | `Class512` | Verified role | Reusable waveform/speed/amplitude/base-intensity definition used by special map flicker type 31. |
+| `FlickeringLightDefinitionManager` | `Class519` | Verified role | Cache-backed manager for flickering-light definitions. |
+| `HighResolutionClock` | `Class509` instance role | High | Instance responsibility is a `System.nanoTime()` clock; class also contains unrelated static methods from obfuscation bundling. |
 
-`Map`, `RegionManager`, `ObjectDefinition`, `ObjectDefinitionManager`, `ModelDefinition`, `Model`, `GraphicsToolkit`, `TerrainData`, `Atmosphere`, `AtmosphereManager`, `MapFlickeringEffect` and `ShapeType` are already sufficiently human-readable and remain canonical.
+Already-readable canonical types include `Map`, `RegionManager`, `ObjectDefinition`, `ObjectDefinitionManager`, `ModelDefinition`, `Model`, `GraphicsToolkit`, `TerrainData`, `Atmosphere`, `AtmosphereManager`, `MapFlickeringEffect` and `ShapeType`.
 
-## Core inheritance / ownership model
-
-Use this model in documentation instead of the decompiled names:
+## Core ownership model
 
 ```text
 RegionManager
@@ -63,10 +69,9 @@ RegionManager
 Map : TerrainBuilder
     |
     +--> FloorOverlayDefinitionManager --> FloorOverlayDefinition
-    |
     +--> FloorUnderlayDefinitionManager --> FloorUnderlayDefinition
-    |
     +--> ObjectDefinitionManager --> ObjectDefinition --> ModelDefinition
+    +--> FlickeringLightDefinitionManager --> FlickeringLightDefinition
     |
     v
 SceneGraph
@@ -76,117 +81,100 @@ SceneGraph
     |      +--> WallDecorationEntity (0..2)
     |      +--> FloorDecorationEntity (0..1)
     |      +--> SceneObjectLink --> MultiTileSceneEntity
-    |      +--> other single-tile scene entity
+    |      +--> optional SingleTileSceneEntity
     |
     +--> TerrainSurface[plane]
-    +--> SceneLight[]
+    +--> SceneLight[] / MapFlickeringEffect[]
+    +--> SceneEntityPickList --> SceneEntityPickEntry --> ScreenSpaceBounds
     +--> OcclusionManager
                +--> Occluder[]
                +--> OcclusionRasterizer
 
 GraphicsToolkit
-    +--> creates TerrainSurface
-    +--> creates Model from ModelDefinition
-    +--> concrete OpenGL / Direct3D / software backends
+    +--> createTerrainSurface
+    +--> createModel(ModelDefinition)
+    +--> create SceneLight
+    +--> OpenGL / Direct3D / software backends
 ```
 
-This is the vocabulary that should be copied into Hagalaz code and API design. Do not introduce `Class###`-inspired names into the server or web renderer.
+New Hagalaz server/web code should use this vocabulary, never the generated source identifiers.
 
-## TerrainBuilder member names
+## TerrainBuilder members
 
-The following members are sufficiently understood for documentation and future GameClient source renaming.
+| Canonical member | Current member | Confidence |
+| --- | --- | --- |
+| `sceneGraph` | `aClass356_2767` | Verified |
+| `floorOverlayDefinitions` | `aClass418_2765` | Verified |
+| `floorUnderlayDefinitions` | `aClass499_2819` | Verified |
+| `terrainData` | `aTerrainData_2811` | Verified |
+| `tileHeights` | `tileHeights` | Verified |
+| `overlayIds` | `overlayIds` | Verified |
+| `underlayIds` | `underlayIds` | Verified |
+| `overlayShapes` | `overlayPaths` | High |
+| `overlayRotations` | `overlayRotations` | Verified |
+| `cameraAdjustments` | `cameraAdjustments` | Existing readable field; exact higher-level semantics remain later work |
+| `setShadingDelayed` | `method2684` | High |
+| `releaseTerrainBuildScratch` | `method2685` | High |
+| `initializeHeightArea` | `method2687` | High |
+| `readCollisionData` | `readCollisionData` | Verified |
+| `readDynamicChunkCollisionData` | `method2689` | High |
+| `createTerrainSurfaces` | `readGroundMapData` | High |
+| `buildTerrainSurfaces` | `method2692` | Verified responsibility |
+| `readLandscapeData` | `readLandscapeData` | Verified |
 
-| Canonical member | Current source member | Confidence | Meaning |
-| --- | --- | --- | --- |
-| `sceneGraph` | `aClass356_2767` | Verified | Scene graph receiving built terrain and scene objects. |
-| `floorOverlayDefinitions` | `aClass418_2765` | Verified | Floor overlay definition manager. |
-| `floorUnderlayDefinitions` | `aClass499_2819` | Verified | Floor underlay definition manager. |
-| `terrainData` | `aTerrainData_2811` | Verified | Terrain flags / effective-plane metadata. |
-| `tileHeights` | `tileHeights` | Verified | Per-plane corner/height grid. |
-| `overlayIds` | `overlayIds` | Verified | Per-tile overlay IDs. |
-| `underlayIds` | `underlayIds` | Verified | Per-tile underlay IDs. |
-| `overlayShapes` | `overlayPaths` | High | Per-tile floor-overlay shape/path value decoded from `(opcode - 2) / 4`. `shape` is clearer for renderer documentation. |
-| `overlayRotations` | `overlayRotations` | Verified | Per-tile overlay rotation `0..3`. |
-| `cameraAdjustments` | `cameraAdjustments` | Verified field name | Per-plane map-provided adjustment grid; exact camera/roof semantics remain a later fidelity topic. |
-| `setShadingDelayed` | `method2684` | High | Enables delayed terrain shading/shadow-related accumulation. |
-| `releaseTerrainBuildScratch` | `method2685` | High | Clears terrain-color/material accumulation arrays and ends delayed-build scratch state. |
-| `initializeHeightArea` | `method2687` | High | Initializes/fills a rectangular height area and repairs boundaries. |
-| `readCollisionData` | `readCollisionData` | Verified | Decodes terrain flags for collision across a normal 64x64 region. |
-| `readDynamicChunkCollisionData` | `method2689` | High | Reads/rotates one dynamic 8x8 region part into destination collision/height space. |
-| `createTerrainSurfaces` | `readGroundMapData` | High | Allocates renderer terrain surfaces for the active planes through `GraphicsToolkit`. |
-| `buildTerrainSurfaces` | `method2692` | Verified responsibility | Resolves floor definitions, colors/material inputs and shaped tiles into the terrain surfaces. |
-| `readLandscapeData` | `readLandscapeData` | Verified | Decodes one tile's terrain opcode list including height, overlay, flags and underlay. |
+Large scratch arrays inside terrain material/shape construction remain intentionally unnamed until each role is proven.
 
-Some large terrain-build scratch arrays are still intentionally unnamed. Their meaning should be derived from the particular material/shape algorithm before they are renamed, rather than receiving names such as `temp1` or `colors2`.
+## TerrainSurface members
 
-## TerrainSurface member names
+| Canonical member | Current member | Confidence |
+| --- | --- | --- |
+| `heightGrid` | `anIntArrayArray6394` | Verified |
+| `tileCountX` | `anInt6397` | Verified |
+| `tileCountY` | `anInt6393` | Verified |
+| `tileSize` | `anInt6395` | Verified |
+| `tileShift` | `anInt6396` | Verified |
+| `getInterpolatedHeight` | `method6416` | Verified |
+| `getTileHeight` | `method6417` | Verified |
 
-| Canonical member | Current source member | Confidence | Meaning |
-| --- | --- | --- | --- |
-| `heightGrid` | `anIntArrayArray6394` | Verified | Corner/grid heights used by exact and interpolated height queries. |
-| `tileCountX` | `anInt6397` | Verified | Terrain width in tiles. |
-| `tileCountY` | `anInt6393` | Verified | Terrain height/depth in tiles. |
-| `tileSize` | `anInt6395` | Verified | Scene units per tile; normally 512 for map terrain. |
-| `tileShift` | `anInt6396` | Verified | `log2(tileSize)` used for tile lookup and interpolation. |
-| `getInterpolatedHeight` | `method6416` | Verified | Bilinear interpolation of four height-grid corners for a world/scene position. |
-| `getTileHeight` | `method6417` | Verified | Direct grid height lookup. |
+Remaining abstract methods should be named only after comparing equivalent operations across multiple renderer backends.
 
-The remaining abstract methods cover backend-specific terrain building, drawing, shadow/mask and resource operations. They should be renamed per behavior after comparing their implementations across the renderer backends; a one-backend guess is not sufficient.
+## FloorUnderlayDefinition members
 
-## FloorUnderlayDefinition member names
+The underlay is one of the clearest definition formats.
 
-The underlay definition is one of the strongest deobfuscation targets because its decode and color conversion are self-contained.
+| Canonical member | Current member | Confidence |
+| --- | --- | --- |
+| `rgbColor` | `anInt5860` | Verified |
+| `hue` | `anInt5855` | Verified |
+| `saturation` | `anInt5861` | Verified |
+| `lightness` | `anInt5862` | Verified |
+| `hueMultiplier` | `anInt5863` | Verified |
+| `texture` | `anInt5856` | High |
+| `textureScale` | `anInt5857` | High |
+| `decode` | `method6072` | Verified |
+| `decodeOpcode` | `method6073` | Verified |
+| `calculateHsl` | `method6074` | Verified |
 
-| Canonical member | Current source member | Confidence | Evidence |
-| --- | --- | --- | --- |
-| `rgbColor` | `anInt5860` | Verified | Opcode `1` reads a 24-bit RGB value and immediately derives HSL data from it. |
-| `hue` | `anInt5855` | Verified | Computed from RGB hue multiplied by the hue multiplier, matching the classic RuneScape underlay-color representation. |
-| `saturation` | `anInt5861` | Verified | RGB-to-HSL saturation clamped to `0..255`. |
-| `lightness` | `anInt5862` | Verified | RGB-to-HSL lightness clamped to `0..255`. |
-| `hueMultiplier` | `anInt5863` | Verified | Saturation/lightness-derived multiplier, minimum `1`, used to scale hue. |
-| `texture` | `anInt5856` | High | Opcode `2` reads an ID with `65535 -> -1`; terrain construction passes it in the same material slot as overlay textures. |
-| `textureScale` | `anInt5857` | High | Opcode `3` reads `ushort << 2` and terrain construction carries it with the underlay texture. |
-| `decode` | `method6072` | Verified | Reads opcodes until `0`. |
-| `decodeOpcode` | `method6073` | Verified | Decodes one underlay-definition opcode. |
-| `calculateHsl` | `method6074` | Verified | Converts the decoded RGB color into hue/saturation/lightness/hue multiplier. |
+Opcode `4` and opcode `5` boolean fields are known to affect rendering/occlusion behavior, but their final semantic names should not be frozen until every use is traced.
 
-Two booleans remain deliberately semantic-but-not-overprecise:
-
-- opcode `4`: default `true`, becomes `false`; participates in shaped-terrain build behavior;
-- opcode `5`: default `true`, becomes `false`; participates in whether an upper-plane flat tile may contribute to the client's occlusion/visibility flags.
-
-Until every use is traced, name these in documentation as `renderFlag4` / `allowsOcclusion` only with an explicit confidence note. Do **not** put guessed names into a public Hagalaz API.
-
-## Floor-definition manager names
+## Floor-definition managers
 
 ### FloorUnderlayDefinitionManager
 
-| Canonical member | Current source member | Confidence |
-| --- | --- | --- |
-| `definitions` | `aNodeCache_5891` | Verified |
-| `configContainer` | `configContainer` | Verified |
-| `getFloorUnderlayDefinition` | `method6111` | Verified |
-
-The remaining instance methods are cache maintenance operations and can be named once their corresponding `NodeCache` methods are deobfuscated consistently.
+- `aNodeCache_5891` -> `definitions`
+- `method6111` -> `getFloorUnderlayDefinition`
 
 ### FloorOverlayDefinitionManager
 
-| Canonical member | Current source member | Confidence |
-| --- | --- | --- |
-| `definitions` | `aNodeCache_4296` | Verified |
-| `configContainer` | `configContainer` | Verified |
-| `getFloorOverlayDefinition` | `getOverlayType` | Verified |
-| `definitionCount` | `anInt4295` | High |
+- `aNodeCache_4296` -> `definitions`
+- `anInt4295` -> `definitionCount`
+- `getOverlayType` -> `getFloorOverlayDefinition`
 
-`anInt4294` is modified by overlay opcode `8`; its exact special-overlay/default role is not sufficiently proven yet.
+The overlay-manager field changed by overlay opcode `8` is still unresolved; do not call it a default/special overlay until proven.
 
-## SceneGraph / SceneTile names
+## SceneGraph members
 
-### SceneGraph
-
-The scene graph has enough evidence to rename its structural fields now, while leaving frame-specific visibility scratch fields for later.
-
-| Canonical member | Current source member | Confidence |
+| Canonical member | Current member | Confidence |
 | --- | --- | --- |
 | `graphicsToolkit` | `aGraphicsToolkit3645` | Verified |
 | `occlusionManager` | `aClass358_3649` | Verified |
@@ -196,21 +184,22 @@ The scene graph has enough evidence to rename its structural fields now, while l
 | `activeTerrainSurfaces` | `aClass_xaArray3676` | Verified |
 | `primaryTerrainSurfaces` | `aClass_xaArray3701` | High |
 | `alternateTerrainSurfaces` | `aClass_xaArray3658` | High |
-| `mapLights` | `aMapFlickeringEffectArray3679` | Verified |
+| `mapFlickeringEffects` | `aMapFlickeringEffectArray3679` | Verified |
+| `entityPickList` | `aClass338_3697` | High |
 | `tilesRangeX` | `tilesRangeX` | Verified |
 | `tilesRangeY` | `tilesRangeY` | Verified |
 | `maxPlanes` | `maxZ` | High |
 | `getOrCreateTile` | `method4136` | Verified responsibility |
 | `ensureTileStack` | `method4137` | High |
-| `addFloorDecoration` | `method4142` | Verified from `Map` layer/shape call sites |
-| `addWallDecoration` | `method4144` | Verified from `ShapeType.wallDecoration*` call sites |
-| `addWalls` | `method4180` | Verified from wall/corner shape call sites |
+| `addFloorDecoration` | `method4142` | Verified from placement call sites |
+| `addWallDecoration` | `method4144` | Verified from placement call sites |
+| `addWalls` | `method4180` | Verified from placement call sites |
 
-The exact names of the two scene modes represented by the primary/alternate tile/surface arrays are not yet proven. `primary`/`alternate` is intentionally less specific than guessing that one is always underwater, roof or bridge state.
+The exact semantics of the primary/alternate scene modes are not yet proven. Neutral names are preferable to guessing underwater/roof/etc.
 
-### SceneTile
+## SceneTile members
 
-| Canonical member | Current source member | Confidence |
+| Canonical member | Current member | Confidence |
 | --- | --- | --- |
 | `tileBelow` | `aClass340_3380` | Verified |
 | `plane` | `aByte3381` | High |
@@ -220,30 +209,61 @@ The exact names of the two scene modes represented by the primary/alternate tile
 | `wallDecorationB` | `aClass432_Sub1_Sub3_3385` | Verified |
 | `floorDecoration` | `aClass432_Sub1_Sub4_3386` | Verified |
 | `objectLinks` | `aClass352_3388` | High |
-| `singleTileEntity` | `aClass432_Sub1_Sub2_3391` | High; precise subtype unresolved |
+| `singleTileEntity` | `aClass432_Sub1_Sub2_3391` | High; exact subtype unresolved |
 
-The remaining shorts are tied to occlusion boundaries/metadata and should be renamed together with the corresponding `OcclusionManager` methods.
+Remaining short fields appear tied to visibility/occlusion metadata and should be renamed with the corresponding occlusion logic.
 
-## Occlusion names
+## Entity picking / bounds
 
-`OcclusionManager` is not merely a generic visibility helper. It creates oriented occluders, stores them by category, maintains a per-plane tile visibility cache and asks `OcclusionRasterizer` to rasterize/test projected occlusion geometry.
+### ScreenSpaceBounds
 
-Useful source aliases:
+The current pick-bound class is mathematically a 2D capsule:
 
-| Canonical member | Current source member | Confidence |
-| --- | --- | --- |
-| `sceneGraph` | `aClass356_3710` | Verified |
-| `rasterizer` | `aClass347_3711` | Verified |
-| `tileVisibilityCache` | `anIntArrayArrayArray3713` | High |
-| `addOccluder` | `method4216` | Verified responsibility |
-| `removeOccluder` | `method4217` | Verified responsibility |
-| `invalidate/rebuildOccluders` | `method4221` | High; exact lifecycle name should be verified before source rename |
+- two endpoints;
+- a radius;
+- an active flag;
+- `hitTest(x, y)` computes distance to the segment or either endpoint and compares with radius.
 
-`Occluder` fields should be renamed as a group after each type (`1`, `2`, `4`, `8`, `16`) is mapped to its axis/orientation. The class name itself is already sufficiently certain.
+Suggested members:
+
+- first endpoint fields -> `startX`, `startY`;
+- second endpoint fields -> `endX`, `endY`;
+- `anInt673` -> `radius`;
+- `aBoolean671` -> `active`;
+- `method944` -> `hitTest` / `containsPoint`.
+
+Use exact start/end field mapping only after tracing renderer population code, since the containment math is symmetric.
+
+### SceneEntityBounds
+
+The 3D bound stores center X/Y/Z, a horizontal radius squared and min/max limits for all axes. `method4019` rejects outside the axis-aligned limits and then tests horizontal X/Z radial distance.
+
+- `method4019` -> `contains`
+- `method4020` -> `setBounds`
+
+Field-by-field min/max naming can be done mechanically from constructor assignments when the source rename is implemented.
+
+### SceneEntityPickList / SceneEntityPickEntry
+
+`SceneGraph` asks a rendered entity for a pick entry, associates the entity, then inserts it into the ordered pick list. The entry hit-test iterates the entity's `ScreenSpaceBounds` and delegates the detailed model/entity hit test.
+
+This evidence is strong enough to prefer `SceneEntityPickList` / `SceneEntityPickEntry` over the earlier generic `SceneEntityList` / `SceneEntityEntry` names.
+
+## Occlusion members
+
+### OcclusionManager
+
+- `aClass356_3710` -> `sceneGraph`
+- `aClass347_3711` -> `rasterizer`
+- `anIntArrayArrayArray3713` -> `tileVisibilityCache`
+- `method4216` -> `addOccluder`
+- `method4217` -> `removeOccluder`
+
+Investigate `method4221` completely before selecting a lifecycle name such as `rebuildOccluders` or `invalidateOcclusion`.
+
+`Occluder` field names should be renamed as one group after types `1`, `2`, `4`, `8`, `16` are mapped to exact orientations.
 
 ## Scene entity hierarchy
-
-The scene-object layer can be understood without retaining the generated inheritance names:
 
 ```text
 SceneEntity
@@ -255,118 +275,145 @@ SceneEntity
   |     +-- precise subtype still unresolved
   |
   +-- WallDecorationEntity
-  |     +-- static/dynamic concrete implementations
+  |     +-- concrete model/animation variants
   |
   +-- FloorDecorationEntity
-  |     +-- static/dynamic concrete implementations
+  |     +-- concrete model/animation variants
   |
   +-- WallEntity
-        +-- static/dynamic concrete implementations
+        +-- concrete model/animation variants
 ```
 
-Do not rename `Sub1` / `Sub2` concrete implementations to `Static` / `Dynamic` until their animation/model lifecycle has been compared. The base category names above are verified from the `Map` placement call sites; the concrete split needs its own evidence.
+Do not rename generated concrete `Sub1`/`Sub2` implementations to `Static`/`Dynamic` until their model cache and animation/update lifecycles have been compared.
 
-## SceneLight names
+## SceneLight members
 
-`SceneLight` currently exposes enough behavior to remove `Node_Sub14` from architecture prose:
+The light is now fully interpretable at the primary-field level because `MapFlickeringEffect` creates it as `(x, y, z, radius, color, 1.0F)` and updates only the float during flicker evaluation.
 
-| Canonical member | Current source member | Confidence |
+| Canonical member | Current member | Confidence |
 | --- | --- | --- |
 | `position` | `aVector3f_7608` | Verified |
+| `radius` | `anInt7606` | Verified |
+| `color` | `anInt7607` | Verified |
+| `intensity` | `aFloat7605` | Verified |
 | `getX` | `method3318` | Verified |
 | `getY` | `method3311` | Verified |
 | `getZ` | `method3312` | Verified |
+| `getRadius` | `method3316` | Verified |
+| `getColor` | `method3313` | Verified |
+| `getIntensity` | `method3317` | Verified |
+| `setIntensity` | `method3314` | Verified |
 | `setPosition` | `method3315` | Verified |
-| scalar light parameter | `aFloat7605` / `method3317` | Medium; likely intensity/brightness but not named until usage is fully traced |
-| integer light parameter A | `anInt7606` / `method3316` | Unresolved |
-| integer light parameter B | `anInt7607` / `method3313` | Unresolved |
 
-A source rename may safely rename the class and position methods now while leaving the three material/light parameters neutral until their renderer uses are traced.
+## FlickeringLightDefinition members
+
+A map flicker with type `31` resolves this external definition and copies its values into `MapFlickeringEffect`.
+
+| Canonical member | Current member | Confidence |
+| --- | --- | --- |
+| `waveform` | `anInt5959` | Verified from receiving field/switch |
+| `speed` | `anInt5956` | High; used as time multiplier/flicker progression speed |
+| `amplitude` | `anInt5958` | Verified from intensity equation |
+| `baseIntensity` | `anInt5957` | Verified from intensity equation |
+| `decode` | `method6187` | Verified |
+| `decodeOpcode` | `method6188` | Verified |
+
+`FlickeringLightDefinitionManager.method6217` -> `getFlickeringLightDefinition`.
+
+Useful `MapFlickeringEffect` renames:
+
+- `aClass330_Sub14_3467` -> `light`
+- `anInt3473` -> `waveform`
+- `anInt3474` -> `speed`
+- `anInt3466` -> `amplitude`
+- `anInt3452` -> `baseIntensity`
+- `method4021` -> `createLight`
+- `method4022` -> `setFlickerDefinition`
+- `method4023` -> `useBuiltInFlickerPreset`
+- `method4024` -> `updateIntensity`
 
 ## Terrain-height helper names
 
-Several exact terrain-height helpers live as unrelated static methods on otherwise miscellaneous classes. **Rename the methods, not the containing classes**, unless the rest of each class is independently understood.
+Several exact terrain-height helpers live as unrelated static methods on otherwise miscellaneous classes. Rename the methods, not the whole classes, unless the containing class is independently understood.
 
-| Canonical helper | Current source locator | Confidence | Behavior |
-| --- | --- | --- | --- |
-| `generateBaseTerrainHeight` | `Class156.calculateHeight` | Verified | Combines three noise octaves, scales the result and clamps to `10..60`. The method already has a partial readable name. |
-| `interpolatedNoise` | `TextureLoader.method652` | Verified | Samples four smoothed lattice values and performs 2D cosine interpolation. |
-| `smoothedNoise` | `Class170.method2039` | Verified | Weighted corner/cardinal/center smoothing over deterministic raw noise. |
-| `rawTerrainNoise` | `AbstractQueue_Sub1.method6486` | Verified | Deterministic integer hash/noise returning `0..255`. |
-| `cosineInterpolate` | `Class20.method466` | Verified | Fixed-point interpolation using the client's cosine lookup table. |
-| `cosineTable` | `Class257.anIntArray2684` | Verified | 16,384-entry fixed-point cosine lookup. |
-| `sineTable` | `Class257.anIntArray2683` | Verified | 16,384-entry fixed-point sine lookup. |
-| `angleToRadians` | `Class257.method2541` | Verified | Converts a masked 14-bit client angle to radians. |
-
-The stable algorithm is documented in `terrain-height-generation.md`; that document should use the canonical helper names and keep these generated source locators only in a reference table.
-
-## ModelDefinition member/method names
-
-`ModelDefinition` is already well enough named to keep. Several members still need cleanup.
-
-High-confidence aliases:
-
-| Canonical member | Current source member | Confidence |
+| Canonical helper | Current source locator | Confidence |
 | --- | --- | --- |
-| `vertexX` | `vertexX` | Verified |
-| `vertexY` | `vertexY` | Verified |
-| `vertexZ` | `vertexZ` | Verified |
-| `triangleVertexA` | `triangleViewSpaceX` | Verified | Despite the current name, this is the first triangle vertex index, not a transformed view-space coordinate. |
+| `generateBaseTerrainHeight` | `Class156.calculateHeight` | Verified |
+| `interpolatedNoise` | `TextureLoader.method652` | Verified |
+| `smoothedNoise` | `Class170.method2039` | Verified |
+| `rawTerrainNoise` | `AbstractQueue_Sub1.method6486` | Verified |
+| `cosineInterpolate` | `Class20.method466` | Verified |
+| `sineTable` | `Class257.anIntArray2683` | Verified |
+| `cosineTable` | `Class257.anIntArray2684` | Verified |
+| `angleToRadians` | `Class257.method2541` | Verified |
+
+See `terrain-height-generation.md` for the full algorithm using the semantic helper names.
+
+## ModelDefinition cleanup
+
+`ModelDefinition` is well named, but several members are misleading.
+
+| Canonical member | Current member | Confidence |
+| --- | --- | --- |
+| `triangleVertexA` | `triangleViewSpaceX` | Verified |
 | `triangleVertexB` | `triangleViewSpaceY` | Verified |
 | `triangleVertexC` | `triangleViewSpaceZ` | Verified |
 | `faceColors` | `colors` | Verified |
 | `faceAlpha` | `alpha` | Verified |
 | `facePriorities` | `priorities` | Verified |
 | `faceTextures` | `textures` | Verified |
-| `decodeLegacyFormat` | `method1199` | Verified responsibility | Reads the older 18-byte-footer model layout. |
-| `decodeModernFormat` | `method1201` | Verified responsibility | Reads the newer `0xFF 0xFF`-terminated layout with the 23-byte base footer and optional sections. |
+| `decodeLegacyFormat` | `method1199` | Verified |
+| `decodeModernFormat` | `method1201` | Verified |
 | `translate` | `method1194` | Verified |
-| `rotate` | `method1195` | High; method applies rotations around the three model axes. |
+| `rotate` | `method1195` | High |
 | `scaleByPowerOfTwo` | `method1196` | Verified |
 | `recolor` | `method1185` | Verified |
 | `retexture` | `method1200` | Verified |
 
-The misleading `triangleViewSpaceX/Y/Z` names should be a priority rename because they can easily produce the wrong web mesh abstraction.
+The `triangleViewSpace*` names are actively misleading: they are triangle topology vertex indices, not view-space positions.
 
 ## GraphicsToolkit aliases
 
-Do not port or expose the obfuscated graphics API. Only a handful of operations are needed to understand the scene pipeline:
+Do not port the obfuscated graphics API. The high-value semantic operations needed for architecture are:
 
-| Canonical operation | Current source member | Confidence |
-| --- | --- | --- |
-| `createTerrainSurface` | `GraphicsToolkit.cn(...)` | Verified |
-| `createModel` | `GraphicsToolkit.cb(ModelDefinition, ...)` | Verified |
+- `GraphicsToolkit.cn(...)` -> `createTerrainSurface(...)`;
+- `GraphicsToolkit.cb(ModelDefinition, ...)` -> `createModel(...)`;
+- the map-light factory used by `MapFlickeringEffect` -> `createSceneLight(...)`.
 
-Concrete subclasses should be described in architecture as **OpenGL backend**, **Direct3D backend**, and **software backend**. Their generated subclass names belong only in a source-tracing note, not in Hagalaz APIs or the web-renderer design.
+Concrete subclasses should be described by backend: OpenGL, Direct3D and software. Generated subclass names should not enter new Hagalaz architecture.
 
-## Names deliberately not frozen yet
+## HighResolutionClock caveat
 
-The following areas still need focused tracing before source renaming:
+The `Class509` **instance** responsibility is a nanosecond clock (`System.nanoTime()`). However the class also contains unrelated static utility methods due decompiler/obfuscator bundling. If the source is renamed, verify all construction/instance call sites and avoid accidentally implying that the unrelated static methods are clock behavior. A later cleanup may be better served by extracting the clock responsibility instead of globally renaming every static reference.
 
-- the exact meaning of all secondary `FloorOverlayDefinition` fields/opcodes;
-- the two unresolved `FloorUnderlayDefinition` boolean flags beyond their known rendering/occlusion effects;
-- the precise identity of `SingleTileSceneEntity`;
-- static-versus-dynamic naming for concrete wall/wall-decoration/floor-decoration/object subclasses;
-- the exact role/name of `SceneEntityList` and `SceneEntityEntry` in rendering versus picking;
-- all occluder orientation/type constants and associated short fields on `SceneTile`;
-- the renderer-specific abstract operations on `TerrainSurface` other than height queries;
-- light color/radius/intensity parameter names on `SceneLight`;
-- secondary atmosphere, roof-hiding and visibility classes.
+## Deliberately unresolved names
 
-These are **deobfuscation tasks**, not reasons to leak generated names into new Hagalaz code. New server/web code should name data by its observed semantic purpose and keep unresolved client-only details behind the render projection.
+Continue tracing before freezing names for:
+
+- all secondary `FloorOverlayDefinition` fields/opcodes;
+- the two secondary underlay booleans;
+- exact identity of `SingleTileSceneEntity`;
+- concrete entity model/animation variants;
+- exact primary/alternate SceneGraph mode semantics;
+- occluder orientation constants and SceneTile occlusion shorts;
+- renderer-specific `TerrainSurface` operations beyond height queries;
+- atmosphere, roof-hiding and advanced visibility classes;
+- model skinning/animation/effect metadata not needed by static rendering.
+
+These are deobfuscation tasks, not reasons to leak generated names into Hagalaz.
 
 ## Recommended source-rename order
 
-A source-level GameClient cleanup should be mechanical and behavior-preserving. Use this order so each step reduces the number of generated names in the next diff:
+Use behavior-preserving, compilable rename groups:
 
-1. Floor definitions/managers: `FloorUnderlayDefinition`, `FloorUnderlayDefinitionManager`, `FloorOverlayDefinitionManager`.
-2. Terrain core: `TerrainSurface`, then `TerrainBuilder`.
-3. Scene core: `SceneTile`, `SceneObjectLink`, `SceneGraph`.
-4. Occlusion: `Occluder`, `OcclusionRasterizer`, `OcclusionManager`.
-5. Scene entity bases: `SceneEntity`, `MultiTileSceneEntity`, `SingleTileSceneEntity`, `WallEntity`, `WallDecorationEntity`, `FloorDecorationEntity`.
-6. `SceneLight`.
-7. High-confidence method/field names in the classes above.
-8. `ModelDefinition` triangle/member cleanup.
-9. Only then investigate lower-confidence render queues, concrete entity variants, atmosphere and backend-specific methods.
+1. floor definitions/managers;
+2. `TerrainSurface` and `TerrainBuilder`;
+3. `SceneTile`, `SceneObjectLink`, bounds/picking helpers and `SceneGraph`;
+4. occluder/rasterizer/occlusion manager;
+5. scene entity bases/categories;
+6. `SceneLight`, flicker definition/manager and `MapFlickeringEffect` members;
+7. high-confidence methods/fields in those classes;
+8. `ModelDefinition` topology/member cleanup;
+9. lower-confidence concrete entity variants, scene modes, atmosphere and backend-specific methods.
 
-Each source-rename commit should compile before the next group is renamed. Do not combine semantic behavior changes with the deobfuscation commits.
+Run `./gradlew build` after every group. Do not mix behavior changes or broad formatting with the rename commits.

--- a/docs/3d-rendering/client-rendering-deobfuscation.md
+++ b/docs/3d-rendering/client-rendering-deobfuscation.md
@@ -1,0 +1,372 @@
+# Game-client rendering deobfuscation map
+
+This document defines the **canonical human-readable names** used by Hagalaz documentation for the RuneScape client rendering subsystem.
+
+The source snapshot is `frankvdb7/Hagalaz.GameClient@6eac3762cc46cec484131369691b5221fd1277bf`.
+
+## Naming policy
+
+The decompiled client still contains many generated identifiers such as `Class274`, `Class356`, `Class_xa` and `method6416`. Those names are source-location artifacts, not architecture.
+
+For Hagalaz 3D work:
+
+1. **Use the semantic name in architecture, specifications, DTO discussions, tests and implementation notes.**
+2. **Keep the obfuscated identifier only in this source-locator document** until the GameClient source itself has been mechanically renamed.
+3. **Rename only when responsibility is supported by call sites and data flow.** Do not guess a precise name from one method or one opcode.
+4. **Separate class confidence from member confidence.** A class can have a clear role even when some of its fields remain unresolved.
+5. **Do not rename a miscellaneous class solely because one static helper in it has been understood.** Several Jagex classes contain unrelated static utility methods because of obfuscation. In those cases the method receives a semantic alias while the containing class remains only a source locator.
+6. **Prefer domain names over renderer-specific names.** `TerrainSurface`, `SceneGraph`, `Occluder` and `SceneLight` describe the RuneScape scene independently of OpenGL, Direct3D or Three.js.
+
+Confidence levels:
+
+- **Verified**: the class/member role is demonstrated directly by construction, fields and call sites.
+- **High**: behavior is strongly constrained by multiple call sites; the chosen name is unlikely to change materially.
+- **Medium**: the broad role is clear, but a more precise RuneScape/client term may emerge later.
+- **Unresolved**: keep the current source identifier in the source repository until more evidence exists; do not expose it in Hagalaz public contracts.
+
+## Core rendering class names
+
+| Canonical name | Current source locator | Confidence | Evidence / responsibility |
+| --- | --- | --- | --- |
+| `TerrainBuilder` | `Class274` | Verified | Owns tile heights, overlays, underlays, overlay shape/rotation, terrain flags and camera-adjustment grids; decodes normal/dynamic landscape tiles and builds renderer-backed terrain surfaces. `Map` extends it. |
+| `SceneGraph` | `Class356` | Verified | Owns per-plane scene tiles, terrain surfaces, scene entities, map lights, visibility state and the occlusion subsystem; inserts/removes walls, decorations and standard objects. |
+| `SceneTile` | `Class340` | Verified | One tile/plane cell in the scene graph. Holds wall entities, wall decorations, floor decoration, linked multi-tile objects and a link to the tile below. |
+| `TerrainSurface` | `Class_xa` | Verified | Abstract renderer-backed terrain height/surface object. Owns the height grid and tile scale and supports exact/interpolated height queries plus backend terrain operations. |
+| `OcclusionManager` | `Class358` | Verified | Owns occluder collections, tile visibility cache and occlusion tests; created by and bound to the scene graph. |
+| `Occluder` | `Class385` | High | Stores occluder type/plane and polygon/corner coordinates; created, indexed and queried exclusively by the occlusion subsystem. |
+| `OcclusionRasterizer` | `Class347` | High | Rasterizes projected occlusion triangles/scanlines into the occlusion manager's depth/visibility buffer. |
+| `FloorUnderlayDefinition` | `Class491` | Verified | Decodes underlay RGB, texture, texture scale and rendering flags and derives HSL/hue-multiplier data used by terrain color/material construction. |
+| `FloorUnderlayDefinitionManager` | `Class499` | Verified | Cache-backed manager for floor-underlay definitions with an ID-keyed `NodeCache`; constructs/decodes/caches `FloorUnderlayDefinition`. |
+| `FloorOverlayDefinitionManager` | `Class418` | Verified | Cache-backed manager for overlay definitions; loads the overlay config archive and constructs/caches `OverlayType`. |
+| `FloorOverlayDefinition` | `OverlayType` | Verified concept | Source class is already partially named. It is the floor-overlay definition containing primary/secondary color, texture, hide-underlay and additional material parameters. |
+| `SceneEntity` | `Entity_Sub1` | High | Common abstract scene-renderable base. Owns scene/plane state, participates in visibility/bounds/render operations, and resolves nearby map lights. |
+| `MultiTileSceneEntity` | `Entity_Sub1_Sub1` | High | Scene entity with explicit start/end X/Y tile bounds and active state; represents entities spanning a tile rectangle. |
+| `SingleTileSceneEntity` | `Entity_Sub1_Sub2` | High | Position-based scene entity whose scene/light/visibility queries resolve from one current tile. Precise gameplay subtype remains intentionally generic. |
+| `WallDecorationEntity` | `Entity_Sub1_Sub3` | Verified | Constructed by `Map` for `ShapeType.wallDecoration*` placements and stored in the scene tile's wall-decoration slots. |
+| `FloorDecorationEntity` | `Entity_Sub1_Sub4` | Verified | Constructed for the floor-decoration scene layer and stored in the scene tile's floor-decoration slot. |
+| `WallEntity` | `Entity_Sub1_Sub5` | Verified | Constructed for wall/corner/unfinished-wall shapes and stored as one or two wall entities per scene tile. |
+| `SceneObjectLink` | `Class352` | High | Pooled linked node containing a `MultiTileSceneEntity`; used by scene tiles to reference multi-tile/standard objects without duplicating the object. |
+| `SceneLight` | `Node_Sub14` | High | Position-bearing light object used by map flickering effects, terrain and scene entities; exposes X/Y/Z, scalar/int light parameters and position mutation. |
+| `SceneEntityList` | `Class338` | Medium | Maintains ordered scene-entity entries, removes duplicates in one mode and releases pooled entries. Exact role in the render/picking pipeline needs more deobfuscation before a source rename. |
+| `SceneEntityEntry` | `Class353` | Medium | Pooled wrapper around a `SceneEntity` with bounds/hit-test behavior and ownership by `SceneEntityList`. |
+
+`Map`, `RegionManager`, `ObjectDefinition`, `ObjectDefinitionManager`, `ModelDefinition`, `Model`, `GraphicsToolkit`, `TerrainData`, `Atmosphere`, `AtmosphereManager`, `MapFlickeringEffect` and `ShapeType` are already sufficiently human-readable and remain canonical.
+
+## Core inheritance / ownership model
+
+Use this model in documentation instead of the decompiled names:
+
+```text
+RegionManager
+    |
+    v
+Map : TerrainBuilder
+    |
+    +--> FloorOverlayDefinitionManager --> FloorOverlayDefinition
+    |
+    +--> FloorUnderlayDefinitionManager --> FloorUnderlayDefinition
+    |
+    +--> ObjectDefinitionManager --> ObjectDefinition --> ModelDefinition
+    |
+    v
+SceneGraph
+    |
+    +--> SceneTile[plane][x][y]
+    |      +--> WallEntity (0..2)
+    |      +--> WallDecorationEntity (0..2)
+    |      +--> FloorDecorationEntity (0..1)
+    |      +--> SceneObjectLink --> MultiTileSceneEntity
+    |      +--> other single-tile scene entity
+    |
+    +--> TerrainSurface[plane]
+    +--> SceneLight[]
+    +--> OcclusionManager
+               +--> Occluder[]
+               +--> OcclusionRasterizer
+
+GraphicsToolkit
+    +--> creates TerrainSurface
+    +--> creates Model from ModelDefinition
+    +--> concrete OpenGL / Direct3D / software backends
+```
+
+This is the vocabulary that should be copied into Hagalaz code and API design. Do not introduce `Class###`-inspired names into the server or web renderer.
+
+## TerrainBuilder member names
+
+The following members are sufficiently understood for documentation and future GameClient source renaming.
+
+| Canonical member | Current source member | Confidence | Meaning |
+| --- | --- | --- | --- |
+| `sceneGraph` | `aClass356_2767` | Verified | Scene graph receiving built terrain and scene objects. |
+| `floorOverlayDefinitions` | `aClass418_2765` | Verified | Floor overlay definition manager. |
+| `floorUnderlayDefinitions` | `aClass499_2819` | Verified | Floor underlay definition manager. |
+| `terrainData` | `aTerrainData_2811` | Verified | Terrain flags / effective-plane metadata. |
+| `tileHeights` | `tileHeights` | Verified | Per-plane corner/height grid. |
+| `overlayIds` | `overlayIds` | Verified | Per-tile overlay IDs. |
+| `underlayIds` | `underlayIds` | Verified | Per-tile underlay IDs. |
+| `overlayShapes` | `overlayPaths` | High | Per-tile floor-overlay shape/path value decoded from `(opcode - 2) / 4`. `shape` is clearer for renderer documentation. |
+| `overlayRotations` | `overlayRotations` | Verified | Per-tile overlay rotation `0..3`. |
+| `cameraAdjustments` | `cameraAdjustments` | Verified field name | Per-plane map-provided adjustment grid; exact camera/roof semantics remain a later fidelity topic. |
+| `setShadingDelayed` | `method2684` | High | Enables delayed terrain shading/shadow-related accumulation. |
+| `releaseTerrainBuildScratch` | `method2685` | High | Clears terrain-color/material accumulation arrays and ends delayed-build scratch state. |
+| `initializeHeightArea` | `method2687` | High | Initializes/fills a rectangular height area and repairs boundaries. |
+| `readCollisionData` | `readCollisionData` | Verified | Decodes terrain flags for collision across a normal 64x64 region. |
+| `readDynamicChunkCollisionData` | `method2689` | High | Reads/rotates one dynamic 8x8 region part into destination collision/height space. |
+| `createTerrainSurfaces` | `readGroundMapData` | High | Allocates renderer terrain surfaces for the active planes through `GraphicsToolkit`. |
+| `buildTerrainSurfaces` | `method2692` | Verified responsibility | Resolves floor definitions, colors/material inputs and shaped tiles into the terrain surfaces. |
+| `readLandscapeData` | `readLandscapeData` | Verified | Decodes one tile's terrain opcode list including height, overlay, flags and underlay. |
+
+Some large terrain-build scratch arrays are still intentionally unnamed. Their meaning should be derived from the particular material/shape algorithm before they are renamed, rather than receiving names such as `temp1` or `colors2`.
+
+## TerrainSurface member names
+
+| Canonical member | Current source member | Confidence | Meaning |
+| --- | --- | --- | --- |
+| `heightGrid` | `anIntArrayArray6394` | Verified | Corner/grid heights used by exact and interpolated height queries. |
+| `tileCountX` | `anInt6397` | Verified | Terrain width in tiles. |
+| `tileCountY` | `anInt6393` | Verified | Terrain height/depth in tiles. |
+| `tileSize` | `anInt6395` | Verified | Scene units per tile; normally 512 for map terrain. |
+| `tileShift` | `anInt6396` | Verified | `log2(tileSize)` used for tile lookup and interpolation. |
+| `getInterpolatedHeight` | `method6416` | Verified | Bilinear interpolation of four height-grid corners for a world/scene position. |
+| `getTileHeight` | `method6417` | Verified | Direct grid height lookup. |
+
+The remaining abstract methods cover backend-specific terrain building, drawing, shadow/mask and resource operations. They should be renamed per behavior after comparing their implementations across the renderer backends; a one-backend guess is not sufficient.
+
+## FloorUnderlayDefinition member names
+
+The underlay definition is one of the strongest deobfuscation targets because its decode and color conversion are self-contained.
+
+| Canonical member | Current source member | Confidence | Evidence |
+| --- | --- | --- | --- |
+| `rgbColor` | `anInt5860` | Verified | Opcode `1` reads a 24-bit RGB value and immediately derives HSL data from it. |
+| `hue` | `anInt5855` | Verified | Computed from RGB hue multiplied by the hue multiplier, matching the classic RuneScape underlay-color representation. |
+| `saturation` | `anInt5861` | Verified | RGB-to-HSL saturation clamped to `0..255`. |
+| `lightness` | `anInt5862` | Verified | RGB-to-HSL lightness clamped to `0..255`. |
+| `hueMultiplier` | `anInt5863` | Verified | Saturation/lightness-derived multiplier, minimum `1`, used to scale hue. |
+| `texture` | `anInt5856` | High | Opcode `2` reads an ID with `65535 -> -1`; terrain construction passes it in the same material slot as overlay textures. |
+| `textureScale` | `anInt5857` | High | Opcode `3` reads `ushort << 2` and terrain construction carries it with the underlay texture. |
+| `decode` | `method6072` | Verified | Reads opcodes until `0`. |
+| `decodeOpcode` | `method6073` | Verified | Decodes one underlay-definition opcode. |
+| `calculateHsl` | `method6074` | Verified | Converts the decoded RGB color into hue/saturation/lightness/hue multiplier. |
+
+Two booleans remain deliberately semantic-but-not-overprecise:
+
+- opcode `4`: default `true`, becomes `false`; participates in shaped-terrain build behavior;
+- opcode `5`: default `true`, becomes `false`; participates in whether an upper-plane flat tile may contribute to the client's occlusion/visibility flags.
+
+Until every use is traced, name these in documentation as `renderFlag4` / `allowsOcclusion` only with an explicit confidence note. Do **not** put guessed names into a public Hagalaz API.
+
+## Floor-definition manager names
+
+### FloorUnderlayDefinitionManager
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `definitions` | `aNodeCache_5891` | Verified |
+| `configContainer` | `configContainer` | Verified |
+| `getFloorUnderlayDefinition` | `method6111` | Verified |
+
+The remaining instance methods are cache maintenance operations and can be named once their corresponding `NodeCache` methods are deobfuscated consistently.
+
+### FloorOverlayDefinitionManager
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `definitions` | `aNodeCache_4296` | Verified |
+| `configContainer` | `configContainer` | Verified |
+| `getFloorOverlayDefinition` | `getOverlayType` | Verified |
+| `definitionCount` | `anInt4295` | High |
+
+`anInt4294` is modified by overlay opcode `8`; its exact special-overlay/default role is not sufficiently proven yet.
+
+## SceneGraph / SceneTile names
+
+### SceneGraph
+
+The scene graph has enough evidence to rename its structural fields now, while leaving frame-specific visibility scratch fields for later.
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `graphicsToolkit` | `aGraphicsToolkit3645` | Verified |
+| `occlusionManager` | `aClass358_3649` | Verified |
+| `activeTiles` | `aClass340ArrayArrayArray3653` | Verified |
+| `primaryTiles` | `aClass340ArrayArrayArray3655` | High |
+| `alternateTiles` | `aClass340ArrayArrayArray3657` | High |
+| `activeTerrainSurfaces` | `aClass_xaArray3676` | Verified |
+| `primaryTerrainSurfaces` | `aClass_xaArray3701` | High |
+| `alternateTerrainSurfaces` | `aClass_xaArray3658` | High |
+| `mapLights` | `aMapFlickeringEffectArray3679` | Verified |
+| `tilesRangeX` | `tilesRangeX` | Verified |
+| `tilesRangeY` | `tilesRangeY` | Verified |
+| `maxPlanes` | `maxZ` | High |
+| `getOrCreateTile` | `method4136` | Verified responsibility |
+| `ensureTileStack` | `method4137` | High |
+| `addFloorDecoration` | `method4142` | Verified from `Map` layer/shape call sites |
+| `addWallDecoration` | `method4144` | Verified from `ShapeType.wallDecoration*` call sites |
+| `addWalls` | `method4180` | Verified from wall/corner shape call sites |
+
+The exact names of the two scene modes represented by the primary/alternate tile/surface arrays are not yet proven. `primary`/`alternate` is intentionally less specific than guessing that one is always underwater, roof or bridge state.
+
+### SceneTile
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `tileBelow` | `aClass340_3380` | Verified |
+| `plane` | `aByte3381` | High |
+| `wallA` | `aClass432_Sub1_Sub5_3382` | Verified |
+| `wallB` | `aClass432_Sub1_Sub5_3383` | Verified |
+| `wallDecorationA` | `aClass432_Sub1_Sub3_3384` | Verified |
+| `wallDecorationB` | `aClass432_Sub1_Sub3_3385` | Verified |
+| `floorDecoration` | `aClass432_Sub1_Sub4_3386` | Verified |
+| `objectLinks` | `aClass352_3388` | High |
+| `singleTileEntity` | `aClass432_Sub1_Sub2_3391` | High; precise subtype unresolved |
+
+The remaining shorts are tied to occlusion boundaries/metadata and should be renamed together with the corresponding `OcclusionManager` methods.
+
+## Occlusion names
+
+`OcclusionManager` is not merely a generic visibility helper. It creates oriented occluders, stores them by category, maintains a per-plane tile visibility cache and asks `OcclusionRasterizer` to rasterize/test projected occlusion geometry.
+
+Useful source aliases:
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `sceneGraph` | `aClass356_3710` | Verified |
+| `rasterizer` | `aClass347_3711` | Verified |
+| `tileVisibilityCache` | `anIntArrayArrayArray3713` | High |
+| `addOccluder` | `method4216` | Verified responsibility |
+| `removeOccluder` | `method4217` | Verified responsibility |
+| `invalidate/rebuildOccluders` | `method4221` | High; exact lifecycle name should be verified before source rename |
+
+`Occluder` fields should be renamed as a group after each type (`1`, `2`, `4`, `8`, `16`) is mapped to its axis/orientation. The class name itself is already sufficiently certain.
+
+## Scene entity hierarchy
+
+The scene-object layer can be understood without retaining the generated inheritance names:
+
+```text
+SceneEntity
+  |
+  +-- MultiTileSceneEntity
+  |     +-- concrete standard/game-object implementations
+  |
+  +-- SingleTileSceneEntity
+  |     +-- precise subtype still unresolved
+  |
+  +-- WallDecorationEntity
+  |     +-- static/dynamic concrete implementations
+  |
+  +-- FloorDecorationEntity
+  |     +-- static/dynamic concrete implementations
+  |
+  +-- WallEntity
+        +-- static/dynamic concrete implementations
+```
+
+Do not rename `Sub1` / `Sub2` concrete implementations to `Static` / `Dynamic` until their animation/model lifecycle has been compared. The base category names above are verified from the `Map` placement call sites; the concrete split needs its own evidence.
+
+## SceneLight names
+
+`SceneLight` currently exposes enough behavior to remove `Node_Sub14` from architecture prose:
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `position` | `aVector3f_7608` | Verified |
+| `getX` | `method3318` | Verified |
+| `getY` | `method3311` | Verified |
+| `getZ` | `method3312` | Verified |
+| `setPosition` | `method3315` | Verified |
+| scalar light parameter | `aFloat7605` / `method3317` | Medium; likely intensity/brightness but not named until usage is fully traced |
+| integer light parameter A | `anInt7606` / `method3316` | Unresolved |
+| integer light parameter B | `anInt7607` / `method3313` | Unresolved |
+
+A source rename may safely rename the class and position methods now while leaving the three material/light parameters neutral until their renderer uses are traced.
+
+## Terrain-height helper names
+
+Several exact terrain-height helpers live as unrelated static methods on otherwise miscellaneous classes. **Rename the methods, not the containing classes**, unless the rest of each class is independently understood.
+
+| Canonical helper | Current source locator | Confidence | Behavior |
+| --- | --- | --- | --- |
+| `generateBaseTerrainHeight` | `Class156.calculateHeight` | Verified | Combines three noise octaves, scales the result and clamps to `10..60`. The method already has a partial readable name. |
+| `interpolatedNoise` | `TextureLoader.method652` | Verified | Samples four smoothed lattice values and performs 2D cosine interpolation. |
+| `smoothedNoise` | `Class170.method2039` | Verified | Weighted corner/cardinal/center smoothing over deterministic raw noise. |
+| `rawTerrainNoise` | `AbstractQueue_Sub1.method6486` | Verified | Deterministic integer hash/noise returning `0..255`. |
+| `cosineInterpolate` | `Class20.method466` | Verified | Fixed-point interpolation using the client's cosine lookup table. |
+| `cosineTable` | `Class257.anIntArray2684` | Verified | 16,384-entry fixed-point cosine lookup. |
+| `sineTable` | `Class257.anIntArray2683` | Verified | 16,384-entry fixed-point sine lookup. |
+| `angleToRadians` | `Class257.method2541` | Verified | Converts a masked 14-bit client angle to radians. |
+
+The stable algorithm is documented in `terrain-height-generation.md`; that document should use the canonical helper names and keep these generated source locators only in a reference table.
+
+## ModelDefinition member/method names
+
+`ModelDefinition` is already well enough named to keep. Several members still need cleanup.
+
+High-confidence aliases:
+
+| Canonical member | Current source member | Confidence |
+| --- | --- | --- |
+| `vertexX` | `vertexX` | Verified |
+| `vertexY` | `vertexY` | Verified |
+| `vertexZ` | `vertexZ` | Verified |
+| `triangleVertexA` | `triangleViewSpaceX` | Verified | Despite the current name, this is the first triangle vertex index, not a transformed view-space coordinate. |
+| `triangleVertexB` | `triangleViewSpaceY` | Verified |
+| `triangleVertexC` | `triangleViewSpaceZ` | Verified |
+| `faceColors` | `colors` | Verified |
+| `faceAlpha` | `alpha` | Verified |
+| `facePriorities` | `priorities` | Verified |
+| `faceTextures` | `textures` | Verified |
+| `decodeLegacyFormat` | `method1199` | Verified responsibility | Reads the older 18-byte-footer model layout. |
+| `decodeModernFormat` | `method1201` | Verified responsibility | Reads the newer `0xFF 0xFF`-terminated layout with the 23-byte base footer and optional sections. |
+| `translate` | `method1194` | Verified |
+| `rotate` | `method1195` | High; method applies rotations around the three model axes. |
+| `scaleByPowerOfTwo` | `method1196` | Verified |
+| `recolor` | `method1185` | Verified |
+| `retexture` | `method1200` | Verified |
+
+The misleading `triangleViewSpaceX/Y/Z` names should be a priority rename because they can easily produce the wrong web mesh abstraction.
+
+## GraphicsToolkit aliases
+
+Do not port or expose the obfuscated graphics API. Only a handful of operations are needed to understand the scene pipeline:
+
+| Canonical operation | Current source member | Confidence |
+| --- | --- | --- |
+| `createTerrainSurface` | `GraphicsToolkit.cn(...)` | Verified |
+| `createModel` | `GraphicsToolkit.cb(ModelDefinition, ...)` | Verified |
+
+Concrete subclasses should be described in architecture as **OpenGL backend**, **Direct3D backend**, and **software backend**. Their generated subclass names belong only in a source-tracing note, not in Hagalaz APIs or the web-renderer design.
+
+## Names deliberately not frozen yet
+
+The following areas still need focused tracing before source renaming:
+
+- the exact meaning of all secondary `FloorOverlayDefinition` fields/opcodes;
+- the two unresolved `FloorUnderlayDefinition` boolean flags beyond their known rendering/occlusion effects;
+- the precise identity of `SingleTileSceneEntity`;
+- static-versus-dynamic naming for concrete wall/wall-decoration/floor-decoration/object subclasses;
+- the exact role/name of `SceneEntityList` and `SceneEntityEntry` in rendering versus picking;
+- all occluder orientation/type constants and associated short fields on `SceneTile`;
+- the renderer-specific abstract operations on `TerrainSurface` other than height queries;
+- light color/radius/intensity parameter names on `SceneLight`;
+- secondary atmosphere, roof-hiding and visibility classes.
+
+These are **deobfuscation tasks**, not reasons to leak generated names into new Hagalaz code. New server/web code should name data by its observed semantic purpose and keep unresolved client-only details behind the render projection.
+
+## Recommended source-rename order
+
+A source-level GameClient cleanup should be mechanical and behavior-preserving. Use this order so each step reduces the number of generated names in the next diff:
+
+1. Floor definitions/managers: `FloorUnderlayDefinition`, `FloorUnderlayDefinitionManager`, `FloorOverlayDefinitionManager`.
+2. Terrain core: `TerrainSurface`, then `TerrainBuilder`.
+3. Scene core: `SceneTile`, `SceneObjectLink`, `SceneGraph`.
+4. Occlusion: `Occluder`, `OcclusionRasterizer`, `OcclusionManager`.
+5. Scene entity bases: `SceneEntity`, `MultiTileSceneEntity`, `SingleTileSceneEntity`, `WallEntity`, `WallDecorationEntity`, `FloorDecorationEntity`.
+6. `SceneLight`.
+7. High-confidence method/field names in the classes above.
+8. `ModelDefinition` triangle/member cleanup.
+9. Only then investigate lower-confidence render queues, concrete entity variants, atmosphere and backend-specific methods.
+
+Each source-rename commit should compile before the next group is renamed. Do not combine semantic behavior changes with the deobfuscation commits.

--- a/docs/3d-rendering/external-742-reference.md
+++ b/docs/3d-rendering/external-742-reference.md
@@ -1,0 +1,184 @@
+# External revision-742 rendering references
+
+This document records public sources that can be used to triangulate the decompiled `Hagalaz.GameClient` rendering/map subsystem.
+
+The local client source and its actual call graph remain authoritative. External sources are evidence for naming and behavior only when their structure matches the local revision.
+
+## Primary reference: LostCityRS/RS742
+
+Repository: `LostCityRS/RS742`.
+
+This is a heavily refactored RuneScape 742 client and is the strongest public naming reference found for the scene/map subsystem. `Avexiis/RSPSi-742` explicitly credits it as the deobfuscated 742 client used while adding 742 map-editor support.
+
+The LostCity README contains an important revision warning:
+
+- its source is **742.1**;
+- the historically circulated client was **742.2**;
+- packet IDs are the same;
+- packet read/write alternative methods differ.
+
+Therefore:
+
+> Use LostCityRS/RS742 as a semantic and structural naming reference after comparing the local class, fields, inheritance and call sites. Do not transplant its protocol read/write methods into Hagalaz.GameClient without local byte-level verification.
+
+## Evidence hierarchy
+
+For deobfuscation work in this subsystem, use evidence in this order:
+
+1. local `Hagalaz.GameClient` construction, fields, inheritance, data flow and call sites;
+2. structurally matching `LostCityRS/RS742` classes;
+3. older/adjacent RuneTek clients with stronger canonical/Jagex terminology, such as 2011Scape;
+4. map editors and RSPS implementations as secondary behavioral evidence only.
+
+A public name is not sufficient by itself. The local class must match the responsibility.
+
+## Revision-specific class vocabulary
+
+The public 742 source resolves a number of classes more precisely than the first-pass names in `client-rendering-deobfuscation.md`.
+
+| Current Hagalaz.GameClient | First-pass semantic alias | Preferred 742 reference name | Evidence |
+| --- | --- | --- | --- |
+| `Class274` | `TerrainBuilder` | `MapLoader` | Same ownership of floor type lists, scene, tile flags, height/overlay/underlay arrays and tile-shape lookup tables. |
+| `Map` | `Map` | `ClientMapLoader` | Both extend the map loader and add loc/object definitions, environment/atmosphere data and static point-light decode. |
+| `Class356` | `SceneGraph` | `Scene` | Same renderer, tile arrays, floor models, entities, lights and occlusion ownership. |
+| `Class340` | `SceneTile` | `Tile` | Same tile-below, wall, wall-decor, ground-decor, object-layer, primary-layer-list and short metadata slots. |
+| `Class_xa` | `TerrainSurface` | `FloorModel` | Exact obfuscated base name `xa`; same height grid, tile dimensions/scale and bilinear fine-height query. |
+| `GraphicsToolkit` | `GraphicsToolkit` | `RendererToolkit` | Local decompiler header is `Class_ra`; public class is annotated obfuscated name `ra`; responsibilities match. |
+| `Entity_Sub1` | `SceneEntity` | `GraphEntity` | Same scene reference, level state, screen bounds, light lookup, entity bounds and pick/render contract. |
+| `Entity_Sub1_Sub1` | `MultiTileSceneEntity` | `PrimaryLayerEntity` | Same rectangular tile footprint and multi-tile primary scene layer role. |
+| `Entity_Sub1_Sub2` | `SingleTileSceneEntity` | `ObjLayerEntity` | Same single-position object-layer visibility/light/occlusion behavior. |
+| `Entity_Sub1_Sub3` | `WallDecorationEntity` | `WallDecorLayerEntity` | Matches the wall-decoration layer. |
+| `Entity_Sub1_Sub4` | `FloorDecorationEntity` | `GroundDecorLayerEntity` | Matches the ground-decoration layer. |
+| `Entity_Sub1_Sub5` | `WallEntity` | `WallLayerEntity` | Matches wall layer placement and light/occlusion behavior. |
+| `Class352` | `SceneObjectLink` | `PrimaryLayerEntityList` | Pooled linked-list node containing a primary-layer entity. |
+| `Class80` | `ScreenSpaceBounds` | `ScreenBoundingBox` | Same valid flag, two projected endpoints, radius and capsule point test. |
+| `Class348` | `SceneEntityBounds` | `EntityBounds` | Same origin/radius/min/max construction and containment test. |
+| `Class338` | `SceneEntityPickList` | `PickableEntityList` | Same ordered list and optional duplicate suppression. |
+| `Class353` | `SceneEntityPickEntry` | `PickableEntity` | Same pooled entity wrapper and screen-bound + detailed hit-test path. |
+| `Node_Sub14` | `SceneLight` | `Light` | Same position, radius/color-like integer parameters and intensity float with position/intensity mutation. |
+| `MapFlickeringEffect` | `MapFlickeringEffect` | `StaticPointLight` | Same map-decoded range masks, levels, light object and flicker configuration. |
+| `Class491` | `FloorUnderlayDefinition` | `FloorUnderlayType` | Same opcodes and HSL conversion. |
+| `Class499` | `FloorUnderlayDefinitionManager` | `FloorUnderlayTypeList` | Same cache-backed floor-underlay lookup role. |
+| `OverlayType` | `FloorOverlayDefinition` | `FloorOverlayType` | Same overlay config role. |
+| `Class418` | `FloorOverlayDefinitionManager` | `FloorOverlayTypeList` | Same cache-backed overlay list role. |
+| `Class512` | `FlickeringLightDefinition` | `LightType` | Same four opcode-decoded parameters used for special static point-light type 31. |
+| `Class519` | `FlickeringLightDefinitionManager` | `LightTypeList` | Same cached light-type lookup. |
+| `ModelDefinition` | `ModelDefinition` | `ModelUnlit` (pending final structural rename decision) | Same raw vertex/face/texture ownership and `FF FF` modern-format discriminator before creation of backend `Model`. |
+
+The preferred reference name should replace the first-pass alias in future source-level GameClient refactors once the local structural match has been verified.
+
+## Entity hierarchy exposed by the reference
+
+The public client provides concrete names for layers that the first-pass investigation intentionally left broad:
+
+```text
+GraphEntity
+├── PrimaryLayerEntity
+│   ├── PathingEntity
+│   │   ├── PlayerEntity
+│   │   └── NpcEntity
+│   ├── StaticSceneryEntity
+│   └── DynamicSceneryEntity
+├── ObjLayerEntity
+├── WallLayerEntity
+│   ├── StaticWallEntity
+│   └── DynamicWallEntity
+├── WallDecorLayerEntity
+│   ├── StaticWallDecorLayerEntity
+│   └── DynamicWallDecorEntity
+└── GroundDecorLayerEntity
+    ├── StaticGroundDecorEntity
+    └── DynamicGroundDecorEntity
+```
+
+Use this hierarchy as a comparison target, not as a blind rename table. For example, the local `Entity_Sub1_Sub5_Sub1` has already been compared with `StaticWallEntity` and exhibits the same object-definition list, model, shadow, bounds, object ID, shape/orientation and shadow/activity state.
+
+## Renderer toolkit vocabulary
+
+The public 742 `RendererToolkit` factory exposes five backend modes and a shared GPU abstraction:
+
+- `PureJavaToolkit`;
+- `SoftwareToolkit`;
+- `GlToolkit`;
+- `GlxToolkit`;
+- `DxToolkit`;
+- shared `GpuToolkit` base where applicable.
+
+This is more precise than documenting only “OpenGL / Direct3D / software”. Match each local `GraphicsToolkit_Sub*` by imports, constructor behavior and owned resources before renaming it.
+
+The local `GraphicsToolkit_Sub1` imports `jaggl.OpenGL` and native memory helpers in the same way as the public `GlToolkit`, making that a strong concrete comparison target.
+
+## Floor model terminology
+
+The public `FloorModel` is especially strong evidence because its obfuscated name is literally `xa`, matching the local original `Class_xa` name.
+
+It owns:
+
+- X/Y tile counts;
+- tile size;
+- tile shift;
+- the integer height grid;
+- a bilinear scene-coordinate height query named `getFineHeight`.
+
+This supports using `FloorModel` and `getFineHeight` rather than the more generic `TerrainSurface` / `getInterpolatedHeight` vocabulary when deobfuscating the Java client.
+
+Hagalaz server/web architecture should still use renderer-neutral terminology where that is clearer. Source deobfuscation vocabulary and public HTTP DTO vocabulary do not have to be identical.
+
+## Floor type findings
+
+The public `FloorUnderlayType` confirms the locally derived opcode meanings:
+
+- opcode `1`: RGB and HSL derivation;
+- opcode `2`: texture ID, with `65535 -> -1`;
+- opcode `3`: texture scale (`ushort << 2`);
+- opcodes `4` and `5`: boolean flags.
+
+The public reference also leaves the opcode-4/5 booleans unresolved. They should remain unnamed in Hagalaz.GameClient until their uses prove exact semantics.
+
+This is useful negative evidence: a plausible material name is not justified merely because another refactored 742 client exists.
+
+## Model terminology
+
+The public `ModelUnlit` is the decoded cache-model representation before the renderer produces a `Model`. Its constructor chooses between the same two binary layouts observed locally:
+
+```text
+last two bytes == FF FF -> newer format
+otherwise              -> legacy format
+```
+
+This reinforces the architectural distinction:
+
+```text
+cache model bytes
+    -> ModelUnlit / local ModelDefinition
+    -> renderer toolkit
+    -> Model
+```
+
+The Hagalaz web API should expose semantic mesh data rather than either Java class directly.
+
+## Secondary reference: 2011Scape
+
+`2011Scape/2011scape-client` targets revision 667 rather than 742, but its maintainers state that they use Jagex's canonical naming where possible, sourced from partially unobfuscated Jagex clients/debug symbols and other reverse-engineering work.
+
+Use it when choosing terminology that LostCity still leaves generic, but only after accounting for revision differences.
+
+## Secondary reference: RSPSi-742
+
+`Avexiis/RSPSi-742` is useful for practical 742 map/model/cache editor behavior and explicitly builds on the LostCity reference. Its own README describes the implementation as experimental and notes model/texture problems and incomplete under-map landscape handling.
+
+Use it to discover edge cases and editor workflows, not as the authoritative renderer/cache format specification.
+
+## Repeatable deobfuscation tooling
+
+LostCity publishes a RuneScape-specific Java deobfuscator, and the RuneWiki `rs-deob` project maintains deobfuscation profiles/remaps across many client revisions.
+
+For future GameClient work outside rendering, check those sources before manually re-deriving every class from scratch. Imported names still require verification against the local source revision.
+
+## Source links
+
+- `https://github.com/LostCityRS/RS742`
+- `https://github.com/LostCityRS/Deobfuscator`
+- `https://github.com/RuneWiki/rs-deob`
+- `https://github.com/2011Scape/2011scape-client`
+- `https://github.com/Avexiis/RSPSi-742`

--- a/docs/3d-rendering/game-client-renderer.md
+++ b/docs/3d-rendering/game-client-renderer.md
@@ -1,8 +1,10 @@
 # RuneScape game-client 3D renderer reference
 
-This document records the rendering behavior that has been verified in `frankvdb7/Hagalaz.GameClient` and is useful when implementing Hagalaz's web scene viewer. It intentionally translates partially deobfuscated classes into stable concepts instead of treating temporary `Class###` names as architecture.
+This document records the rendering behavior verified in `frankvdb7/Hagalaz.GameClient` and useful when implementing Hagalaz's web scene viewer.
 
 Snapshot: `Hagalaz.GameClient/main` at `6eac3762cc46cec484131369691b5221fd1277bf`.
+
+The canonical human-readable names used here are defined in [Rendering deobfuscation map](client-rendering-deobfuscation.md). Generated decompiler identifiers are intentionally excluded from the architecture narrative. Use the deobfuscation map only when a current source-file/method locator is needed.
 
 ## High-level pipeline
 
@@ -17,80 +19,87 @@ RegionManager
   - assembles normal or dynamic regions
   - owns collision data and load state
         |
-        +----------------------+
-        |                      |
-        v                      v
-Map / Class274            ObjectDefinitionManager
-  - decode floor tiles      - decode object render recipes
-  - compute heights         - choose models by object shape
-  - overlay/underlay        - recolor/retexture/transform
-  - dynamic chunk rotate             |
-        |                             v
-        |                       ModelDefinition
-        |                       vertex/triangle/texture data
-        |                             |
-        v                             v
-GraphicsToolkit.cn(...)        GraphicsToolkit.cb(...)
-  -> terrain surface              -> render Model
-        |                             |
-        +-------------+---------------+
-                      v
-                  Class356
-             tile scene / entities
-                      |
-                      v
-               GraphicsToolkit
-          OpenGL / Direct3D / software
+        +----------------------------+
+        |                            |
+        v                            v
+Map : TerrainBuilder            ObjectDefinitionManager
+  - decode floor tiles            - decode object render recipes
+  - compute heights               - choose models by object shape
+  - overlay/underlay              - recolor/retexture/transform
+  - dynamic chunk rotate                   |
+        |                                   v
+        |                             ModelDefinition
+        |                             vertex/triangle/texture data
+        |                                   |
+        v                                   v
+GraphicsToolkit.createTerrainSurface  GraphicsToolkit.createModel
+        |                                   |
+        +-----------------+-----------------+
+                          v
+                      SceneGraph
+              SceneTile / SceneEntity
+                          |
+                          v
+                   GraphicsToolkit
+             OpenGL / Direct3D / software
 ```
 
-The important architectural lesson is not to port `GraphicsToolkit`. The useful pattern is to keep RuneScape scene assembly independent from the selected renderer.
+The architectural lesson is **not** to port the client's large graphics API. The useful pattern is that RuneScape cache semantics and scene assembly are independent from the selected renderer.
 
 ## Stable concept map
 
-| Client class | Useful interpretation | Verified responsibility |
-| --- | --- | --- |
-| `RegionManager` | Region/scene loader | Resolves visible region IDs and XTEA keys, loads region bytes, handles normal and dynamic region assembly, creates `Map`, owns `CollisionData[]`, and triggers terrain/object construction. |
-| `Map` | Map scene builder | Extends `Class274`, adds object definitions, atmosphere, lights, camera adjustments, object placement/removal, and region-part landscape handling. |
-| `Class274` | Terrain/floor decoder and builder | Decodes tile heights, overlays, underlays, tile shapes/rotations and terrain flags, then builds backend terrain surfaces. |
-| `TerrainData` | Tile flags / effective-plane metadata | Stores decoded terrain flags and resolves bridge/plane behavior. It is not the visible terrain mesh or height map. |
-| `Class_xa` | Terrain surface | Owns a height grid, supports height interpolation, and exposes terrain drawing/build operations implemented per backend. |
-| `Class356` | Scene/tile graph | Owns tile cells, terrain surfaces, scene entities, occlusion-related state and map lights. |
-| `ObjectDefinition` | Object render recipe | Selects model IDs by shape and applies render-time scale, offsets, recolor/retexture, contouring, transforms, animation-related state and visibility properties. |
-| `ModelDefinition` | Decoded mesh source | Contains vertex positions, triangle indices, colors, alpha, texture references/mapping and skin/animation grouping data. |
-| `Model` | Backend render model | Backend-specific renderable produced from a `ModelDefinition`. |
-| `GraphicsToolkit` | Renderer abstraction | Creates terrain surfaces and models, manages transforms/render targets/material-related resources, and exposes drawing operations. |
-| `GraphicsToolkit_Sub1` | OpenGL backend | Uses `jaggl.OpenGL` and native buffers. |
-| `GraphicsToolkit_Sub2_Sub1` | OpenGL backend | OpenGL implementation of the shared `GraphicsToolkit_Sub2` hardware path. |
-| `GraphicsToolkit_Sub2_Sub2` | Direct3D backend | Uses `jagdx` Direct3D device/surface/capability APIs. |
-| `GraphicsToolkit_Sub3` | Software renderer | CPU/software rasterization path with its own buffers and matrices. |
-| `OverlayType` | Floor-overlay material definition | Includes primary/secondary RGB, texture ID, underlay visibility and additional material/blending properties. |
-| `Class491` | Floor-underlay definition | Decodes RGB-derived HSL data and other underlay rendering properties. The class still needs a human-readable deobfuscation name. |
+| Stable concept | Verified responsibility |
+| --- | --- |
+| `RegionManager` | Resolves visible region IDs and XTEA keys, loads region bytes, handles normal and dynamic region assembly, creates `Map`, owns collision data and triggers terrain/object construction. |
+| `Map` | Extends `TerrainBuilder`; adds object definitions, atmosphere, lights, camera adjustments, object placement/removal and region-part landscape handling. |
+| `TerrainBuilder` | Decodes tile heights, overlays, underlays, tile shapes/rotations and terrain flags, transforms dynamic chunks and builds renderer terrain surfaces. |
+| `TerrainData` | Stores terrain flags and resolves bridge/effective-plane behavior. It is not the visible terrain mesh or height map. |
+| `TerrainSurface` | Renderer-backed terrain surface with the height grid, exact height lookup and bilinear height interpolation. |
+| `SceneGraph` | Owns scene tiles, terrain surfaces, scene entities, map lights, visibility state and occlusion. |
+| `SceneTile` | One per-plane tile cell holding walls, wall decorations, a floor decoration and links to standard/multi-tile scene objects. |
+| `OcclusionManager` | Owns occluders, per-tile visibility results and occlusion tests. |
+| `Occluder` | One oriented occlusion volume/polygon represented by plane/type and projected corner data. |
+| `OcclusionRasterizer` | Rasterizes/tests projected occlusion geometry for the occlusion manager. |
+| `FloorOverlayDefinition` | Floor-overlay material input with primary/secondary color, texture, underlay visibility and additional material parameters. |
+| `FloorUnderlayDefinition` | Floor-underlay material input with RGB-derived HSL data, texture, texture scale and rendering flags. |
+| `ObjectDefinition` | Object render recipe: model selection by shape plus recolor/retexture, scale, offsets, contouring, transform and animation-related state. |
+| `ModelDefinition` | Decoded mesh source containing vertices, triangle indices, face colors/alpha/priorities, textures and optional skin/effect data. |
+| `Model` | Backend renderable created from `ModelDefinition`. |
+| `SceneEntity` | Abstract entity participating in scene visibility, bounds, nearby-light lookup and rendering. |
+| `WallEntity` | One or two wall pieces attached to a scene tile. |
+| `WallDecorationEntity` | Wall-attached decoration created for wall-decoration shape types. |
+| `FloorDecorationEntity` | Ground/floor decoration occupying a scene tile. |
+| `MultiTileSceneEntity` | Scene entity spanning an explicit rectangular tile footprint, used for standard/game objects. |
+| `SceneLight` | Position-bearing scene light used by map flicker effects, terrain and scene entities. |
+| `GraphicsToolkit` | Renderer abstraction that creates terrain surfaces/models and performs backend drawing/resource operations. |
 
 ## Region and chunk structure
 
-A normal cache region is 64×64 tiles with four planes. `RegionManager` maintains the surrounding region IDs and separate byte arrays for the region data it needs. The server-side Hagalaz `MapProvider` independently confirms the cache convention:
+A normal cache region is **64x64 tiles with four planes**. `RegionManager` maintains the surrounding region IDs and separate byte arrays for the region data it needs. Hagalaz's `MapProvider` independently confirms the cache naming convention:
 
 - terrain archive name: `m{regionX}_{regionY}`;
-- object archive name: `l{regionX}_{regionY}`;
-- object archives may require the four XTEA keys supplied for the region.
+- object/location archive name: `l{regionX}_{regionY}`;
+- location archives may require four XTEA keys for the region.
 
-Dynamic/constructed maps use 8×8 region parts. `RegionManager` selects a source region/plane/chunk and `Map.readRegionPartLandscape(...)` / `Class274` rotate the source coordinates into their destination chunk. The rotation is not a presentation-only transform: the decoded tile data and object placement must use the same rotation semantics.
+Dynamic/constructed maps use **8x8 region parts**. `RegionManager` selects a source region, plane and chunk. `Map`/`TerrainBuilder` rotate source tile coordinates into the destination chunk. Rotation is not a presentation transform: terrain semantics and object placements must use the same source-to-destination rotation rules.
 
-### Coordinate units
+## Coordinate units
 
-The scene uses **512 legacy scene units per tile**. This is visible in several places:
+The scene uses **512 legacy scene units per tile**.
 
-- terrain surfaces are created with a tile scale of `512` through `GraphicsToolkit.cn(...)`;
-- map light positions convert tile coordinates with `<< 9`;
-- terrain code uses 512-sized tile-local geometry coordinates.
+Verified evidence includes:
 
-Region-local tile coordinates therefore map naturally to scene X/Z positions by multiplying by 512. World locations need a local scene origin before this multiplication to avoid enormous render coordinates.
+- terrain surfaces are created with tile scale `512`;
+- map-light positions convert tile coordinates with `<< 9`;
+- terrain shape geometry uses the same 512-unit tile-local coordinate space.
+
+Region-local tile coordinates therefore map naturally to legacy scene X/Z by multiplying by 512. For a web renderer, keep a region-local scene origin so absolute RuneScape world coordinates do not turn into unnecessarily large floating-point render coordinates.
 
 ### Height sign and plane spacing
 
-The legacy client stores visible terrain heights with a convention that frequently becomes more negative as terrain rises. Explicit plane-0 height opcodes are converted to negative values, while an upper plane with no explicit height defaults to the lower plane minus `960` scene units.
+The client height convention frequently becomes more negative as visible terrain rises. Explicit plane-0 heights decode to negative values. If an upper plane ends with an implicit-height opcode, it defaults to the lower plane minus `960` legacy height units.
 
-For a conventional Y-up browser engine, use one conversion boundary such as:
+For a conventional Y-up browser engine, use one conversion owner such as:
 
 ```text
 webX = legacyLocalX
@@ -98,126 +107,225 @@ webY = -legacyHeight
 webZ = legacyLocalY
 ```
 
-Do not scatter sign changes through terrain, model, object and camera code. The transport DTO should preserve legacy semantics; the scene assembler should own the conversion.
+Do not scatter sign changes through terrain, model, object and camera code. Transport/domain data should preserve client/cache semantics and the scene assembler should own the conversion.
 
-Keeping 512 units per tile for the first vertical slice has an important advantage: decoded object-model vertex units align with terrain units without another scale factor. Use a region-local origin (and later origin rebasing if needed) rather than normalizing tiles to 1.0 in multiple places.
+Keeping 512 units per tile in the first implementation also lets decoded object-model vertex units align naturally with terrain units.
 
 ## Terrain decoding
 
-`Class274.readLandscapeData(...)` is the authoritative verified floor-tile decoder for this client revision.
+`TerrainBuilder.readLandscapeData(...)` is the authoritative floor-tile decoder for this client revision. The current decompiled source locator is recorded in the deobfuscation map, but the semantic operation is stable enough to use directly in design documents.
 
 For every tile it consumes opcodes until a terminator is reached:
 
 | Opcode | Meaning | Client behavior |
 | --- | --- | --- |
-| `0` | implicit/default height | Plane 0 receives a generated/default height; higher planes use the previous plane minus `960`. |
-| `1` | explicit height follows | Reads one byte. Value `1` is treated as `0`. Plane 0 derives its height from that byte; higher planes are relative to the plane below. |
-| `2..49` | overlay + tile shape/rotation | Reads overlay ID. Shape/path is `(opcode - 2) / 4`; rotation is `(opcode - 2 + partRotation) & 3`. |
-| `50..81` | terrain flag | Stores `opcode - 49` in `TerrainData.decodedTerrainData`. |
+| `0` | implicit/default height | Plane 0 receives deterministic generated terrain height; higher planes use previous plane minus `960`. |
+| `1` | explicit height follows | Reads one byte. Encoded value `1` is normalized to `0`. Plane 0 derives absolute legacy height; upper planes are relative to the plane below. |
+| `2..49` | overlay + tile shape/rotation | Reads overlay ID. Shape is `(opcode - 2) / 4`; rotation is `(opcode - 2 + partRotation) & 3`. |
+| `50..81` | terrain flag | Stores `opcode - 49` in `TerrainData`. |
 | `82+` | underlay ID | Stores `opcode - 81` as the floor underlay. |
 
-The tile therefore needs more than the current Hagalaz `sbyte TerrainData` flag value. At minimum, visible terrain reconstruction requires:
+A renderable terrain tile therefore needs more than Hagalaz's current terrain-flag byte. At minimum preserve:
 
-- vertex/corner heights;
+- corner/vertex heights;
 - overlay ID;
 - underlay ID;
-- overlay shape/path;
+- overlay shape;
 - overlay rotation;
-- terrain flags.
+- terrain flags;
+- source height encoding when round-trip writing matters.
 
-### Terrain build
+The exact plane-0 implicit-height algorithm is documented separately in [Implicit terrain height generation](terrain-height-generation.md).
 
-After decoding, `Class274.method2692(...)` builds one terrain surface per plane. It calls `GraphicsToolkit.cn(...)` with the height grid and a tile scale of 512, then attaches the returned `Class_xa` to `Class356`.
+## Terrain surface construction
 
-The build phase also resolves `OverlayType` and underlay definitions to colors/textures and creates the shaped tile geometry. The temporary arrays `underlayIds`, `overlayIds`, `overlayPaths`, and `overlayRotations` are released after the surfaces are built. This is an important lifecycle distinction: decoded cache tiles are build input; renderable terrain surfaces are the scene representation.
+After decoding, `TerrainBuilder.buildTerrainSurfaces(...)` creates/fills one `TerrainSurface` per active plane.
 
-### Terrain height queries
+The build phase:
 
-`Class_xa.method6416(x, y, ...)` performs bilinear interpolation between four neighboring height-grid values. Object contouring, camera/interaction placement, and any web picking/ground placement should use equivalent interpolation instead of nearest-tile height when a position can lie inside a tile.
+1. resolves floor underlay/overlay definitions;
+2. computes smoothed underlay color inputs;
+3. applies overlay shape and rotation;
+4. combines the four tile-corner heights with material/shape data;
+5. writes geometry/material data into the renderer-created `TerrainSurface`;
+6. attaches those surfaces to `SceneGraph`.
+
+Decoded `underlayIds`, `overlayIds`, overlay shapes and rotations are build input. The renderer surface is the scene representation after those semantic inputs have been resolved.
+
+### Height queries
+
+`TerrainSurface.getInterpolatedHeight(x, y)` performs bilinear interpolation over the four surrounding height-grid values. Ground contouring, camera/interaction placement and web picking/ground placement should use equivalent interpolation when a position lies inside a tile rather than snapping to one corner.
+
+`TerrainSurface.getTileHeight(tileX, tileY)` performs direct height-grid lookup.
 
 ## Floor materials
 
-### Overlay
+### FloorOverlayDefinition
 
-`OverlayType` decodes, among other fields:
+Verified fields include:
 
 - primary RGB color;
 - optional texture ID;
-- `hideUnderlay`;
+- whether the overlay hides the underlay;
 - secondary RGB color;
-- additional material/order/scale-like flags used by the terrain builder.
+- several additional ordering/scale/material flags used by terrain construction.
 
-### Underlay
+The secondary fields are not all semantically named yet. Hagalaz should expose only fields that are understood and required by a rendering milestone rather than copying opaque integers into a public API.
 
-`Class491` decodes a base RGB value and converts it into HSL-derived values used by the floor renderer. It also contains optional IDs/flags used during terrain construction.
+### FloorUnderlayDefinition
 
-The exact semantic names of every secondary material field remain partially obfuscated. The web foundation should initially expose only fields proven necessary by the first representative-region tests, then extend the rendering projection as fidelity tests reveal a need. Do not copy unexplained `anInt####` fields into a public API.
+This definition is now substantially deobfuscated. Its RGB conversion matches RuneScape's familiar underlay HSL representation:
+
+- `rgbColor`;
+- `hue`;
+- `saturation`;
+- `lightness`;
+- `hueMultiplier`;
+- `texture`;
+- `textureScale`;
+- two additional rendering/occlusion-related flags whose exact final names are not yet frozen.
+
+Its manager is a straightforward cache-backed `FloorUnderlayDefinitionManager`.
+
+## Scene graph
+
+`SceneGraph` owns the runtime spatial/render scene. The important structure is:
+
+```text
+SceneGraph
+  +-- SceneTile[plane][x][y]
+  |     +-- wallA / wallB
+  |     +-- wallDecorationA / wallDecorationB
+  |     +-- floorDecoration
+  |     +-- linked multi-tile scene objects
+  |     +-- optional other single-tile entity
+  |
+  +-- TerrainSurface[plane]
+  +-- SceneLight[] / map flicker effects
+  +-- OcclusionManager
+```
+
+`Map` determines the object scene layer/shape and delegates insertion/removal to the scene graph. Collision updates happen alongside those scene changes but are a separate concern.
+
+The browser should reproduce the *conceptual* separation only. It does not need the client's exact tile-linked-list implementation unless measurement later shows that it solves a real browser bottleneck.
+
+## Scene object categories
+
+Object placement call sites remove much of the ambiguity in the generated entity hierarchy.
+
+### Walls
+
+Wall and corner shape types create `WallEntity` instances. A tile may contain two wall entities for compound/corner wall shapes.
+
+### Wall decorations
+
+All `ShapeType.wallDecoration*` paths create `WallDecorationEntity` instances and add them to the tile's two wall-decoration slots.
+
+### Floor decorations
+
+The floor-decoration layer creates `FloorDecorationEntity` and stores it in the tile's floor-decoration slot. Collision handling also identifies this as the decoration layer.
+
+### Standard / multi-tile objects
+
+Standard objects have explicit start/end tile bounds and are represented by `MultiTileSceneEntity`. Scene tiles reference these through pooled `SceneObjectLink` nodes so an object spanning multiple tiles need not be represented as unrelated duplicates.
+
+Concrete `Sub1`/`Sub2` implementations inside each category appear to represent different model/animation lifecycles, but they should not be prematurely called `Static`/`Dynamic` until those constructors and update paths are fully compared.
 
 ## Object placement and model construction
 
-Map object placement and object render definition are separate pieces of data.
+Map object placement and object render definition are separate data.
 
 A placement identifies:
 
 - object ID;
-- local X/Y/plane;
+- source/effective plane;
+- local X/Y;
 - shape type;
 - rotation.
 
-`ObjectDefinition` supplies the render recipe for that ID. Opcode `1` decodes parallel `nodeTypes` and `modelIDs` arrays: each supported object shape can select one or more model IDs. The client checks availability for the requested shape, decodes those model files, combines multiple `ModelDefinition` instances when needed, and calls `GraphicsToolkit.cb(...)` to create the backend `Model`.
+`ObjectDefinition` supplies the render recipe. Its model-selection opcode decodes parallel shape/node-type and model-ID arrays, allowing each object shape to select one or more models.
 
-The definition can then alter that model through properties including:
+The client then:
+
+1. selects the model set for the placement shape;
+2. verifies model availability;
+3. decodes `ModelDefinition` data;
+4. combines multiple definitions when required;
+5. asks `GraphicsToolkit` to create a renderer `Model`;
+6. applies definition/placement transforms.
+
+Relevant render transforms include:
 
 - inversion/mirroring;
 - recoloring;
 - retexturing;
 - per-axis scale (default 128);
 - X/Y/Z offsets;
-- orientation according to placement rotation and shape;
-- ground contouring modes;
+- orientation based on placement rotation and shape;
+- ground contouring;
 - animation IDs;
 - varbit/config-driven transformations to another object definition;
-- shadow/occlusion-related flags.
+- shadow/occlusion flags.
 
-That means a web viewer cannot render a placed object correctly from `{ id, shape, rotation, x, y, z }` plus gameplay `IObjectType` fields alone.
+A web viewer therefore cannot render objects correctly from only `{ id, shape, rotation, x, y, plane }` plus gameplay `IObjectType` fields.
 
 ## Model definition data
 
-`ModelDefinition` already exposes the core mesh information that a web renderer eventually needs to decode server-side:
+`ModelDefinition` exposes the mesh data needed by a future web model projection:
 
 - `vertexX`, `vertexY`, `vertexZ`, `vertexCount`;
-- three triangle-index arrays (`triangleViewSpaceX/Y/Z`) and `triangleCount`;
+- three triangle vertex-index arrays;
 - per-face colors;
-- alpha and priority data;
-- texture IDs and texture pointers;
-- texture-triangle mapping indices and render types;
-- vertex/triangle skin groups and particle/effect-related metadata.
+- face alpha and priority;
+- texture IDs and texture mapping pointers;
+- texture-triangle mapping indices/render types;
+- optional vertex/triangle skin groups and effect metadata.
 
-For the first web static-object milestone, the rendering API should project only static mesh data needed for geometry/material fidelity. Skinning/animation metadata can be deferred until animated scene entities are in scope.
+The current names `triangleViewSpaceX/Y/Z` are misleading: these arrays are **triangle vertex indices**, not transformed view-space coordinates. The canonical aliases are:
 
-## Scene graph
+```text
+triangleVertexA
+triangleVertexB
+triangleVertexC
+```
 
-`Class356` is the client-side scene owner. It contains:
+The client supports an older model binary layout and a newer `0xFF 0xFF`-terminated layout. In the deobfuscation map their decoder methods are named conceptually `decodeLegacyFormat` and `decodeModernFormat`.
 
-- a 3D array of tile cells (`Class340[][][]`);
-- terrain surfaces (`Class_xa[]`) for the active scene mode;
-- scene entity collections/lists;
-- map flickering lights;
-- occlusion/visibility-related arrays and an occlusion helper (`Class358`);
-- methods for adding/removing wall objects, wall decorations, standard objects and ground decorations.
+For the first static-object web milestone, project only geometry/material data actually required for static fidelity. Skinning/animation metadata can wait until animated scene entities are in scope.
 
-`Map` resolves an object's layer/shape and delegates insertion/removal to this scene graph. Collision changes happen alongside those scene changes but remain a different concern.
+## Occlusion
 
-For the browser this should become a much smaller conceptual structure: loaded render regions/planes with terrain batches plus object instances. Do not reproduce the client's tile-linked-list implementation unless a measured browser bottleneck demonstrates a need.
+`OcclusionManager` is a dedicated subsystem rather than an incidental scene flag.
+
+It owns:
+
+- collections of oriented `Occluder` objects;
+- a per-plane/per-tile visibility cache;
+- visibility tests against terrain heights and scene bounds;
+- an `OcclusionRasterizer` on the relevant hardware path.
+
+Wall/object placement can create or remove occluders based on shape, rotation and object-definition occlusion flags.
+
+This is deliberately **not** part of the first terrain-only web milestone. Correct geometry should come first. Once roof/visibility fidelity becomes a milestone, the client occlusion system provides a useful reference without requiring a direct port.
+
+## Scene lights
+
+Map flickering effects own/use `SceneLight` objects. A scene light has a mutable 3D position plus several light parameters. Scene entities can gather up to four nearby map lights from the scene graph.
+
+The exact names of the remaining integer/scalar light parameters are not frozen yet. The class-level concept and position operations are sufficiently understood; color/radius/intensity names should be based on renderer call sites rather than guessed.
 
 ## Renderer abstraction and backends
 
-`GraphicsToolkit` demonstrates that the cache/scene representation is not tied to OpenGL or Direct3D. Two particularly relevant factory methods are:
+`GraphicsToolkit` demonstrates that cache/scene representation is not tied to OpenGL or Direct3D.
 
-- `cn(...)`: create a terrain surface from dimensions, height data, tile scale, and rendering flags;
-- `cb(ModelDefinition, ...)`: create a backend-specific model from decoded model data.
+Two particularly relevant conceptual operations are:
 
-The concrete client supports OpenGL, Direct3D and software rendering. This validates the separation between scene semantics and renderer, but the browser abstraction should be intentionally tiny. A useful boundary is closer to:
+- `createTerrainSurface(...)`: create the renderer terrain surface from dimensions, height data, tile scale and render flags;
+- `createModel(ModelDefinition, ...)`: create a renderer model from decoded mesh data.
+
+The concrete client has OpenGL, Direct3D and software implementations. Their generated subclass names are not useful architecture and are intentionally omitted here; the deobfuscation map can be used to locate them when backend-specific behavior must be traced.
+
+The web abstraction should be far smaller than `GraphicsToolkit`, for example:
 
 ```text
 SceneRenderer
@@ -228,59 +336,53 @@ SceneRenderer
   dispose()
 ```
 
-Terrain/model builders should produce renderer-neutral scene data or engine-native geometry behind that one adapter. They should not depend on Angular components.
+Terrain/model builders should produce renderer-neutral scene data or engine-native geometry behind this adapter, not depend on Angular components.
 
 ## Camera and visibility notes
 
-Camera code remains spread across partially deobfuscated client classes. One verified convention is that yaw-like values such as `Client.cameraMoveY` are masked with `0x3fff` and use 14-bit sine/cosine lookup tables. The scene also has dedicated occlusion state and separate roof/plane decisions.
+Camera behavior remains spread across partially deobfuscated code. One verified convention is that camera yaw-like angles are 14-bit values (`0..16383`) with 16,384-entry sine/cosine lookup tables.
 
-These details are deliberately **not** required for the first web milestone. A free-orbit perspective camera that can inspect the correctly assembled region is a better validation tool. Matching RuneScape gameplay camera constraints, roof hiding and client occlusion should be separate fidelity work after the geometry pipeline is proven.
+The scene separately handles occlusion and roof/plane visibility.
 
-## What is verified versus still open
+These details are deliberately not required for the first web milestone. A diagnostic free-orbit perspective camera is a better validation tool for correctly assembled terrain. Gameplay camera constraints, roof hiding and client occlusion belong in later fidelity work.
 
-### Verified enough to build against
+## What is verified enough to build against
 
-- 64×64 region and four-plane structure.
-- 8×8 dynamic chunk rotation model.
-- 512 scene units per tile.
-- tile height/overlay/flag/underlay opcode categories.
-- overlay shape and rotation formula.
-- upper-plane default spacing of 960 legacy height units.
-- separate terrain flags versus visible height/material data.
-- object shape-to-model selection.
-- object render transforms and recolor/retexture requirements.
-- model vertex/triangle/texture data shape.
+- 64x64 region and four-plane structure;
+- 8x8 dynamic chunk rotation model;
+- 512 scene units per tile;
+- exact terrain height/overlay/flag/underlay opcode categories;
+- exact overlay shape and rotation formula;
+- exact implicit upper-plane spacing of 960 legacy units;
+- exact deterministic plane-0 implicit-height algorithm;
+- separate terrain flags versus visible height/material data;
+- floor underlay HSL/texture/scale representation;
+- scene graph/tile responsibilities;
+- wall, wall-decoration, floor-decoration and multi-tile object categories;
+- object shape-to-model selection;
+- object render transforms and recolor/retexture requirements;
+- model vertex/triangle/texture data shape;
+- occlusion as a dedicated subsystem;
 - renderer-neutral scene assembly feeding multiple graphics backends.
 
-### Follow-up deobfuscation / fidelity work
+## Remaining deobfuscation / fidelity work
 
-- Human-readable name and every secondary field of `Class491`.
-- Exact semantics of all secondary `OverlayType` material fields.
-- Texture cache format and client texture sampling/material rules.
-- Complete roof hiding and occlusion rules (`Class356`/`Class358`).
-- Atmosphere/HDR/skybox/light blending details.
-- Exact gameplay camera projection/constraints.
-- Animated object/model skinning path.
-- Water/special-material effects and any shader-specific behavior.
+- exact semantics of every secondary floor-overlay material field;
+- final names for two floor-underlay boolean flags;
+- precise identity of the remaining single-tile scene entity base;
+- static/dynamic semantics of concrete scene-entity subclasses;
+- exact purpose of the scene-entity list/entry helpers in rendering versus picking;
+- occluder orientation constants and the remaining scene-tile occlusion shorts;
+- renderer-specific `TerrainSurface` operations other than height lookup/interpolation;
+- scene-light color/radius/intensity fields;
+- complete roof-hiding rules;
+- atmosphere/HDR/skybox/light blending details;
+- exact gameplay camera projection/constraints;
+- animated object/model skinning;
+- water/special-material effects and shader-specific behavior.
 
-These should be investigated only when the corresponding web milestone needs them.
+These gaps should be deobfuscated when their corresponding rendering milestone needs them. They should not force generated class names into new Hagalaz architecture.
 
-## Reference files
+## Source location
 
-Primary client files used for this document:
-
-- `src/main/java/RegionManager.java`
-- `src/main/java/Map.java`
-- `src/main/java/Class274.java`
-- `src/main/java/TerrainData.java`
-- `src/main/java/Class_xa.java`
-- `src/main/java/Class356.java`
-- `src/main/java/ObjectDefinition.java`
-- `src/main/java/ModelDefinition.java`
-- `src/main/java/GraphicsToolkit.java`
-- `src/main/java/GraphicsToolkit_Sub1.java`
-- `src/main/java/GraphicsToolkit_Sub2_Sub1.java`
-- `src/main/java/GraphicsToolkit_Sub2_Sub2.java`
-- `src/main/java/GraphicsToolkit_Sub3.java`
-- `src/main/java/OverlayType.java`
-- `src/main/java/Class491.java`
+For current decompiled filenames/method identifiers and confidence/evidence for each semantic name, use [Rendering deobfuscation map](client-rendering-deobfuscation.md). That is intentionally the only 3D-rendering document that treats generated identifiers as first-class source locators.

--- a/docs/3d-rendering/game-client-renderer.md
+++ b/docs/3d-rendering/game-client-renderer.md
@@ -1,0 +1,286 @@
+# RuneScape game-client 3D renderer reference
+
+This document records the rendering behavior that has been verified in `frankvdb7/Hagalaz.GameClient` and is useful when implementing Hagalaz's web scene viewer. It intentionally translates partially deobfuscated classes into stable concepts instead of treating temporary `Class###` names as architecture.
+
+Snapshot: `Hagalaz.GameClient/main` at `6eac3762cc46cec484131369691b5221fd1277bf`.
+
+## High-level pipeline
+
+The client separates cache/scene semantics from the concrete graphics backend:
+
+```text
+region packet / visible region set
+        |
+        v
+RegionManager
+  - obtains terrain/object archives and XTEA keys
+  - assembles normal or dynamic regions
+  - owns collision data and load state
+        |
+        +----------------------+
+        |                      |
+        v                      v
+Map / Class274            ObjectDefinitionManager
+  - decode floor tiles      - decode object render recipes
+  - compute heights         - choose models by object shape
+  - overlay/underlay        - recolor/retexture/transform
+  - dynamic chunk rotate             |
+        |                             v
+        |                       ModelDefinition
+        |                       vertex/triangle/texture data
+        |                             |
+        v                             v
+GraphicsToolkit.cn(...)        GraphicsToolkit.cb(...)
+  -> terrain surface              -> render Model
+        |                             |
+        +-------------+---------------+
+                      v
+                  Class356
+             tile scene / entities
+                      |
+                      v
+               GraphicsToolkit
+          OpenGL / Direct3D / software
+```
+
+The important architectural lesson is not to port `GraphicsToolkit`. The useful pattern is to keep RuneScape scene assembly independent from the selected renderer.
+
+## Stable concept map
+
+| Client class | Useful interpretation | Verified responsibility |
+| --- | --- | --- |
+| `RegionManager` | Region/scene loader | Resolves visible region IDs and XTEA keys, loads region bytes, handles normal and dynamic region assembly, creates `Map`, owns `CollisionData[]`, and triggers terrain/object construction. |
+| `Map` | Map scene builder | Extends `Class274`, adds object definitions, atmosphere, lights, camera adjustments, object placement/removal, and region-part landscape handling. |
+| `Class274` | Terrain/floor decoder and builder | Decodes tile heights, overlays, underlays, tile shapes/rotations and terrain flags, then builds backend terrain surfaces. |
+| `TerrainData` | Tile flags / effective-plane metadata | Stores decoded terrain flags and resolves bridge/plane behavior. It is not the visible terrain mesh or height map. |
+| `Class_xa` | Terrain surface | Owns a height grid, supports height interpolation, and exposes terrain drawing/build operations implemented per backend. |
+| `Class356` | Scene/tile graph | Owns tile cells, terrain surfaces, scene entities, occlusion-related state and map lights. |
+| `ObjectDefinition` | Object render recipe | Selects model IDs by shape and applies render-time scale, offsets, recolor/retexture, contouring, transforms, animation-related state and visibility properties. |
+| `ModelDefinition` | Decoded mesh source | Contains vertex positions, triangle indices, colors, alpha, texture references/mapping and skin/animation grouping data. |
+| `Model` | Backend render model | Backend-specific renderable produced from a `ModelDefinition`. |
+| `GraphicsToolkit` | Renderer abstraction | Creates terrain surfaces and models, manages transforms/render targets/material-related resources, and exposes drawing operations. |
+| `GraphicsToolkit_Sub1` | OpenGL backend | Uses `jaggl.OpenGL` and native buffers. |
+| `GraphicsToolkit_Sub2_Sub1` | OpenGL backend | OpenGL implementation of the shared `GraphicsToolkit_Sub2` hardware path. |
+| `GraphicsToolkit_Sub2_Sub2` | Direct3D backend | Uses `jagdx` Direct3D device/surface/capability APIs. |
+| `GraphicsToolkit_Sub3` | Software renderer | CPU/software rasterization path with its own buffers and matrices. |
+| `OverlayType` | Floor-overlay material definition | Includes primary/secondary RGB, texture ID, underlay visibility and additional material/blending properties. |
+| `Class491` | Floor-underlay definition | Decodes RGB-derived HSL data and other underlay rendering properties. The class still needs a human-readable deobfuscation name. |
+
+## Region and chunk structure
+
+A normal cache region is 64×64 tiles with four planes. `RegionManager` maintains the surrounding region IDs and separate byte arrays for the region data it needs. The server-side Hagalaz `MapProvider` independently confirms the cache convention:
+
+- terrain archive name: `m{regionX}_{regionY}`;
+- object archive name: `l{regionX}_{regionY}`;
+- object archives may require the four XTEA keys supplied for the region.
+
+Dynamic/constructed maps use 8×8 region parts. `RegionManager` selects a source region/plane/chunk and `Map.readRegionPartLandscape(...)` / `Class274` rotate the source coordinates into their destination chunk. The rotation is not a presentation-only transform: the decoded tile data and object placement must use the same rotation semantics.
+
+### Coordinate units
+
+The scene uses **512 legacy scene units per tile**. This is visible in several places:
+
+- terrain surfaces are created with a tile scale of `512` through `GraphicsToolkit.cn(...)`;
+- map light positions convert tile coordinates with `<< 9`;
+- terrain code uses 512-sized tile-local geometry coordinates.
+
+Region-local tile coordinates therefore map naturally to scene X/Z positions by multiplying by 512. World locations need a local scene origin before this multiplication to avoid enormous render coordinates.
+
+### Height sign and plane spacing
+
+The legacy client stores visible terrain heights with a convention that frequently becomes more negative as terrain rises. Explicit plane-0 height opcodes are converted to negative values, while an upper plane with no explicit height defaults to the lower plane minus `960` scene units.
+
+For a conventional Y-up browser engine, use one conversion boundary such as:
+
+```text
+webX = legacyLocalX
+webY = -legacyHeight
+webZ = legacyLocalY
+```
+
+Do not scatter sign changes through terrain, model, object and camera code. The transport DTO should preserve legacy semantics; the scene assembler should own the conversion.
+
+Keeping 512 units per tile for the first vertical slice has an important advantage: decoded object-model vertex units align with terrain units without another scale factor. Use a region-local origin (and later origin rebasing if needed) rather than normalizing tiles to 1.0 in multiple places.
+
+## Terrain decoding
+
+`Class274.readLandscapeData(...)` is the authoritative verified floor-tile decoder for this client revision.
+
+For every tile it consumes opcodes until a terminator is reached:
+
+| Opcode | Meaning | Client behavior |
+| --- | --- | --- |
+| `0` | implicit/default height | Plane 0 receives a generated/default height; higher planes use the previous plane minus `960`. |
+| `1` | explicit height follows | Reads one byte. Value `1` is treated as `0`. Plane 0 derives its height from that byte; higher planes are relative to the plane below. |
+| `2..49` | overlay + tile shape/rotation | Reads overlay ID. Shape/path is `(opcode - 2) / 4`; rotation is `(opcode - 2 + partRotation) & 3`. |
+| `50..81` | terrain flag | Stores `opcode - 49` in `TerrainData.decodedTerrainData`. |
+| `82+` | underlay ID | Stores `opcode - 81` as the floor underlay. |
+
+The tile therefore needs more than the current Hagalaz `sbyte TerrainData` flag value. At minimum, visible terrain reconstruction requires:
+
+- vertex/corner heights;
+- overlay ID;
+- underlay ID;
+- overlay shape/path;
+- overlay rotation;
+- terrain flags.
+
+### Terrain build
+
+After decoding, `Class274.method2692(...)` builds one terrain surface per plane. It calls `GraphicsToolkit.cn(...)` with the height grid and a tile scale of 512, then attaches the returned `Class_xa` to `Class356`.
+
+The build phase also resolves `OverlayType` and underlay definitions to colors/textures and creates the shaped tile geometry. The temporary arrays `underlayIds`, `overlayIds`, `overlayPaths`, and `overlayRotations` are released after the surfaces are built. This is an important lifecycle distinction: decoded cache tiles are build input; renderable terrain surfaces are the scene representation.
+
+### Terrain height queries
+
+`Class_xa.method6416(x, y, ...)` performs bilinear interpolation between four neighboring height-grid values. Object contouring, camera/interaction placement, and any web picking/ground placement should use equivalent interpolation instead of nearest-tile height when a position can lie inside a tile.
+
+## Floor materials
+
+### Overlay
+
+`OverlayType` decodes, among other fields:
+
+- primary RGB color;
+- optional texture ID;
+- `hideUnderlay`;
+- secondary RGB color;
+- additional material/order/scale-like flags used by the terrain builder.
+
+### Underlay
+
+`Class491` decodes a base RGB value and converts it into HSL-derived values used by the floor renderer. It also contains optional IDs/flags used during terrain construction.
+
+The exact semantic names of every secondary material field remain partially obfuscated. The web foundation should initially expose only fields proven necessary by the first representative-region tests, then extend the rendering projection as fidelity tests reveal a need. Do not copy unexplained `anInt####` fields into a public API.
+
+## Object placement and model construction
+
+Map object placement and object render definition are separate pieces of data.
+
+A placement identifies:
+
+- object ID;
+- local X/Y/plane;
+- shape type;
+- rotation.
+
+`ObjectDefinition` supplies the render recipe for that ID. Opcode `1` decodes parallel `nodeTypes` and `modelIDs` arrays: each supported object shape can select one or more model IDs. The client checks availability for the requested shape, decodes those model files, combines multiple `ModelDefinition` instances when needed, and calls `GraphicsToolkit.cb(...)` to create the backend `Model`.
+
+The definition can then alter that model through properties including:
+
+- inversion/mirroring;
+- recoloring;
+- retexturing;
+- per-axis scale (default 128);
+- X/Y/Z offsets;
+- orientation according to placement rotation and shape;
+- ground contouring modes;
+- animation IDs;
+- varbit/config-driven transformations to another object definition;
+- shadow/occlusion-related flags.
+
+That means a web viewer cannot render a placed object correctly from `{ id, shape, rotation, x, y, z }` plus gameplay `IObjectType` fields alone.
+
+## Model definition data
+
+`ModelDefinition` already exposes the core mesh information that a web renderer eventually needs to decode server-side:
+
+- `vertexX`, `vertexY`, `vertexZ`, `vertexCount`;
+- three triangle-index arrays (`triangleViewSpaceX/Y/Z`) and `triangleCount`;
+- per-face colors;
+- alpha and priority data;
+- texture IDs and texture pointers;
+- texture-triangle mapping indices and render types;
+- vertex/triangle skin groups and particle/effect-related metadata.
+
+For the first web static-object milestone, the rendering API should project only static mesh data needed for geometry/material fidelity. Skinning/animation metadata can be deferred until animated scene entities are in scope.
+
+## Scene graph
+
+`Class356` is the client-side scene owner. It contains:
+
+- a 3D array of tile cells (`Class340[][][]`);
+- terrain surfaces (`Class_xa[]`) for the active scene mode;
+- scene entity collections/lists;
+- map flickering lights;
+- occlusion/visibility-related arrays and an occlusion helper (`Class358`);
+- methods for adding/removing wall objects, wall decorations, standard objects and ground decorations.
+
+`Map` resolves an object's layer/shape and delegates insertion/removal to this scene graph. Collision changes happen alongside those scene changes but remain a different concern.
+
+For the browser this should become a much smaller conceptual structure: loaded render regions/planes with terrain batches plus object instances. Do not reproduce the client's tile-linked-list implementation unless a measured browser bottleneck demonstrates a need.
+
+## Renderer abstraction and backends
+
+`GraphicsToolkit` demonstrates that the cache/scene representation is not tied to OpenGL or Direct3D. Two particularly relevant factory methods are:
+
+- `cn(...)`: create a terrain surface from dimensions, height data, tile scale, and rendering flags;
+- `cb(ModelDefinition, ...)`: create a backend-specific model from decoded model data.
+
+The concrete client supports OpenGL, Direct3D and software rendering. This validates the separation between scene semantics and renderer, but the browser abstraction should be intentionally tiny. A useful boundary is closer to:
+
+```text
+SceneRenderer
+  initialize(canvas)
+  setScene(scene)
+  resize(width, height, devicePixelRatio)
+  render(camera)
+  dispose()
+```
+
+Terrain/model builders should produce renderer-neutral scene data or engine-native geometry behind that one adapter. They should not depend on Angular components.
+
+## Camera and visibility notes
+
+Camera code remains spread across partially deobfuscated client classes. One verified convention is that yaw-like values such as `Client.cameraMoveY` are masked with `0x3fff` and use 14-bit sine/cosine lookup tables. The scene also has dedicated occlusion state and separate roof/plane decisions.
+
+These details are deliberately **not** required for the first web milestone. A free-orbit perspective camera that can inspect the correctly assembled region is a better validation tool. Matching RuneScape gameplay camera constraints, roof hiding and client occlusion should be separate fidelity work after the geometry pipeline is proven.
+
+## What is verified versus still open
+
+### Verified enough to build against
+
+- 64×64 region and four-plane structure.
+- 8×8 dynamic chunk rotation model.
+- 512 scene units per tile.
+- tile height/overlay/flag/underlay opcode categories.
+- overlay shape and rotation formula.
+- upper-plane default spacing of 960 legacy height units.
+- separate terrain flags versus visible height/material data.
+- object shape-to-model selection.
+- object render transforms and recolor/retexture requirements.
+- model vertex/triangle/texture data shape.
+- renderer-neutral scene assembly feeding multiple graphics backends.
+
+### Follow-up deobfuscation / fidelity work
+
+- Human-readable name and every secondary field of `Class491`.
+- Exact semantics of all secondary `OverlayType` material fields.
+- Texture cache format and client texture sampling/material rules.
+- Complete roof hiding and occlusion rules (`Class356`/`Class358`).
+- Atmosphere/HDR/skybox/light blending details.
+- Exact gameplay camera projection/constraints.
+- Animated object/model skinning path.
+- Water/special-material effects and any shader-specific behavior.
+
+These should be investigated only when the corresponding web milestone needs them.
+
+## Reference files
+
+Primary client files used for this document:
+
+- `src/main/java/RegionManager.java`
+- `src/main/java/Map.java`
+- `src/main/java/Class274.java`
+- `src/main/java/TerrainData.java`
+- `src/main/java/Class_xa.java`
+- `src/main/java/Class356.java`
+- `src/main/java/ObjectDefinition.java`
+- `src/main/java/ModelDefinition.java`
+- `src/main/java/GraphicsToolkit.java`
+- `src/main/java/GraphicsToolkit_Sub1.java`
+- `src/main/java/GraphicsToolkit_Sub2_Sub1.java`
+- `src/main/java/GraphicsToolkit_Sub2_Sub2.java`
+- `src/main/java/GraphicsToolkit_Sub3.java`
+- `src/main/java/OverlayType.java`
+- `src/main/java/Class491.java`

--- a/docs/3d-rendering/terrain-height-generation.md
+++ b/docs/3d-rendering/terrain-height-generation.md
@@ -1,0 +1,248 @@
+# Implicit terrain height generation
+
+This document records the exact plane-0 height path used when a terrain tile ends with opcode `0` in `Hagalaz.GameClient` revision `6eac3762cc46cec484131369691b5221fd1277bf`.
+
+Relevant client methods:
+
+- `Class274.readLandscapeData(...)`
+- `Class156.calculateHeight(...)`
+- `TextureLoader.method652(...)`
+- `Class170.method2039(...)`
+- `AbstractQueue_Sub1.method6486(...)`
+- `Class20.method466(...)`
+- `Class257` sine/cosine lookup initialization
+
+The names below are human-readable names for the verified behavior, not claims that the client classes have already been renamed.
+
+## 1. Tile-level rule
+
+For terrain opcode `0`:
+
+```text
+if plane == 0:
+    generated = CalculateBaseHeight(sourceTileX + 932731,
+                                    sourceTileY + 556238)
+    legacyHeight = -(generated * 32)
+else:
+    legacyHeight = heightBelow - 960
+```
+
+The client expression for plane 0 is equivalent to:
+
+```text
+-Class156.calculateHeight(...) * 8 << 2
+```
+
+which is `-generated * 32`.
+
+The inputs passed to `CalculateBaseHeight` must be the same source-map tile coordinates used by the client. For an offline normal-region decoder, derive them from the region's absolute tile origin and validate the convention against a real client/cache fixture before freezing the public contract.
+
+## 2. Base-height function
+
+`Class156.calculateHeight(x, y)` combines three interpolated noise samples:
+
+```text
+sample = InterpolatedNoise(x + 45365, y + 91923, 4) - 128
+       + ((InterpolatedNoise(x + 10294, y + 37821, 2) - 128) >> 1)
+       + ((InterpolatedNoise(x,         y,         1) - 128) >> 2)
+
+height = 35 + truncateTowardZero(0.3 * sample)
+height = clamp(height, 10, 60)
+return height
+```
+
+Because `readLandscapeData` already adds `(932731, 556238)` before this function, the first two calls have those additional offsets as well. Keep the functions separated exactly as the client does; it makes parity testing easier than pre-combining constants.
+
+C# `(int)(0.3 * sample)` has the same truncation-toward-zero behavior needed here.
+
+## 3. Interpolated noise
+
+`TextureLoader.method652(x, y, scale)` performs two-dimensional cosine interpolation over four smoothed lattice values.
+
+For the scales used by terrain (`1`, `2`, `4`), `scale` is a power of two:
+
+```text
+cellX = x / scale
+fracX = x & (scale - 1)
+cellY = y / scale
+fracY = y & (scale - 1)
+
+n00 = SmoothNoise(cellX,     cellY)
+n10 = SmoothNoise(cellX + 1, cellY)
+n01 = SmoothNoise(cellX,     cellY + 1)
+n11 = SmoothNoise(cellX + 1, cellY + 1)
+
+north = CosineInterpolate(n00, n10, fracX, scale)
+south = CosineInterpolate(n01, n11, fracX, scale)
+
+return CosineInterpolate(north, south, fracY, scale)
+```
+
+All world-region coordinates normally used here are non-negative. If a tool ever supports negative source coordinates, preserve Java integer-division/remainder semantics explicitly rather than assuming floor division.
+
+## 4. Smoothed lattice noise
+
+`Class170.method2039(x, y)` smooths the raw deterministic pseudo-random value using corners, cardinal neighbors and center:
+
+```text
+corners = RawNoise(x - 1, y - 1)
+        + RawNoise(x + 1, y - 1)
+        + RawNoise(x - 1, y + 1)
+        + RawNoise(x + 1, y + 1)
+
+sides = RawNoise(x - 1, y)
+      + RawNoise(x + 1, y)
+      + RawNoise(x, y - 1)
+      + RawNoise(x, y + 1)
+
+center = RawNoise(x, y)
+
+return (sides / 8) + (corners / 16) + (center / 4)
+```
+
+Use integer division.
+
+## 5. Raw deterministic noise
+
+`AbstractQueue_Sub1.method6486(x, y)` is:
+
+```text
+n = x + y * 57
+n = (n << 13) ^ n
+v = (1376312589 + (789221 + 15731 * (n * n)) * n) & 0x7fffffff
+return (v >> 19) & 0xff
+```
+
+The client uses Java 32-bit signed integer overflow. A C# implementation must use `unchecked` arithmetic for the multiplications/additions/shifts that can overflow.
+
+For example, conceptually:
+
+```csharp
+private static int RawNoise(int x, int y)
+{
+    unchecked
+    {
+        var n = x + y * 57;
+        n = (n << 13) ^ n;
+        var value = (1376312589 + (789221 + 15731 * (n * n)) * n) & 0x7fffffff;
+        return (value >> 19) & 0xff;
+    }
+}
+```
+
+Keep this implementation pure and deterministic; it is ideal for table-driven tests.
+
+## 6. Cosine interpolation
+
+`Class20.method466(a, b, offset, scale)` calculates an integer interpolation weight from the client cosine table:
+
+```text
+cosIndex = offset * 8192 / scale
+weight = (65536 - cosine[cosIndex]) >> 1
+
+return (((65536 - weight) * a) >> 16)
+     + ((weight * b) >> 16)
+```
+
+The cosine table is `Class257.anIntArray2684`.
+
+## 7. Cosine lookup table
+
+`Class257` creates 16,384 entries:
+
+```text
+angleStep = 0.0003834951969714103  // 2*pi / 16384
+
+for i = 0..16383:
+    sine[i]   = truncate(16384.0 * sin(i * angleStep))
+    cosine[i] = truncate(16384.0 * cos(i * angleStep))
+```
+
+Only the cosine table is needed for implicit terrain height generation.
+
+Generate the table once and share it. Do not call floating-point `Math.Cos` separately for every terrain interpolation; besides needless cost, doing so makes it easier for implementations to drift from the client's integer lookup behavior.
+
+## 8. Complete reference pseudocode
+
+```text
+function DecodeImplicitHeight(plane, sourceX, sourceY, heightBelow):
+    if plane > 0:
+        return heightBelow - 960
+
+    baseHeight = CalculateBaseHeight(sourceX + 932731,
+                                     sourceY + 556238)
+    return -(baseHeight * 32)
+
+function CalculateBaseHeight(x, y):
+    value = InterpolatedNoise(x + 45365, y + 91923, 4) - 128
+    value += (InterpolatedNoise(x + 10294, y + 37821, 2) - 128) >> 1
+    value += (InterpolatedNoise(x, y, 1) - 128) >> 2
+
+    height = 35 + truncateTowardZero(0.3 * value)
+    return clamp(height, 10, 60)
+
+function InterpolatedNoise(x, y, scale):
+    cellX = x / scale
+    fracX = x & (scale - 1)
+    cellY = y / scale
+    fracY = y & (scale - 1)
+
+    n00 = SmoothNoise(cellX,     cellY)
+    n10 = SmoothNoise(cellX + 1, cellY)
+    n01 = SmoothNoise(cellX,     cellY + 1)
+    n11 = SmoothNoise(cellX + 1, cellY + 1)
+
+    a = CosineInterpolate(n00, n10, fracX, scale)
+    b = CosineInterpolate(n01, n11, fracX, scale)
+    return CosineInterpolate(a, b, fracY, scale)
+
+function SmoothNoise(x, y):
+    corners = RawNoise(x-1,y-1) + RawNoise(x+1,y-1)
+            + RawNoise(x-1,y+1) + RawNoise(x+1,y+1)
+    sides = RawNoise(x-1,y) + RawNoise(x+1,y)
+          + RawNoise(x,y-1) + RawNoise(x,y+1)
+    center = RawNoise(x,y)
+    return sides/8 + corners/16 + center/4
+
+function RawNoise(x, y):
+    unchecked int32:
+        n = x + y*57
+        n = (n << 13) xor n
+        v = (1376312589 + (789221 + 15731*(n*n))*n) & 0x7fffffff
+        return (v >> 19) & 0xff
+
+function CosineInterpolate(a, b, offset, scale):
+    index = offset * 8192 / scale
+    weight = (65536 - cosine[index]) >> 1
+    return (((65536-weight)*a) >> 16) + ((weight*b) >> 16)
+```
+
+## 9. Encoder implications
+
+If a decoded tile preserves that its source height encoding was opcode `0`, an unchanged tile can simply re-emit opcode `0`; the writer does not need to reverse the noise function.
+
+For a canonical semantic encoder that decides between implicit and explicit height:
+
+1. Calculate the implicit height using this exact function.
+2. If desired height equals implicit height, write opcode `0`.
+3. Otherwise encode opcode `1` using the explicit 32-unit delta rules from `cache-map-codecs.md`.
+
+This is why region/source coordinates belong in the terrain codec context even if the encoded payload itself contains no region ID.
+
+## 10. Required tests
+
+Do not test only self-consistency. Capture client-parity expected values for fixed source coordinates.
+
+At minimum test:
+
+- `RawNoise` at several positive coordinate pairs including large world coordinates;
+- `SmoothNoise` against fixed expected integers;
+- `CosineInterpolate` at offsets `0`, midpoint and `scale-1` for scales `1`, `2`, `4`;
+- `InterpolatedNoise` for each scale used by `CalculateBaseHeight`;
+- `CalculateBaseHeight` values below/inside/above the clamp range;
+- plane-0 final legacy height equals `-baseHeight * 32`;
+- planes 1..3 implicit height exactly subtract `960` from the previous plane;
+- known real `mX_Y` tiles ending in opcode `0` match the height observed through the client/scene fixture;
+- region-boundary coordinates use the same absolute/source coordinate convention on both sides of the seam.
+
+A test that only compares the C# implementation to another C# copy of these formulas is not sufficient. Keep at least a small table of expected constants captured from the client or independently decoded real cache fixture.

--- a/docs/3d-rendering/terrain-height-generation.md
+++ b/docs/3d-rendering/terrain-height-generation.md
@@ -2,17 +2,7 @@
 
 This document records the exact plane-0 height path used when a terrain tile ends with opcode `0` in `Hagalaz.GameClient` revision `6eac3762cc46cec484131369691b5221fd1277bf`.
 
-Relevant client methods:
-
-- `Class274.readLandscapeData(...)`
-- `Class156.calculateHeight(...)`
-- `TextureLoader.method652(...)`
-- `Class170.method2039(...)`
-- `AbstractQueue_Sub1.method6486(...)`
-- `Class20.method466(...)`
-- `Class257` sine/cosine lookup initialization
-
-The names below are human-readable names for the verified behavior, not claims that the client classes have already been renamed.
+The algorithm is described entirely with semantic helper names. Current decompiled source locators are listed only in the final section and in [Rendering deobfuscation map](client-rendering-deobfuscation.md).
 
 ## 1. Tile-level rule
 
@@ -20,26 +10,20 @@ For terrain opcode `0`:
 
 ```text
 if plane == 0:
-    generated = CalculateBaseHeight(sourceTileX + 932731,
-                                    sourceTileY + 556238)
+    generated = GenerateBaseTerrainHeight(sourceTileX + 932731,
+                                          sourceTileY + 556238)
     legacyHeight = -(generated * 32)
 else:
     legacyHeight = heightBelow - 960
 ```
 
-The client expression for plane 0 is equivalent to:
+The client multiplies the generated plane-0 value by `-32` scene-height units.
 
-```text
--Class156.calculateHeight(...) * 8 << 2
-```
-
-which is `-generated * 32`.
-
-The inputs passed to `CalculateBaseHeight` must be the same source-map tile coordinates used by the client. For an offline normal-region decoder, derive them from the region's absolute tile origin and validate the convention against a real client/cache fixture before freezing the public contract.
+The inputs to `GenerateBaseTerrainHeight` must be the same source-map tile coordinates used by the client. For an offline normal-region decoder, derive them from the region's absolute tile origin and verify that convention against a real cache/client fixture before making it part of a public contract.
 
 ## 2. Base-height function
 
-`Class156.calculateHeight(x, y)` combines three interpolated noise samples:
+`GenerateBaseTerrainHeight(x, y)` combines three interpolated noise samples:
 
 ```text
 sample = InterpolatedNoise(x + 45365, y + 91923, 4) - 128
@@ -51,15 +35,17 @@ height = clamp(height, 10, 60)
 return height
 ```
 
-Because `readLandscapeData` already adds `(932731, 556238)` before this function, the first two calls have those additional offsets as well. Keep the functions separated exactly as the client does; it makes parity testing easier than pre-combining constants.
+Because the terrain decoder already adds `(932731, 556238)` before this function, the first two calls receive those source-coordinate offsets in addition to their own octave offsets.
 
-C# `(int)(0.3 * sample)` has the same truncation-toward-zero behavior needed here.
+Keep the helpers separated as the client does. That makes parity testing easier and prevents accidental pre-combination of constants from changing integer behavior.
+
+C# `(int)(0.3 * sample)` has the required truncation-toward-zero behavior.
 
 ## 3. Interpolated noise
 
-`TextureLoader.method652(x, y, scale)` performs two-dimensional cosine interpolation over four smoothed lattice values.
+`InterpolatedNoise(x, y, scale)` performs two-dimensional cosine interpolation over four smoothed lattice values.
 
-For the scales used by terrain (`1`, `2`, `4`), `scale` is a power of two:
+For the terrain scales (`1`, `2`, `4`), `scale` is a power of two:
 
 ```text
 cellX = x / scale
@@ -67,10 +53,10 @@ fracX = x & (scale - 1)
 cellY = y / scale
 fracY = y & (scale - 1)
 
-n00 = SmoothNoise(cellX,     cellY)
-n10 = SmoothNoise(cellX + 1, cellY)
-n01 = SmoothNoise(cellX,     cellY + 1)
-n11 = SmoothNoise(cellX + 1, cellY + 1)
+n00 = SmoothedNoise(cellX,     cellY)
+n10 = SmoothedNoise(cellX + 1, cellY)
+n01 = SmoothedNoise(cellX,     cellY + 1)
+n11 = SmoothedNoise(cellX + 1, cellY + 1)
 
 north = CosineInterpolate(n00, n10, fracX, scale)
 south = CosineInterpolate(n01, n11, fracX, scale)
@@ -78,24 +64,24 @@ south = CosineInterpolate(n01, n11, fracX, scale)
 return CosineInterpolate(north, south, fracY, scale)
 ```
 
-All world-region coordinates normally used here are non-negative. If a tool ever supports negative source coordinates, preserve Java integer-division/remainder semantics explicitly rather than assuming floor division.
+All normal RuneScape world-region coordinates used here are non-negative. If a future tool supports negative source coordinates, preserve Java integer-division/remainder behavior explicitly rather than assuming mathematical floor division.
 
 ## 4. Smoothed lattice noise
 
-`Class170.method2039(x, y)` smooths the raw deterministic pseudo-random value using corners, cardinal neighbors and center:
+`SmoothedNoise(x, y)` combines deterministic samples from the four corners, four cardinal neighbors and the center:
 
 ```text
-corners = RawNoise(x - 1, y - 1)
-        + RawNoise(x + 1, y - 1)
-        + RawNoise(x - 1, y + 1)
-        + RawNoise(x + 1, y + 1)
+corners = RawTerrainNoise(x - 1, y - 1)
+        + RawTerrainNoise(x + 1, y - 1)
+        + RawTerrainNoise(x - 1, y + 1)
+        + RawTerrainNoise(x + 1, y + 1)
 
-sides = RawNoise(x - 1, y)
-      + RawNoise(x + 1, y)
-      + RawNoise(x, y - 1)
-      + RawNoise(x, y + 1)
+sides = RawTerrainNoise(x - 1, y)
+      + RawTerrainNoise(x + 1, y)
+      + RawTerrainNoise(x, y - 1)
+      + RawTerrainNoise(x, y + 1)
 
-center = RawNoise(x, y)
+center = RawTerrainNoise(x, y)
 
 return (sides / 8) + (corners / 16) + (center / 4)
 ```
@@ -104,7 +90,7 @@ Use integer division.
 
 ## 5. Raw deterministic noise
 
-`AbstractQueue_Sub1.method6486(x, y)` is:
+`RawTerrainNoise(x, y)` is:
 
 ```text
 n = x + y * 57
@@ -113,12 +99,12 @@ v = (1376312589 + (789221 + 15731 * (n * n)) * n) & 0x7fffffff
 return (v >> 19) & 0xff
 ```
 
-The client uses Java 32-bit signed integer overflow. A C# implementation must use `unchecked` arithmetic for the multiplications/additions/shifts that can overflow.
+The client uses Java 32-bit signed integer overflow. A C# implementation must use `unchecked` arithmetic for multiplications, additions and shifts that can overflow.
 
-For example, conceptually:
+Conceptually:
 
 ```csharp
-private static int RawNoise(int x, int y)
+private static int RawTerrainNoise(int x, int y)
 {
     unchecked
     {
@@ -130,37 +116,37 @@ private static int RawNoise(int x, int y)
 }
 ```
 
-Keep this implementation pure and deterministic; it is ideal for table-driven tests.
+Keep this implementation pure and deterministic; it is ideal for table-driven parity tests.
 
 ## 6. Cosine interpolation
 
-`Class20.method466(a, b, offset, scale)` calculates an integer interpolation weight from the client cosine table:
+`CosineInterpolate(a, b, offset, scale)` uses the client's fixed-point cosine lookup table:
 
 ```text
 cosIndex = offset * 8192 / scale
-weight = (65536 - cosine[cosIndex]) >> 1
+weight = (65536 - cosineTable[cosIndex]) >> 1
 
 return (((65536 - weight) * a) >> 16)
      + ((weight * b) >> 16)
 ```
 
-The cosine table is `Class257.anIntArray2684`.
+This is fixed-point interpolation, not a generic floating-point easing function.
 
-## 7. Cosine lookup table
+## 7. Trigonometry lookup tables
 
-`Class257` creates 16,384 entries:
+The client creates 16,384 entries:
 
 ```text
 angleStep = 0.0003834951969714103  // 2*pi / 16384
 
 for i = 0..16383:
-    sine[i]   = truncate(16384.0 * sin(i * angleStep))
-    cosine[i] = truncate(16384.0 * cos(i * angleStep))
+    sineTable[i]   = truncate(16384.0 * sin(i * angleStep))
+    cosineTable[i] = truncate(16384.0 * cos(i * angleStep))
 ```
 
-Only the cosine table is needed for implicit terrain height generation.
+Only the cosine table is required for implicit terrain height generation, but the paired 14-bit sine/cosine convention is used elsewhere in camera/rendering code.
 
-Generate the table once and share it. Do not call floating-point `Math.Cos` separately for every terrain interpolation; besides needless cost, doing so makes it easier for implementations to drift from the client's integer lookup behavior.
+Generate the tables once and share them. Do not call floating-point `Math.Cos` for each terrain interpolation; aside from needless work, doing that makes it easier to drift from the client's integer lookup behavior.
 
 ## 8. Complete reference pseudocode
 
@@ -169,11 +155,11 @@ function DecodeImplicitHeight(plane, sourceX, sourceY, heightBelow):
     if plane > 0:
         return heightBelow - 960
 
-    baseHeight = CalculateBaseHeight(sourceX + 932731,
-                                     sourceY + 556238)
+    baseHeight = GenerateBaseTerrainHeight(sourceX + 932731,
+                                           sourceY + 556238)
     return -(baseHeight * 32)
 
-function CalculateBaseHeight(x, y):
+function GenerateBaseTerrainHeight(x, y):
     value = InterpolatedNoise(x + 45365, y + 91923, 4) - 128
     value += (InterpolatedNoise(x + 10294, y + 37821, 2) - 128) >> 1
     value += (InterpolatedNoise(x, y, 1) - 128) >> 2
@@ -187,24 +173,24 @@ function InterpolatedNoise(x, y, scale):
     cellY = y / scale
     fracY = y & (scale - 1)
 
-    n00 = SmoothNoise(cellX,     cellY)
-    n10 = SmoothNoise(cellX + 1, cellY)
-    n01 = SmoothNoise(cellX,     cellY + 1)
-    n11 = SmoothNoise(cellX + 1, cellY + 1)
+    n00 = SmoothedNoise(cellX,     cellY)
+    n10 = SmoothedNoise(cellX + 1, cellY)
+    n01 = SmoothedNoise(cellX,     cellY + 1)
+    n11 = SmoothedNoise(cellX + 1, cellY + 1)
 
     a = CosineInterpolate(n00, n10, fracX, scale)
     b = CosineInterpolate(n01, n11, fracX, scale)
     return CosineInterpolate(a, b, fracY, scale)
 
-function SmoothNoise(x, y):
-    corners = RawNoise(x-1,y-1) + RawNoise(x+1,y-1)
-            + RawNoise(x-1,y+1) + RawNoise(x+1,y+1)
-    sides = RawNoise(x-1,y) + RawNoise(x+1,y)
-          + RawNoise(x,y-1) + RawNoise(x,y+1)
-    center = RawNoise(x,y)
+function SmoothedNoise(x, y):
+    corners = RawTerrainNoise(x-1,y-1) + RawTerrainNoise(x+1,y-1)
+            + RawTerrainNoise(x-1,y+1) + RawTerrainNoise(x+1,y+1)
+    sides = RawTerrainNoise(x-1,y) + RawTerrainNoise(x+1,y)
+          + RawTerrainNoise(x,y-1) + RawTerrainNoise(x,y+1)
+    center = RawTerrainNoise(x,y)
     return sides/8 + corners/16 + center/4
 
-function RawNoise(x, y):
+function RawTerrainNoise(x, y):
     unchecked int32:
         n = x + y*57
         n = (n << 13) xor n
@@ -213,7 +199,7 @@ function RawNoise(x, y):
 
 function CosineInterpolate(a, b, offset, scale):
     index = offset * 8192 / scale
-    weight = (65536 - cosine[index]) >> 1
+    weight = (65536 - cosineTable[index]) >> 1
     return (((65536-weight)*a) >> 16) + ((weight*b) >> 16)
 ```
 
@@ -227,7 +213,7 @@ For a canonical semantic encoder that decides between implicit and explicit heig
 2. If desired height equals implicit height, write opcode `0`.
 3. Otherwise encode opcode `1` using the explicit 32-unit delta rules from `cache-map-codecs.md`.
 
-This is why region/source coordinates belong in the terrain codec context even if the encoded payload itself contains no region ID.
+This is why region/source coordinates belong in terrain codec context even though the encoded payload itself contains no region ID.
 
 ## 10. Required tests
 
@@ -235,14 +221,32 @@ Do not test only self-consistency. Capture client-parity expected values for fix
 
 At minimum test:
 
-- `RawNoise` at several positive coordinate pairs including large world coordinates;
-- `SmoothNoise` against fixed expected integers;
-- `CosineInterpolate` at offsets `0`, midpoint and `scale-1` for scales `1`, `2`, `4`;
-- `InterpolatedNoise` for each scale used by `CalculateBaseHeight`;
-- `CalculateBaseHeight` values below/inside/above the clamp range;
+- `RawTerrainNoise` at several positive coordinate pairs including large world coordinates;
+- `SmoothedNoise` against fixed expected integers;
+- `CosineInterpolate` at offset `0`, midpoint and `scale-1` for scales `1`, `2`, `4`;
+- `InterpolatedNoise` for every scale used by `GenerateBaseTerrainHeight`;
+- `GenerateBaseTerrainHeight` values below/inside/above the clamp range;
 - plane-0 final legacy height equals `-baseHeight * 32`;
 - planes 1..3 implicit height exactly subtract `960` from the previous plane;
 - known real `mX_Y` tiles ending in opcode `0` match the height observed through the client/scene fixture;
-- region-boundary coordinates use the same absolute/source coordinate convention on both sides of the seam.
+- region-boundary coordinates use the same absolute/source coordinate convention on both sides of a seam.
 
-A test that only compares the C# implementation to another C# copy of these formulas is not sufficient. Keep at least a small table of expected constants captured from the client or independently decoded real cache fixture.
+A test comparing the C# implementation only to a second C# copy of the formulas is insufficient. Keep a small table of expected constants captured from the client or independently decoded real cache fixtures.
+
+## 11. Current source locators
+
+These identifiers are listed solely to find the current decompiled implementation. They are **not** the names to use in new code or architecture.
+
+| Semantic helper | Current GameClient source locator |
+| --- | --- |
+| terrain opcode decoder | `Class274.readLandscapeData(...)` |
+| `GenerateBaseTerrainHeight` | `Class156.calculateHeight(...)` |
+| `InterpolatedNoise` | `TextureLoader.method652(...)` |
+| `SmoothedNoise` | `Class170.method2039(...)` |
+| `RawTerrainNoise` | `AbstractQueue_Sub1.method6486(...)` |
+| `CosineInterpolate` | `Class20.method466(...)` |
+| `sineTable` | `Class257.anIntArray2683` |
+| `cosineTable` | `Class257.anIntArray2684` |
+| 14-bit angle conversion | `Class257.method2541(...)` |
+
+Do not rename the entire miscellaneous containing classes solely because these static helpers are understood. Source-level deobfuscation should rename the methods first unless the rest of the containing class has independently been identified.

--- a/docs/3d-rendering/web-renderer-foundation.md
+++ b/docs/3d-rendering/web-renderer-foundation.md
@@ -1,0 +1,569 @@
+# Web 3D map renderer foundation
+
+This document describes the current Hagalaz web/cache implementation gaps and the target foundation for displaying real RuneScape scenes in `Hagalaz.Web.App`.
+
+Snapshot: `Hagalaz/main` at `ba134cbcd531a6cd3b35c19b20404084e926bbfc` and `Hagalaz.GameClient/main` at `6eac3762cc46cec484131369691b5221fd1277bf`.
+
+## Executive summary
+
+The current blocker is **data fidelity**, not browser drawing capability.
+
+`Hagalaz.Web.App` contains `maplibre-gl`, but `main` has no map route or 3D scene feature and no MapLibre/Three.js/Babylon renderer implementation. More importantly, the cache service currently cannot return enough information to reconstruct a RuneScape scene:
+
+- `MapCodec` discards explicit heights, overlay IDs/shapes/rotations, and underlay IDs while retaining only terrain flags.
+- `MapTypeResponse` does not even return those terrain flags; it returns dimensions and object placements only.
+- `IObjectType` is gameplay-oriented and does not expose shape-to-model IDs or model transforms/material overrides.
+- Hagalaz has no decoded model-geometry API for the web UI.
+- Hagalaz has no floor overlay/underlay rendering-definition projection or texture delivery path.
+
+Building a more advanced Angular canvas before fixing this contract would create placeholders that later need to be replaced.
+
+## Current implementation inventory
+
+### Web UI
+
+`Hagalaz.Web.App/package.json` includes `maplibre-gl`, Turf helpers, protobuf and IndexedDB support. On `main`:
+
+- there is no `map` route in `main-routing.ts`;
+- no Angular map/scene feature directory was found;
+- there is no `maplibre-gl` source usage;
+- there is no Three.js or Babylon dependency/usage;
+- there is no renderer/camera/terrain/model abstraction.
+
+Treat MapLibre as an unused dependency until a separate map-overview feature proves a need for it.
+
+### Cache map decoding
+
+`Hagalaz.Cache/Logic/Codecs/MapCodec.cs` currently models a map for game-world purposes:
+
+```text
+IMapType
+  Id
+  TerrainData: sbyte[4,64,64]   // terrain flags only
+  Objects[]                     // id, shape, rotation, x, y, z
+```
+
+The decoder consumes the real terrain stream but intentionally throws away rendering data:
+
+- opcode `1`: explicit height byte is consumed and discarded;
+- opcodes `2..49`: overlay payload is consumed and discarded;
+- opcodes `50..81`: terrain flag is retained;
+- opcodes `82+`: underlay ID is discarded.
+
+This is sufficient for parts of collision/bridge logic but cannot generate visible terrain.
+
+### Cache service map response
+
+`Hagalaz.Services.Cache/Features/Types/TypeEndpoints.cs` exposes:
+
+- `GET /types/maps/{id}`;
+- `POST /types/maps/{id}/decode` for XTEA-protected data.
+
+The mapped response contains ID, terrain dimensions, object count, and placements. It does **not** serialize `TerrainData`. Even a debug flag renderer cannot be built from the current endpoint without changing the contract.
+
+### Object definitions
+
+`IObjectType` exposes gameplay fields such as name, size, solid/gateway/clipping data, varbit ID and actions. The client renderer needs additional render-definition data:
+
+- model IDs grouped/selected by object shape;
+- recolor/retexture pairs;
+- inversion;
+- scale and offsets;
+- ground-contouring mode;
+- transformation targets;
+- animation metadata;
+- render/occlusion/shadow flags.
+
+Do not put all of this onto `IObjectType`. A rendering projection should be a separate cache-service concern.
+
+### Models and materials
+
+No decoded `ModelDefinition` equivalent or model endpoint was found in Hagalaz. No floor-overlay/underlay rendering types equivalent to the client `OverlayType` / `Class491` path were found either.
+
+That leaves three missing asset families before object/terrain fidelity is possible:
+
+1. floor definitions;
+2. model geometry;
+3. textures/material inputs.
+
+## Target architecture
+
+Use a server-decoded, renderer-neutral scene contract and a small web scene assembly layer.
+
+```text
+RuneScape cache
+    |
+    v
+Hagalaz.Cache codecs/providers
+    |  decode authoritative cache semantics once
+    v
+Render projections in Hagalaz.Services.Cache
+    |
+    +--> region render data
+    +--> object render definitions
+    +--> model meshes
+    +--> floor/material/texture data
+    |
+    v
+Angular render-data service
+    |
+    v
+Scene assembler
+  - region/chunk placement
+  - coordinate conversion
+  - terrain mesh generation
+  - object model selection/transforms
+    |
+    v
+Scene renderer adapter
+    |
+    v
+Dedicated browser 3D engine / WebGL backend
+```
+
+### Ownership boundaries
+
+**Cache layer owns:**
+
+- decoding cache bytes;
+- XTEA-aware archive access;
+- legacy terrain opcode semantics;
+- object definition/model/material decoding.
+
+**Cache service owns:**
+
+- stable HTTP DTOs suitable for rendering;
+- validation and limits;
+- avoiding transport of unexplained cache bytes to the browser.
+
+**Web scene assembler owns:**
+
+- selecting regions requested by the UI;
+- converting legacy coordinates to renderer coordinates exactly once;
+- creating terrain geometry from decoded tiles;
+- selecting object models by placement shape;
+- applying placement rotation + definition transforms;
+- disposing/replacing region resources.
+
+**Renderer adapter owns:**
+
+- canvas/context lifecycle;
+- camera matrices and resize;
+- GPU resources/draw submission;
+- picking hooks when introduced.
+
+**Angular component owns:**
+
+- user controls and presentation state only;
+- it should not decode cache formats or build individual triangles directly.
+
+## Rendering data contracts
+
+The exact DTO names can be refined during implementation, but the data boundaries should look like the following. These are rendering projections, not replacements for existing gameplay types.
+
+### Region render data
+
+```text
+MapRenderRegion
+  regionId
+  planes[4]
+    vertexHeights[65,65] or equivalent corner-height representation
+    tiles[64,64]
+      terrainFlags
+      underlayId
+      overlayId
+      overlayShape
+      overlayRotation
+  objects[]
+    id
+    shape
+    rotation
+    x
+    y
+    plane
+```
+
+Why a 65×65 height grid: a 64×64 tile surface needs the shared corner on the far X/Y edge. If the decoder internally retains 64×64 tile-origin heights, the projection/build step must deterministically derive the border from neighboring region data. Prefer a contract that makes seams explicit rather than guessing in the browser.
+
+### Object render definition
+
+Keep this focused on static object rendering initially:
+
+```text
+ObjectRenderDefinition
+  id
+  modelGroups[]
+    shape
+    modelIds[]
+  inverted
+  recolors[]
+  retextures[]
+  scaleX/Y/Z
+  offsetX/Y/Z
+  groundContourMode + parameters
+  transform metadata when required
+```
+
+Animation can be added later. Shape-to-model selection is mandatory for the first object milestone.
+
+### Model mesh
+
+A first static mesh contract needs enough to recreate the client's `ModelDefinition` geometry without exposing the cache binary format:
+
+```text
+ModelMesh
+  id
+  positions[]
+  triangleIndices[]
+  faceColors[]
+  faceAlpha[]? 
+  textureIds[]?
+  textureMapping data when required
+```
+
+Whether the server returns raw decoded model semantics or a more browser-ready interleaved/indexed mesh should be decided with representative measurements. Start with the smallest lossless projection that permits client-parity geometry/material tests. Do not prematurely bake engine-specific Three.js objects into the API contract.
+
+### Floor/material definitions
+
+Expose proven semantic fields from overlay/underlay decoders, beginning with:
+
+- primary/secondary color;
+- texture ID;
+- whether an overlay hides the underlay;
+- fields required by the terrain-shape/material tests.
+
+Do not expose unnamed client `anInt####` fields merely because they exist. Deobfuscate or demonstrate their effect first.
+
+### Texture delivery
+
+Texture decoding needs its own focused investigation. The browser should receive a normal renderable asset or a documented decoded texture representation. It should not reproduce the proprietary cache texture decoder inside Angular.
+
+## Coordinate system
+
+Use legacy client units inside render DTOs and convert once during scene assembly.
+
+Recommended first implementation:
+
+- 512 units = one tile;
+- scene origin = selected region/chunk origin, not absolute world origin;
+- web X = legacy X;
+- web Z = legacy map Y;
+- web Y = negative legacy height.
+
+This keeps decoded model vertex units aligned with terrain units and prevents subtle scale mismatches. Region-local origins also avoid large floating-point positions.
+
+World-coordinate metadata can remain available separately for labels, links, or selecting neighboring regions.
+
+## Terrain mesh strategy
+
+The first terrain implementation should optimize for correctness and inspectability:
+
+1. build one geometry per loaded region/plane or another coarse region-sized batch;
+2. share tile corner vertices where the material/normal rules allow it;
+3. reproduce overlay tile shape/path and rotation before attempting visual effects;
+4. resolve underlay + overlay colors/textures using decoded definitions;
+5. calculate normals after the correct height surface exists;
+6. avoid one draw object per tile;
+7. verify region seams with adjacent-region fixtures.
+
+Do not begin with GPU instancing, LOD, worker pools, IndexedDB caches, or custom shaders. Add them only after profiling the representative multi-region scene.
+
+## Static object strategy
+
+For each placement:
+
+1. fetch/cache its render definition;
+2. select the model group matching the placement shape;
+3. fetch/cache referenced model meshes;
+4. combine models if the definition specifies multiple model IDs;
+5. apply definition inversion/recolor/retexture/scale/offset rules;
+6. apply shape/orientation rules and placement rotation;
+7. contour to terrain when the definition requires it;
+8. place in region-local scene coordinates.
+
+Reuse immutable decoded mesh data. Engine-level instancing is valid only when two placements genuinely share the same final geometry/material state; do not let instancing erase per-definition transforms or contouring differences.
+
+## Renderer choice
+
+### MapLibre GL JS
+
+**Do not use MapLibre as the core RuneScape 3D renderer.**
+
+MapLibre is designed around geographic maps, Mercator/globe coordinates, map-owned camera/navigation and custom layers inside its rendering lifecycle. A RuneScape scene uses discrete 64×64 regions, four planes, shaped floor tiles, game models and its own world/camera semantics. A custom MapLibre layer would still require all terrain/model/material work while adding coordinate and context constraints.
+
+Keep MapLibre only if Hagalaz later wants a separate world-overview/navigation experience.
+
+### Raw WebGL2
+
+Advantages: complete control and no rendering dependency.
+
+Disadvantages: Hagalaz would own buffer/material/shader/camera/picking/resource-lifecycle infrastructure that does not differentiate the project. This is too much foundation work unless client-parity shader behavior later requires it.
+
+### Three.js
+
+**Recommended default for the first dedicated 3D scene implementation**, after the render-data contract is ready.
+
+Why:
+
+- `BufferGeometry` maps naturally to decoded model/terrain arrays;
+- mature camera, frustum, material, texture, picking and GPU-resource lifecycle support;
+- custom shaders remain available for later client-fidelity work;
+- keeps the project focused on RuneScape cache/scene semantics instead of generic WebGL plumbing.
+
+Per repository guardrails, do not add the dependency in this documentation change. Add it in the implementation OpenSpec/PR that proves the first terrain vertical slice and records the dependency justification.
+
+## Web feature shape
+
+Avoid an interface for every class. A compact feature can start as:
+
+```text
+Hagalaz.Web.App/src/app/main/map/
+  map-page.component.*
+  rendering/
+    scene-renderer.ts          // real external-engine boundary
+    scene-assembler.ts         // RuneScape -> renderer coordinates/resources
+    terrain-mesh-builder.ts
+    object-mesh-builder.ts
+  data/
+    map-render-data.service.ts // HTTP/DTO boundary
+  model/
+    render-scene.models.ts
+```
+
+This is a target shape, not a requirement to create empty files. Only create a type/service when the first vertical slice uses it.
+
+## Loading and lifecycle
+
+Start with one explicitly selected region. Then add neighboring-region streaming.
+
+When streaming is introduced:
+
+- use Angular request cancellation/abort semantics when selection changes;
+- deduplicate model/definition/material requests in the data layer;
+- release engine resources when a region leaves the active set;
+- keep one owner for each cache/lifecycle responsibility;
+- do not add a second IndexedDB cache merely because `idb` is already installed. Add persistent browser caching only after measuring network/decode costs and defining invalidation/versioning.
+
+## Camera and interaction
+
+The first camera should be a diagnostic orbit/pan/zoom camera. Its goal is to verify scene fidelity, not mimic gameplay.
+
+Initial controls should support:
+
+- orbit around a selected point;
+- pan;
+- zoom/dolly;
+- reset/focus region;
+- plane visibility toggles.
+
+Later milestones can add:
+
+- tile/object picking;
+- coordinate display;
+- object definition/model inspection;
+- RuneScape-like camera constraints;
+- roof/occlusion behavior.
+
+For a developer/admin map viewer, inspection tools are more valuable initially than matching the in-game camera.
+
+## Phased implementation
+
+### Phase 0 — contract/decoder foundation
+
+Goal: make the server capable of representing visible map data without changing gameplay contracts.
+
+- Add render-focused terrain decoding that preserves heights, overlays, underlays, shapes, rotations and flags.
+- Add floor overlay/underlay definition decoding required by representative regions.
+- Add object render-definition projection with model IDs by shape and static transforms.
+- Add model-definition decoding/projection for static meshes.
+- Define bounded cache-service endpoints/DTOs.
+- Add client-parity decoder tests.
+
+Exit criterion: a test can request one known region and prove all data needed for terrain + selected static objects is present.
+
+### Phase 1 — one real terrain region in the browser
+
+Goal: display one 64×64 region from actual cache data.
+
+- Add dedicated renderer dependency/adapter.
+- Build all four planes from real heights.
+- Render underlay/overlay shapes with correct rotations and base colors.
+- Add orbit camera and plane toggles.
+- Verify seams and known tile heights against fixtures/client observations.
+
+Exit criterion: no generated placeholder height map or guessed floor colors are required for the representative region.
+
+### Phase 2 — static objects
+
+Goal: render the real static object scene.
+
+- Decode/fetch object render definitions and model meshes.
+- Select models by shape.
+- Apply rotation, scale, offsets, recolor/retexture and required contouring.
+- Add object picking/inspection.
+
+Exit criterion: representative walls, decorations and standard objects appear in the right tiles/orientation with recognizable client-parity geometry.
+
+### Phase 3 — multi-region scene
+
+Goal: make the viewer useful beyond a single fixture.
+
+- Load adjacent regions around a selected coordinate.
+- Handle XTEA-protected regions through the server contract.
+- Guarantee terrain seams and resource cleanup.
+- Support dynamic 8×8 chunk assembly when required by the viewer use case.
+- Profile and optimize batching/model reuse based on measurements.
+
+### Phase 4 — visual fidelity
+
+Only after geometry is correct:
+
+- decoded textures and texture mapping;
+- improved material rules;
+- lighting/shadows;
+- atmosphere/skybox/fog;
+- roofs/occlusion;
+- water/special effects.
+
+### Phase 5 — animation/dynamic scene data
+
+Optional, depending on viewer goals:
+
+- transformed object definitions;
+- object animations/skinning;
+- dynamic world objects/NPCs/players;
+- live GameWorld overlays.
+
+Do not make Phase 5 a prerequisite for a useful static world viewer.
+
+## Test strategy
+
+### Decoder parity tests
+
+Create small deterministic fixtures from representative cache regions/models and assert the semantics verified in `Hagalaz.GameClient`:
+
+- opcode 0/1 heights;
+- upper-plane `-960` default spacing;
+- overlay ID/path/rotation;
+- terrain flags;
+- underlay IDs;
+- bridge plane adjustment;
+- object shape/rotation/location;
+- dynamic 8×8 chunk rotation.
+
+Prefer targeted byte fixtures for opcode tests plus at least one real region integration fixture.
+
+### Object/model tests
+
+- shape selects the expected model group;
+- multi-model definitions are combined deterministically;
+- scale/offset/rotation conversions are exact;
+- recolor/retexture mappings survive the API projection;
+- model vertex/triangle counts and selected known bounds match a decoded fixture.
+
+### API contract tests
+
+- invalid region/model IDs are bounded and handled consistently;
+- XTEA endpoint requires exactly four keys where applicable;
+- responses do not leak raw unexplained cache streams;
+- response sizes are bounded for single-resource requests.
+
+### Web geometry tests
+
+Pure TypeScript tests should cover:
+
+- coordinate conversion;
+- one flat tile and one sloped tile;
+- each overlay shape/rotation used by fixtures;
+- neighboring-region seam coordinates;
+- object placement rotation;
+- plane visibility selection.
+
+These do not require a browser GPU.
+
+### Visual regression
+
+Add screenshot/reference-image testing only once the renderer can deterministically render a representative region. Keep numeric decoder/geometry tests as the primary correctness signal; screenshots are a complementary fidelity signal.
+
+## Performance guardrails
+
+Do not optimize from assumptions. Once Phase 3 exists, measure:
+
+- API payload sizes;
+- decode/projection time;
+- scene assembly time;
+- GPU geometry/material counts;
+- draw calls;
+- frame time while orbiting representative dense regions;
+- memory before/after unloading regions.
+
+Likely optimizations, only after measurement, include:
+
+- region-level terrain batching;
+- immutable model mesh reuse;
+- material grouping;
+- selective instancing;
+- background geometry assembly in a worker;
+- compressed/binary transport for large mesh data;
+- browser persistent caching with explicit cache-version invalidation.
+
+## Risks and controls
+
+| Risk | Control |
+| --- | --- |
+| Browser reimplements cache semantics and diverges from server/client | Decode once in Hagalaz.Cache and expose semantic DTOs. |
+| Gameplay models become polluted by graphics concerns | Add render projections instead of expanding `IMapType`/`IObjectType` indiscriminately. |
+| Placeholder renderer looks good but cannot reach client fidelity | Require real height/floor data in Phase 1 exit criteria. |
+| Object positions work but models are wrong | Treat shape-to-model selection and transforms as first-class contract data. |
+| Region seams crack | Represent/derive border heights explicitly and test adjacent fixtures. |
+| Huge absolute world coordinates cause precision issues | Use region-local scene origins. |
+| New 3D dependency becomes architecture | Hide only the true engine boundary; keep scene semantics in plain project code. |
+| Optimization creates duplicate caches/lifecycles | Profile first and keep one owner per resource cache. |
+| Obfuscated client fields become accidental API | Expose only deobfuscated/proven semantics. |
+
+## Concrete missing-work checklist
+
+### Backend/cache
+
+- [ ] Preserve full visible floor-tile decode data instead of terrain flags only.
+- [ ] Preserve/derive border heights needed for seamless 64×64 terrain meshes.
+- [ ] Decode floor overlay definitions.
+- [ ] Decode floor underlay definitions.
+- [ ] Investigate/decode texture assets required by the chosen representative region.
+- [ ] Decode static `ModelDefinition` geometry.
+- [ ] Extend object decoding with a separate render projection containing model groups and transforms.
+- [ ] Expose bounded render-focused endpoints/DTOs from `Hagalaz.Services.Cache`.
+- [ ] Add client-parity tests before frontend consumption.
+
+### Web
+
+- [ ] Add a map route/page only when the first real-region API is available.
+- [ ] Add a dedicated 3D renderer adapter; Three.js is the recommended default decision.
+- [ ] Add a single coordinate-conversion owner.
+- [ ] Build region/plane terrain meshes from real tile data.
+- [ ] Implement floor shapes/rotations/material lookup.
+- [ ] Add diagnostic camera and plane controls.
+- [ ] Add static object mesh selection/transforms.
+- [ ] Add multi-region loading only after the single-region path is correct.
+- [ ] Add performance optimizations based on measured bottlenecks.
+
+### Documentation/deobfuscation
+
+- [ ] Keep `game-client-renderer.md` updated as client classes are renamed/deobfuscated.
+- [ ] Record texture/material findings before exposing new unexplained fields.
+- [ ] Document roof/occlusion/camera behavior when those fidelity phases begin.
+
+## Definition of a solid foundation
+
+The foundation is complete when a developer can answer these questions without reverse-engineering the entire client again:
+
+1. Where do region tiles, objects, materials and models come from?
+2. Which server type owns decoding each cache format?
+3. What exact terrain opcode semantics must be preserved?
+4. How are object shape and rotation used to choose/render a model?
+5. What are the coordinate and unit conventions?
+6. Which fields are verified and which are still partially obfuscated?
+7. What is the renderer boundary in the Angular app?
+8. What is the next smallest client-parity milestone and how is it tested?
+
+The accompanying game-client reference and OpenSpec change are intended to keep those answers stable and discoverable.

--- a/openspec/changes/establish-web-3d-rendering-foundation/design.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/design.md
@@ -1,0 +1,181 @@
+## Context
+
+The current Hagalaz cache map path was built for GameWorld semantics, not rendering. `MapCodec` consumes map terrain bytes but preserves only terrain flags, while map object placement is reduced to ID/shape/rotation/local coordinates. `TypeEndpoints.MapMap(...)` further reduces the HTTP response to dimensions and object placements.
+
+The game client uses a richer two-stage design. `RegionManager` loads/assembles regions, `Map`/`Class274` decode the full tile representation and construct terrain surfaces, `ObjectDefinition` selects and transforms `ModelDefinition` data, `Class356` owns the scene, and `GraphicsToolkit` hides OpenGL/Direct3D/software backends.
+
+The target should preserve that separation of concerns without reproducing the original client's complexity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish one authoritative server-side decode of cache semantics required for rendering.
+- Keep gameplay types focused while exposing separate rendering projections.
+- Make the first useful web milestone a real, inspectable cache region rather than a visual mock.
+- Keep RuneScape scene assembly independent from the selected browser graphics engine.
+- Preserve the verified 64×64 region, four-plane, 8×8 chunk, 512-unit tile and terrain-opcode semantics.
+- Provide deterministic parity tests against documented client behavior.
+
+**Non-Goals:**
+
+- Port client renderer internals or obfuscated data structures directly.
+- Implement live game rendering, animation, atmosphere, occlusion or gameplay camera behavior in the initial milestone.
+- Add speculative caching/performance infrastructure.
+
+## Decisions
+
+### Decode render semantics on the server
+
+Hagalaz.Cache remains the owner of RuneScape cache-format knowledge. The web app consumes semantic render data through `Hagalaz.Services.Cache` rather than raw cache containers.
+
+This prevents two independently evolving decoders and lets tests compare server decode behavior directly with `Hagalaz.GameClient` semantics.
+
+### Add render projections instead of expanding gameplay contracts
+
+`IMapType` and `IObjectType` serve existing gameplay/cache consumers and intentionally omit most graphics data. Rendering needs separate projections for region tiles, object render definitions, model meshes and floor/material definitions.
+
+The implementation SHOULD reuse existing cache providers and decoded values where they are sufficient. It MUST NOT create a parallel cache-access mechanism merely to support rendering.
+
+### Preserve full terrain input before building meshes
+
+The render path must retain:
+
+- height data;
+- terrain flags;
+- overlay ID;
+- underlay ID;
+- overlay shape/path;
+- overlay rotation.
+
+A 64×64 region mesh also needs the far-edge corner heights. The server projection should make border/seam behavior deterministic, preferably with a 65×65 vertex-height representation or an equivalently explicit neighboring-border contract.
+
+### Use legacy units at the transport boundary
+
+Rendering DTOs keep cache/client units. One web scene assembler converts to browser-engine axes and establishes a region-local origin.
+
+The first implementation keeps 512 scene units per tile so model vertices and terrain use the same scale. For a conventional Y-up engine, legacy map Y becomes web Z and legacy height is negated into web Y.
+
+This conversion MUST have a single owner.
+
+### Build one real region before streaming
+
+The first vertical slice loads one explicitly selected 64×64 region, constructs real four-plane terrain, applies overlay/underlay shape/rotation/color data, and provides diagnostic orbit/plane controls.
+
+Multi-region streaming, dynamic maps and persistent browser caching are deferred until this path is correct and measurable.
+
+### Static object rendering is the second vertical slice
+
+A placement is not enough to render an object. The render definition must select model IDs for the placement shape and preserve the static transforms/material substitutions needed by the client.
+
+Static model decoding comes before animation. Animation/skinning fields should not inflate the first mesh API unless a representative static object genuinely requires them.
+
+### Recommend Three.js for the dedicated scene renderer
+
+MapLibre remains inappropriate as the core scene renderer because its geographic coordinate/camera lifecycle does not match RuneScape regions, planes, shaped floors and game models; a custom layer would still require the full scene pipeline.
+
+Raw WebGL2 would force Hagalaz to own generic camera/buffer/material/picking/resource infrastructure.
+
+Three.js is the recommended first implementation because its `BufferGeometry`, camera, texture, picking and resource abstractions fit the decoded data while allowing custom shaders later. This design does not add the dependency. The implementation PR must justify and add it when the first terrain slice uses it.
+
+### Keep the web renderer boundary small
+
+Do not port `GraphicsToolkit`. The web renderer adapter should own external-engine lifecycle only: initialization, scene attachment/update, camera rendering, resize and disposal.
+
+Terrain/object builders and coordinate conversion remain project code and should be testable without a GPU or Angular component.
+
+### Use correctness tests before visual snapshots
+
+Client-parity decoder fixtures and pure geometry tests are the primary correctness signal. Screenshot regression is added only after deterministic rendering exists and should complement, not replace, numeric assertions.
+
+## Detailed data flow
+
+```text
+Cache archives
+  | mX_Y terrain; lX_Y objects; model/config/texture archives
+  v
+Hagalaz.Cache
+  | decode/cache-format semantics
+  +-- map render region projection
+  +-- floor definitions
+  +-- object render definitions
+  +-- model mesh projection
+  +-- decoded textures/material inputs
+  v
+Hagalaz.Services.Cache
+  | bounded HTTP DTOs
+  v
+MapRenderDataService (Angular)
+  | request/dedup/cancellation ownership
+  v
+SceneAssembler
+  | region-local origin + one coordinate conversion
+  | terrain mesh builder
+  | object mesh builder
+  v
+SceneRenderer adapter
+  v
+Three.js (recommended) / selected dedicated browser renderer
+```
+
+## Representative-region strategy
+
+Select at least one region that contains:
+
+- non-flat terrain;
+- multiple overlay shapes/rotations;
+- textured and untextured floors if texture decoding is ready;
+- walls, wall decorations, standard objects and floor decorations;
+- multi-tile and contoured objects where practical.
+
+Use small hand-built byte fixtures for exhaustive opcode tests and the representative real region for integration/fidelity tests. A second adjacent region should be introduced before Phase 3 to prove border-height seams.
+
+## API shape constraints
+
+Rendering endpoints MUST be bounded by an explicit resource such as one region, one object definition, one model or one material/texture. Do not expose an unbounded "all maps/models" operation.
+
+Large mesh payloads may eventually justify binary transport or compression, but the first contract should optimize for semantic clarity and testability. Change transport representation only after recording payload/latency measurements.
+
+## Failure and lifecycle behavior
+
+- Invalid/missing cache resources should produce the cache service's normal mapped error behavior rather than partial invented geometry.
+- XTEA-protected region object data remains server-decoded; the browser supplies/obtains only the API inputs required by the chosen viewer workflow.
+- Switching region selection should cancel stale web requests when possible.
+- Renderer resources created for an unloaded region must be disposed by one scene/resource owner.
+- Model/material reuse should initially be in-memory within that owner. Persistent browser caching is a separate measured optimization.
+
+## Risks / Trade-offs
+
+- **Risk: render DTOs duplicate gameplay data.** → Accept small semantic duplication at the API boundary to keep gameplay contracts clean; share underlying decoders/providers.
+- **Risk: a 65×65 height contract needs neighboring data.** → Define border derivation explicitly and cover adjacent-region seams; never silently repeat the last row/column in the browser.
+- **Risk: texture behavior is more complex than color-only terrain.** → Ship a color-correct first terrain slice, then add decoded textures as a fidelity increment if representative acceptance criteria permit it.
+- **Risk: model projection becomes engine-specific.** → Keep cache/model semantics renderer-neutral and translate to `BufferGeometry` in the web builder.
+- **Risk: partially deobfuscated fields leak into stable DTOs.** → Expose only named/proven semantics; document open fields and investigate them when a failing fidelity case requires them.
+- **Risk: scene abstraction grows into a second game client.** → Optimize for an inspection viewer: coarse region batches and static scene data first, live/dynamic behavior only when explicitly required.
+
+## Migration Plan
+
+There is no production migration for the documentation foundation.
+
+Implementation should be additive:
+
+1. add render-focused decoding/projections and tests without changing current gameplay consumers;
+2. expose bounded cache-service endpoints;
+3. add the one-region web feature behind its new route;
+4. add static objects;
+5. expand to neighboring regions and fidelity features.
+
+Existing `/types/maps/{id}` consumers should not be broken merely to serve the viewer. A new render-focused endpoint or backward-compatible response evolution should be chosen based on existing API consumers during implementation.
+
+Rollback each phase by removing its additive endpoint/feature while leaving existing gameplay cache types unchanged.
+
+## Open Questions
+
+These are intentionally deferred until the milestone that needs them:
+
+- Which exact cache archive/provider should own overlay and underlay definitions in Hagalaz?
+- What decoded texture representation is smallest while preserving the client material behavior needed by representative regions?
+- Should model mesh transport remain JSON for the first slice or use a compact binary format after measurements?
+- Which `Class491` and secondary `OverlayType` fields need human-readable names for visible client parity?
+- Is dynamic 8×8 map assembly required by the initial web viewer product use case, or only by a later developer inspection mode?
+- Which roof/occlusion rules should the viewer expose versus intentionally allowing users to inspect every plane?

--- a/openspec/changes/establish-web-3d-rendering-foundation/design.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/design.md
@@ -1,45 +1,39 @@
 ## Context
 
-The current Hagalaz cache map path was built for GameWorld semantics, not rendering. `MapCodec` consumes map terrain bytes but preserves only terrain flags, while map object placement is reduced to ID/shape/rotation/local coordinates. `TypeEndpoints.MapMap(...)` further reduces the HTTP response to dimensions and object placements.
+The current Hagalaz cache map path was built for GameWorld semantics, not rendering. `MapCodec` consumes map terrain bytes but preserves only terrain flags, while `TypeEndpoints.MapMap(...)` reduces the HTTP map response further to dimensions and object placements.
 
-The game client uses a richer two-stage design. `RegionManager` loads/assembles regions, `Map`/`Class274` decode the full tile representation and construct terrain surfaces, `ObjectDefinition` selects and transforms `ModelDefinition` data, `Class356` owns the scene, and `GraphicsToolkit` hides OpenGL/Direct3D/software backends.
+The verified game client has a richer two-stage terrain design. `RegionManager` loads/assembles regions, `Map`/`Class274` decode full tile data and construct terrain surfaces, and `GraphicsToolkit` hides OpenGL/Direct3D/software backends. Object/model rendering exists beyond that path, but it is deliberately outside this change.
 
-The target should preserve that separation of concerns without reproducing the original client's complexity.
+The concrete goal is one authoritative 64×64 four-plane terrain region rendered in the browser from server-decoded cache semantics.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Establish one authoritative server-side decode of cache semantics required for rendering.
-- Keep gameplay types focused while exposing separate rendering projections.
-- Make the first useful web milestone a real, inspectable cache region rather than a visual mock.
-- Keep RuneScape scene assembly independent from the selected browser graphics engine.
-- Preserve the verified 64×64 region, four-plane, 8×8 chunk, 512-unit tile and terrain-opcode semantics.
-- Provide deterministic parity tests against documented client behavior.
+- Preserve the terrain data currently discarded by Hagalaz's map decoder without replacing the existing cache ownership path.
+- Expose a bounded render-region projection separate from gameplay-oriented map contracts.
+- Render one representative real region in the web UI through one coordinate-conversion owner and one small renderer boundary.
+- Prove behavior with client-parity decoder/API/geometry tests.
 
 **Non-Goals:**
 
-- Port client renderer internals or obfuscated data structures directly.
-- Implement live game rendering, animation, atmosphere, occlusion or gameplay camera behavior in the initial milestone.
-- Add speculative caching/performance infrastructure.
+- Static objects/models, model APIs, multi-region streaming, dynamic-map rendering, decoded textures, animation, atmosphere, occlusion, roof logic or live entities.
+- New distributed state, queues, retry/reconciliation mechanisms or persistent browser caching.
+- A port of the client's renderer/toolkit abstractions.
 
 ## Decisions
 
-### Decode render semantics on the server
+### Reuse the existing cache-access owner
 
-Hagalaz.Cache remains the owner of RuneScape cache-format knowledge. The web app consumes semantic render data through `Hagalaz.Services.Cache` rather than raw cache containers.
+`ICacheAPI`/`MapProvider` and their current container/XTEA mechanisms remain authoritative for obtaining map bytes. Render decoding is an additional semantic projection over that same source; it is not a second cache reader.
 
-This prevents two independently evolving decoders and lets tests compare server decode behavior directly with `Hagalaz.GameClient` semantics.
+There is no new retry or reconciliation owner in this change. Region rendering is request/response data access; existing cache-service error handling remains responsible for failed reads.
 
-### Add render projections instead of expanding gameplay contracts
+### Add a render terrain projection instead of changing gameplay meaning
 
-`IMapType` and `IObjectType` serve existing gameplay/cache consumers and intentionally omit most graphics data. Rendering needs separate projections for region tiles, object render definitions, model meshes and floor/material definitions.
+`IMapType.TerrainData` currently means tile flags to existing consumers. Reinterpreting it as a full graphics tile would silently broaden a gameplay contract.
 
-The implementation SHOULD reuse existing cache providers and decoded values where they are sufficient. It MUST NOT create a parallel cache-access mechanism merely to support rendering.
-
-### Preserve full terrain input before building meshes
-
-The render path must retain:
+Introduce a render-focused representation that can preserve, per plane/tile:
 
 - height data;
 - terrain flags;
@@ -48,134 +42,142 @@ The render path must retain:
 - overlay shape/path;
 - overlay rotation.
 
-A 64×64 region mesh also needs the far-edge corner heights. The server projection should make border/seam behavior deterministic, preferably with a 65×65 vertex-height representation or an equivalently explicit neighboring-border contract.
+Reuse existing decoded flag/object logic where doing so keeps one authoritative implementation. Do not maintain two copies of the same opcode formula.
 
-### Use legacy units at the transport boundary
+### Make region borders explicit
 
-Rendering DTOs keep cache/client units. One web scene assembler converts to browser-engine axes and establishes a region-local origin.
+A 64×64 terrain surface needs the far X/Y corner heights as well as tile-origin heights. The render projection/build process must define border derivation deterministically. Prefer an explicit 65×65 vertex-height representation when constructing the API result; if the cache decoder retains a different internal representation, the projection owns the conversion.
 
-The first implementation keeps 512 scene units per tile so model vertices and terrain use the same scale. For a conventional Y-up engine, legacy map Y becomes web Z and legacy height is negated into web Y.
+The browser must not invent a border by repeating the last row/column.
 
-This conversion MUST have a single owner.
+### Preserve legacy units through the service boundary
 
-### Build one real region before streaming
+Transport/domain data stays in legacy client units. The web scene assembler owns the only renderer-coordinate conversion.
 
-The first vertical slice loads one explicitly selected 64×64 region, constructs real four-plane terrain, applies overlay/underlay shape/rotation/color data, and provides diagnostic orbit/plane controls.
+For the first vertical slice:
 
-Multi-region streaming, dynamic maps and persistent browser caching are deferred until this path is correct and measurable.
+- 512 legacy units = one tile;
+- the selected region provides the local scene origin;
+- web X maps from legacy X;
+- web Z maps from legacy map Y;
+- web Y negates legacy height for a conventional Y-up renderer.
 
-### Static object rendering is the second vertical slice
+Keeping the 512-unit scale also prepares the scene for future client model geometry without introducing another scale convention now.
 
-A placement is not enough to render an object. The render definition must select model IDs for the placement shape and preserve the static transforms/material substitutions needed by the client.
+### Base-color terrain before decoded textures
 
-Static model decoding comes before animation. Animation/skinning fields should not inflate the first mesh API unless a representative static object genuinely requires them.
+The first representative region proves height, floor ID, floor shape and rotation correctness. Overlay/underlay definitions expose the semantic color fields required to reproduce recognizable base floor coloration.
 
-### Recommend Three.js for the dedicated scene renderer
+Texture decoding/material shaders are a separate fidelity change. Texture IDs may be retained if useful for future compatibility, but missing decoded textures do not expand this change.
 
-MapLibre remains inappropriate as the core scene renderer because its geographic coordinate/camera lifecycle does not match RuneScape regions, planes, shaped floors and game models; a custom layer would still require the full scene pipeline.
+### Recommend Three.js, reject MapLibre/raw WebGL for this slice
 
-Raw WebGL2 would force Hagalaz to own generic camera/buffer/material/picking/resource infrastructure.
+**MapLibre custom layer rejected:** it adds geographic camera/coordinate ownership without solving RuneScape terrain semantics and would couple the core viewer to the wrong scene model.
 
-Three.js is the recommended first implementation because its `BufferGeometry`, camera, texture, picking and resource abstractions fit the decoded data while allowing custom shaders later. This design does not add the dependency. The implementation PR must justify and add it when the first terrain slice uses it.
+**Raw WebGL2 rejected:** it would make Hagalaz own generic buffer, camera, material, picking and lifecycle plumbing before any project-specific value is proven.
 
-### Keep the web renderer boundary small
+**Three.js recommended:** `BufferGeometry` and its camera/resource primitives map cleanly to the region geometry while leaving custom shaders possible later.
 
-Do not port `GraphicsToolkit`. The web renderer adapter should own external-engine lifecycle only: initialization, scene attachment/update, camera rendering, resize and disposal.
+No dependency is added by this planning/documentation commit. The implementation task that first renders terrain must add and justify the package under repository dependency rules.
 
-Terrain/object builders and coordinate conversion remain project code and should be testable without a GPU or Angular component.
+### Keep the web renderer boundary intentionally small
 
-### Use correctness tests before visual snapshots
+Do not mirror `GraphicsToolkit`. The external-engine boundary should cover only context/scene lifecycle such as initialize, resize, render and dispose. RuneScape coordinate conversion and terrain geometry generation remain plain project code and are testable without a GPU.
 
-Client-parity decoder fixtures and pure geometry tests are the primary correctness signal. Screenshot regression is added only after deterministic rendering exists and should complement, not replace, numeric assertions.
+Angular page components own user-facing controls, not cache decoding or triangle generation.
 
-## Detailed data flow
+### Use numeric correctness tests before screenshots
+
+The cache decoder is tested with small deterministic byte fixtures plus one representative real-region integration fixture. Pure TypeScript tests verify coordinate conversion and terrain geometry. Screenshot comparison can be added after deterministic rendering exists, but it is not the primary proof of opcode/geometry correctness.
+
+## Data Flow
 
 ```text
-Cache archives
-  | mX_Y terrain; lX_Y objects; model/config/texture archives
-  v
-Hagalaz.Cache
-  | decode/cache-format semantics
-  +-- map render region projection
-  +-- floor definitions
-  +-- object render definitions
-  +-- model mesh projection
-  +-- decoded textures/material inputs
-  v
-Hagalaz.Services.Cache
-  | bounded HTTP DTOs
-  v
-MapRenderDataService (Angular)
-  | request/dedup/cancellation ownership
-  v
-SceneAssembler
-  | region-local origin + one coordinate conversion
-  | terrain mesh builder
-  | object mesh builder
-  v
-SceneRenderer adapter
-  v
-Three.js (recommended) / selected dedicated browser renderer
+mX_Y terrain cache archive
+        |
+        v
+ICacheAPI / MapProvider
+        |
+        v
+render-focused terrain decode/projection
+  - four planes
+  - heights
+  - flags
+  - overlay/underlay
+  - overlay shape/rotation
+  - explicit border heights
+        |
+        v
+Hagalaz.Services.Cache region-render endpoint
+        |
+        v
+Angular render-data service
+        |
+        v
+Scene assembler
+  - region-local origin
+  - one coordinate conversion
+  - terrain geometry
+        |
+        v
+small renderer adapter
+        |
+        v
+Three.js (recommended implementation)
 ```
 
-## Representative-region strategy
+## Representative Region
 
-Select at least one region that contains:
+Implementation must choose and record one region containing enough variation to prove the contract, preferably:
 
 - non-flat terrain;
+- more than one overlay/underlay;
 - multiple overlay shapes/rotations;
-- textured and untextured floors if texture decoding is ready;
-- walls, wall decorations, standard objects and floor decorations;
-- multi-tile and contoured objects where practical.
+- bridge/terrain flags if available without pulling object rendering into scope.
 
-Use small hand-built byte fixtures for exhaustive opcode tests and the representative real region for integration/fidelity tests. A second adjacent region should be introduced before Phase 3 to prove border-height seams.
+Use hand-built byte fixtures for exhaustive opcode cases. Add an adjacent-region fixture only to test border-height derivation; rendering multiple active regions is still a follow-up.
 
-## API shape constraints
+## API Shape Constraints
 
-Rendering endpoints MUST be bounded by an explicit resource such as one region, one object definition, one model or one material/texture. Do not expose an unbounded "all maps/models" operation.
+The endpoint is bounded to one explicit region (and whatever query/body inputs the existing XTEA workflow requires). It must not expose an unbounded "all maps" operation or raw cache container bytes.
 
-Large mesh payloads may eventually justify binary transport or compression, but the first contract should optimize for semantic clarity and testability. Change transport representation only after recording payload/latency measurements.
+The first transport should favor semantic clarity and testability. Do not add binary mesh transport or compression until an actual region response has been measured and the JSON representation is proven inadequate.
 
-## Failure and lifecycle behavior
+## Failure and Lifecycle Behavior
 
-- Invalid/missing cache resources should produce the cache service's normal mapped error behavior rather than partial invented geometry.
-- XTEA-protected region object data remains server-decoded; the browser supplies/obtains only the API inputs required by the chosen viewer workflow.
-- Switching region selection should cancel stale web requests when possible.
-- Renderer resources created for an unloaded region must be disposed by one scene/resource owner.
-- Model/material reuse should initially be in-memory within that owner. Persistent browser caching is a separate measured optimization.
+- Missing/invalid cache resources use existing cache-service error mapping; the renderer does not invent flat fallback terrain.
+- Stale web requests should be cancellable when region selection changes using existing Angular/HTTP cancellation behavior.
+- The scene owner disposes renderer resources when the page/region is replaced.
+- No retry queue, reconciliation loop, IndexedDB cache or secondary server cache is introduced.
 
 ## Risks / Trade-offs
 
-- **Risk: render DTOs duplicate gameplay data.** → Accept small semantic duplication at the API boundary to keep gameplay contracts clean; share underlying decoders/providers.
-- **Risk: a 65×65 height contract needs neighboring data.** → Define border derivation explicitly and cover adjacent-region seams; never silently repeat the last row/column in the browser.
-- **Risk: texture behavior is more complex than color-only terrain.** → Ship a color-correct first terrain slice, then add decoded textures as a fidelity increment if representative acceptance criteria permit it.
-- **Risk: model projection becomes engine-specific.** → Keep cache/model semantics renderer-neutral and translate to `BufferGeometry` in the web builder.
-- **Risk: partially deobfuscated fields leak into stable DTOs.** → Expose only named/proven semantics; document open fields and investigate them when a failing fidelity case requires them.
-- **Risk: scene abstraction grows into a second game client.** → Optimize for an inspection viewer: coarse region batches and static scene data first, live/dynamic behavior only when explicitly required.
+- **Risk: render projection duplicates flag decode logic.** → Factor/reuse the existing opcode semantics so gameplay flags and render flags have one source.
+- **Risk: explicit border heights require neighboring data.** → Make border derivation a server projection responsibility and test it with an adjacent fixture before the browser consumes the contract.
+- **Risk: color-only floors are less visually faithful than the client.** → Accept this bounded Phase-1 trade-off; preserve semantic IDs and add decoded textures in a later fidelity change.
+- **Risk: Three.js leaks into domain contracts.** → Keep HTTP/render-domain data engine-neutral and convert only in the web renderer/geometry layer.
+- **Risk: the change expands into objects/models because the client docs cover them.** → Treat object/model sections as documented follow-up knowledge; stop this change if terrain implementation requires them.
 
 ## Migration Plan
 
-There is no production migration for the documentation foundation.
+This foundation is additive:
 
-Implementation should be additive:
+1. add tested render-focused terrain decoding/projection while leaving current gameplay consumers unchanged;
+2. add one bounded cache-service render-region endpoint;
+3. add the single-region Angular viewer and renderer dependency;
+4. verify the representative region and complete the change.
 
-1. add render-focused decoding/projections and tests without changing current gameplay consumers;
-2. expose bounded cache-service endpoints;
-3. add the one-region web feature behind its new route;
-4. add static objects;
-5. expand to neighboring regions and fidelity features.
+Existing `/types/maps/{id}` consumers should remain compatible. Prefer a distinct render-focused endpoint unless implementation proves a backward-compatible extension is simpler and does not change existing response meaning.
 
-Existing `/types/maps/{id}` consumers should not be broken merely to serve the viewer. A new render-focused endpoint or backward-compatible response evolution should be chosen based on existing API consumers during implementation.
-
-Rollback each phase by removing its additive endpoint/feature while leaving existing gameplay cache types unchanged.
+Rollback by removing the additive endpoint/viewer/projection together; no persisted data migration is involved.
 
 ## Open Questions
 
-These are intentionally deferred until the milestone that needs them:
+Resolve these during the implementation tasks without expanding scope:
 
-- Which exact cache archive/provider should own overlay and underlay definitions in Hagalaz?
-- What decoded texture representation is smallest while preserving the client material behavior needed by representative regions?
-- Should model mesh transport remain JSON for the first slice or use a compact binary format after measurements?
-- Which `Class491` and secondary `OverlayType` fields need human-readable names for visible client parity?
-- Is dynamic 8×8 map assembly required by the initial web viewer product use case, or only by a later developer inspection mode?
-- Which roof/occlusion rules should the viewer expose versus intentionally allowing users to inspect every plane?
+- Which exact existing cache config archive/provider should own the minimum overlay/underlay color definitions?
+- Which representative region provides the best small parity fixture?
+- What endpoint shape best fits the existing cache-service route naming while clearly distinguishing gameplay map data from render terrain data?
+- Does the first region JSON payload justify any compact height/tile encoding, or is straightforward JSON sufficient?
+
+Object/model APIs, decoded textures, multi-region streaming, dynamic maps and client camera/occlusion behavior are follow-up changes, not open questions for this one.

--- a/openspec/changes/establish-web-3d-rendering-foundation/design.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/design.md
@@ -2,7 +2,9 @@
 
 The current Hagalaz cache map path was built for GameWorld semantics, not rendering. `MapCodec` consumes map terrain bytes but preserves only terrain flags, while `TypeEndpoints.MapMap(...)` reduces the HTTP map response further to dimensions and object placements.
 
-The verified game client has a richer two-stage terrain design. `RegionManager` loads/assembles regions, `Map`/`Class274` decode full tile data and construct terrain surfaces, and `GraphicsToolkit` hides OpenGL/Direct3D/software backends. Object/model rendering exists beyond that path, but it is deliberately outside this change.
+The verified game client has a richer two-stage terrain design. `RegionManager` loads/assembles regions, `Map`/`TerrainBuilder` decode full tile data and construct terrain surfaces, and `GraphicsToolkit` hides OpenGL/Direct3D/software backends. Object/model rendering exists beyond that path, but it is deliberately outside this change.
+
+The GameClient still contains generated decompiler identifiers in this subsystem. Those identifiers are temporary source locators, not architecture. Hagalaz documentation and new server/web code use the evidence-backed semantic vocabulary defined in `docs/3d-rendering/client-rendering-deobfuscation.md`, such as `TerrainBuilder`, `SceneGraph`, `SceneTile`, `TerrainSurface`, `FloorUnderlayDefinition` and `OcclusionManager`.
 
 The concrete goal is one authoritative 64×64 four-plane terrain region rendered in the browser from server-decoded cache semantics.
 
@@ -14,12 +16,14 @@ The concrete goal is one authoritative 64×64 four-plane terrain region rendered
 - Expose a bounded render-region projection separate from gameplay-oriented map contracts.
 - Render one representative real region in the web UI through one coordinate-conversion owner and one small renderer boundary.
 - Prove behavior with client-parity decoder/API/geometry tests.
+- Use stable semantic rendering names so generated GameClient identifiers do not become permanent Hagalaz DTO/API/TypeScript vocabulary.
 
 **Non-Goals:**
 
 - Static objects/models, model APIs, multi-region streaming, dynamic-map rendering, decoded textures, animation, atmosphere, occlusion, roof logic or live entities.
 - New distributed state, queues, retry/reconciliation mechanisms or persistent browser caching.
 - A port of the client's renderer/toolkit abstractions.
+- Completing all GameClient source-level deobfuscation inside this Hagalaz change; that source cleanup is tracked separately and this design already uses the semantic names.
 
 ## Decisions
 
@@ -69,6 +73,21 @@ Keeping the 512-unit scale also prepares the scene for future client model geome
 The first representative region proves height, floor ID, floor shape and rotation correctness. Overlay/underlay definitions expose the semantic color fields required to reproduce recognizable base floor coloration.
 
 Texture decoding/material shaders are a separate fidelity change. Texture IDs may be retained if useful for future compatibility, but missing decoded textures do not expand this change.
+
+### Use semantic names rather than generated client identifiers
+
+The GameClient source mapping is valuable evidence, but generated names are not allowed to leak into new Hagalaz contracts.
+
+The canonical vocabulary is maintained in `docs/3d-rendering/client-rendering-deobfuscation.md`. Examples:
+
+- `TerrainBuilder` for the terrain decode/build base used by `Map`;
+- `SceneGraph` / `SceneTile` for the scene owner and tile cells;
+- `TerrainSurface` for renderer-backed height/terrain surfaces;
+- `FloorOverlayDefinition` / `FloorUnderlayDefinition` for floor materials;
+- `OcclusionManager` / `Occluder` for visibility geometry;
+- `SceneEntity`, `WallEntity`, `WallDecorationEntity`, `FloorDecorationEntity` and `MultiTileSceneEntity` for scene-object categories.
+
+If a client field is not understood well enough to name, do not expose that field just to preserve parity with an opaque source identifier. Keep it internal/unresolved until behavior supplies a defensible semantic name.
 
 ### Recommend Three.js, reject MapLibre/raw WebGL for this slice
 
@@ -143,6 +162,8 @@ The endpoint is bounded to one explicit region (and whatever query/body inputs t
 
 The first transport should favor semantic clarity and testability. Do not add binary mesh transport or compression until an actual region response has been measured and the JSON representation is proven inadequate.
 
+Generated client identifiers must not appear in the public response schema. If a render semantic is not understood well enough to name, resolve it before adding it to the public contract or leave it out of the bounded milestone.
+
 ## Failure and Lifecycle Behavior
 
 - Missing/invalid cache resources use existing cache-service error mapping; the renderer does not invent flat fallback terrain.
@@ -156,6 +177,7 @@ The first transport should favor semantic clarity and testability. Do not add bi
 - **Risk: explicit border heights require neighboring data.** → Make border derivation a server projection responsibility and test it with an adjacent fixture before the browser consumes the contract.
 - **Risk: color-only floors are less visually faithful than the client.** → Accept this bounded Phase-1 trade-off; preserve semantic IDs and add decoded textures in a later fidelity change.
 - **Risk: Three.js leaks into domain contracts.** → Keep HTTP/render-domain data engine-neutral and convert only in the web renderer/geometry layer.
+- **Risk: generated GameClient names become permanent Hagalaz names.** → Treat the deobfuscation map as canonical and forbid generated identifiers in new DTO/API/TypeScript architecture.
 - **Risk: the change expands into objects/models because the client docs cover them.** → Treat object/model sections as documented follow-up knowledge; stop this change if terrain implementation requires them.
 
 ## Migration Plan

--- a/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+Hagalaz cannot currently reproduce RuneScape 3D map scenes in the web UI from authoritative cache data. The Angular app has no active 3D map feature, while the cache map decoder retains only terrain flags and object placements. The real game client additionally uses tile heights, overlays, underlays, floor definitions, object shape-to-model mappings, model geometry, textures and object transforms before handing a scene to a renderer-independent graphics toolkit.
+
+Without a documented rendering model and server-side render-data boundary, frontend work would either use placeholders or duplicate proprietary cache decoding in TypeScript. Both would create a second source of truth and make later fidelity work expensive.
+
+## What Changes
+
+- Document the verified `Hagalaz.GameClient` terrain, object, model, scene and graphics-backend pipeline in human-readable terms.
+- Establish a render-focused cache/service contract separate from gameplay-oriented `IMapType` and `IObjectType`.
+- Preserve the full visible terrain semantics required for rendering: height, overlay, underlay, shape, rotation and terrain flags.
+- Define the object/model/material data required for static object rendering.
+- Establish one coordinate conversion and region-local scene-origin convention for the web viewer.
+- Define a small web renderer boundary and a phased implementation that proves one real region before multi-region streaming or visual effects.
+- Record Three.js as the recommended first dedicated 3D engine and MapLibre as unsuitable for the core RuneScape scene renderer, while deferring any new dependency to the implementation change that proves the first vertical slice.
+- Add client-parity decoder/geometry/API tests before relying on visual inspection.
+
+### In Scope
+
+- Static 64×64 map-region terrain across four planes.
+- Dynamic 8×8 region-part semantics needed to keep the data model correct, even if dynamic-map UI support ships after the single-region slice.
+- Floor overlay/underlay data required to render representative regions.
+- Static object placement, shape-to-model selection and model transforms.
+- Static model mesh geometry/material inputs.
+- Cache-service render DTOs/endpoints.
+- Angular scene assembly, diagnostic camera, plane controls and renderer boundary.
+- Documentation and targeted client deobfuscation needed by these milestones.
+
+### Non-goals
+
+- Port the original `GraphicsToolkit` API or scene tile graph verbatim.
+- Decode RuneScape cache formats in Angular.
+- Make MapLibre a custom-layer host for the 3D game scene.
+- Match the gameplay camera, roof hiding, occlusion, atmosphere, water, animated objects, NPCs or players in the first vertical slice.
+- Add browser persistent caching, worker pools, LOD, instancing or custom shaders before profiling demonstrates a need.
+- Add render-only fields indiscriminately to gameplay `IMapType` / `IObjectType` contracts.
+
+### Acceptance Criteria
+
+- The engine reference documents verified client class responsibilities, terrain opcode semantics, object/model construction, renderer backends, units and open deobfuscation areas.
+- The web foundation document identifies the current Hagalaz data/API gaps and defines explicit ownership boundaries and phased milestones.
+- A future implementation can request one representative region from the cache service with enough semantic data to build its real terrain without placeholder height/material data.
+- Static object rendering can obtain a shape-appropriate model plus the definition transformations needed to place it correctly.
+- The browser does not need raw map/model cache decoding logic.
+- Coordinate conversion has exactly one owner and uses region-local scene origins.
+- The first renderer implementation is tested numerically for decoder/geometry parity before visual-regression coverage is treated as a correctness signal.
+- New graphics dependencies are introduced only in the implementation change that exercises them.
+
+### Stop Conditions
+
+Pause and split follow-up work if the first static-region vertical slice requires gameplay contract redesign, live GameWorld entity streaming, full animation/skinning, a new distributed cache, or broad client deobfuscation unrelated to the representative scene.
+
+## Capabilities
+
+### New Capabilities
+
+- `web-3d-map-rendering`: Hagalaz exposes authoritative render-focused scene data and the web UI assembles it into an inspectable 3D RuneScape map scene without duplicating cache decoding.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+Expected implementation areas:
+
+- `Hagalaz.Cache` / `Hagalaz.Cache.Abstractions` for render-focused decoders/projections that reuse the existing cache API.
+- `Hagalaz.Services.Cache` for bounded rendering endpoints/DTOs.
+- `Hagalaz.Cache.Tests` and cache-service tests for client-parity coverage.
+- `Hagalaz.Web.App` for the map feature, scene assembly and renderer adapter.
+- `docs/3d-rendering` for long-lived renderer knowledge.
+
+The documentation-only foundation change itself adds no runtime dependency, API, migration, configuration or distributed-topology change.

--- a/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
@@ -4,9 +4,12 @@ Hagalaz cannot currently display an authoritative RuneScape terrain region in th
 
 Starting in Angular with placeholder geometry or a second TypeScript cache decoder would create the wrong ownership boundary. The smallest useful foundation is therefore one real 64×64 region whose terrain is decoded once by the existing cache stack, exposed through a bounded render-data contract, and rendered in the browser with a single coordinate-conversion owner.
 
+The current `MapCodec` must also not be mistaken for a full cache round-trip implementation. `MapProvider` combines separate terrain/location payloads into an internal length-prefixed stream, terrain rendering data is discarded, bridge adjustment loses raw source-plane information, and cache writing has no XTEA-aware symmetric path for protected location containers. These format boundaries and encoding requirements must be documented before renderer or editor work builds on incorrect assumptions.
+
 ## What Changes
 
 - Document the verified `Hagalaz.GameClient` terrain/scene/renderer pipeline and the broader object/model findings for future work.
+- Document byte-level decode/encode rules for map cache containers, terrain payloads, location payloads, smart/huge-smart deltas, XTEA, canonical encoding and persisted-write verification.
 - Add a render-focused terrain projection that reuses the existing Hagalaz cache access path while preserving height, overlay, underlay, shape, rotation and terrain flags.
 - Expose one bounded cache-service region-render contract instead of sending raw cache bytes to the browser.
 - Establish one region-local coordinate conversion and a small browser renderer boundary.
@@ -23,8 +26,10 @@ Starting in Angular with placeholder geometry or a second TypeScript cache decod
 ### In Scope
 
 - Documentation of the verified game-client 3D pipeline and current Hagalaz gaps.
+- Detailed implementation instructions for decoding and semantically encoding `mX_Y` terrain and `lX_Y` location data, including cache-container/XTEA boundaries and known current codec hazards.
 - Static terrain for one 64×64 region across four planes.
 - Terrain height, terrain flags, overlay ID, underlay ID, overlay shape/path and overlay rotation.
+- Source encoding information needed to avoid making later cache re-encoding impossible, without adding a map mutation API in this change.
 - Floor definition fields needed to render base colors for the chosen representative region.
 - Deterministic region-border/corner-height semantics so the contract does not bake in a seam bug.
 - A bounded render-region endpoint/DTO.
@@ -33,8 +38,10 @@ Starting in Angular with placeholder geometry or a second TypeScript cache decod
 
 ### Non-goals
 
+- A production map/cache mutation endpoint. Encoding rules are documented so data is not thrown away, but persisted write support requires a separate capability and destructive-write test boundary.
 - Static object/model rendering. The client object/model analysis is documented now, but its API/renderer implementation is a follow-up change.
 - Model geometry endpoints, object render-definition endpoints, animation or live GameWorld entities.
+- A model binary encoder; Hagalaz does not yet have a verified server-side model codec and the web viewer does not need model writes.
 - Multi-region streaming or dynamic 8×8 region-part rendering.
 - Decoded floor textures, custom shaders, lighting, shadows, atmosphere, water, roof hiding or occlusion.
 - Porting `GraphicsToolkit`, `Class356`, or another client renderer structure verbatim.
@@ -46,6 +53,8 @@ Starting in Angular with placeholder geometry or a second TypeScript cache decod
 ### Acceptance Criteria
 
 - `docs/3d-rendering` explains the verified client pipeline, terrain opcode semantics, coordinate units, broader object/model requirements, current Hagalaz gaps, and follow-up milestones.
+- `docs/3d-rendering` contains a byte-level map codec guide that distinguishes real cache files from the internal `MapCodec` stream and gives deterministic instructions for terrain/location decode, semantic encode, smart/huge-smart coding, source/effective planes, XTEA container handling, corruption guards and persisted-write verification.
+- Known limitations of the current reduced encoder are explicitly documented rather than described as cache-faithful round-trip support.
 - The server can represent one renderable region with all terrain semantics needed for correct four-plane geometry and base floor coloration without changing the gameplay meaning of `IMapType.TerrainData`.
 - A bounded cache-service endpoint returns that semantic region representation; the browser does not decode raw terrain cache bytes.
 - The web viewer renders the chosen representative region from real decoded heights and floor shape/rotation/material data, with no generated placeholder height map.
@@ -55,7 +64,7 @@ Starting in Angular with placeholder geometry or a second TypeScript cache decod
 
 ### Stop Conditions
 
-Pause and create a follow-up change if the representative terrain slice requires static object/model rendering, live GameWorld data, texture/shader fidelity, multi-region streaming, dynamic-region assembly, gameplay contract redesign, a second cache-access mechanism, or a new distributed state/cache owner.
+Pause and create a follow-up change if the representative terrain slice requires static object/model rendering, live GameWorld data, texture/shader fidelity, multi-region streaming, dynamic-region assembly, gameplay contract redesign, a second cache-access mechanism, a new distributed state/cache owner, or production map mutation/write-back support.
 
 ## Capabilities
 
@@ -75,6 +84,6 @@ Expected implementation areas:
 - `Hagalaz.Services.Cache` for one bounded region-render endpoint/DTO.
 - cache/service tests for client-parity coverage.
 - `Hagalaz.Web.App` for the single-region map page, terrain assembly and renderer adapter.
-- `docs/3d-rendering` for long-lived renderer knowledge.
+- `docs/3d-rendering` for long-lived renderer and codec knowledge.
 
 The current documentation-only foundation commit adds no runtime dependency, API, migration, configuration or distributed-topology change.

--- a/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
@@ -6,9 +6,12 @@ Starting in Angular with placeholder geometry or a second TypeScript cache decod
 
 The current `MapCodec` must also not be mistaken for a full cache round-trip implementation. `MapProvider` combines separate terrain/location payloads into an internal length-prefixed stream, terrain rendering data is discarded, bridge adjustment loses raw source-plane information, and cache writing has no XTEA-aware symmetric path for protected location containers. These format boundaries and encoding requirements must be documented before renderer or editor work builds on incorrect assumptions.
 
+Finally, the GameClient still contains generated decompiler names throughout this subsystem. Those identifiers are useful only for locating the current source and must not become permanent names in Hagalaz services, DTOs, TypeScript or documentation. The rendering foundation therefore defines one evidence-backed semantic vocabulary for the terrain, scene graph, floor definitions, entities, lights, model data and occlusion system, with source-level GameClient renaming tracked separately.
+
 ## What Changes
 
-- Document the verified `Hagalaz.GameClient` terrain/scene/renderer pipeline and the broader object/model findings for future work.
+- Document the verified `Hagalaz.GameClient` terrain/scene/renderer pipeline and the broader object/model findings for future work using stable semantic names rather than generated decompiler identifiers.
+- Add a dedicated deobfuscation/source-locator map with confidence and evidence for names such as `TerrainBuilder`, `SceneGraph`, `SceneTile`, `TerrainSurface`, `FloorUnderlayDefinition`, `OcclusionManager`, `WallEntity` and `SceneLight`.
 - Document byte-level decode/encode rules for map cache containers, terrain payloads, location payloads, smart/huge-smart deltas, XTEA, canonical encoding and persisted-write verification.
 - Add a render-focused terrain projection that reuses the existing Hagalaz cache access path while preserving height, overlay, underlay, shape, rotation and terrain flags.
 - Expose one bounded cache-service region-render contract instead of sending raw cache bytes to the browser.
@@ -26,6 +29,7 @@ The current `MapCodec` must also not be mistaken for a full cache round-trip imp
 ### In Scope
 
 - Documentation of the verified game-client 3D pipeline and current Hagalaz gaps.
+- A semantic rendering/deobfuscation vocabulary and source-locator mapping for the high-confidence GameClient rendering core.
 - Detailed implementation instructions for decoding and semantically encoding `mX_Y` terrain and `lX_Y` location data, including cache-container/XTEA boundaries and known current codec hazards.
 - Static terrain for one 64×64 region across four planes.
 - Terrain height, terrain flags, overlay ID, underlay ID, overlay shape/path and overlay rotation.
@@ -38,13 +42,14 @@ The current `MapCodec` must also not be mistaken for a full cache round-trip imp
 
 ### Non-goals
 
+- Completing all source-level GameClient deobfuscation in this Hagalaz change. The high-confidence source rename is tracked separately in `Hagalaz.GameClient`; this change establishes the names Hagalaz will use now.
 - A production map/cache mutation endpoint. Encoding rules are documented so data is not thrown away, but persisted write support requires a separate capability and destructive-write test boundary.
 - Static object/model rendering. The client object/model analysis is documented now, but its API/renderer implementation is a follow-up change.
 - Model geometry endpoints, object render-definition endpoints, animation or live GameWorld entities.
 - A model binary encoder; Hagalaz does not yet have a verified server-side model codec and the web viewer does not need model writes.
 - Multi-region streaming or dynamic 8×8 region-part rendering.
 - Decoded floor textures, custom shaders, lighting, shadows, atmosphere, water, roof hiding or occlusion.
-- Porting `GraphicsToolkit`, `Class356`, or another client renderer structure verbatim.
+- Porting the client `GraphicsToolkit`, `SceneGraph`, or another renderer structure verbatim.
 - Decoding RuneScape cache formats in Angular.
 - Making MapLibre a custom-layer host for the RuneScape 3D scene.
 - Browser persistent caching, worker pools, LOD or speculative performance mechanisms.
@@ -53,6 +58,8 @@ The current `MapCodec` must also not be mistaken for a full cache round-trip imp
 ### Acceptance Criteria
 
 - `docs/3d-rendering` explains the verified client pipeline, terrain opcode semantics, coordinate units, broader object/model requirements, current Hagalaz gaps, and follow-up milestones.
+- `docs/3d-rendering/client-rendering-deobfuscation.md` defines the canonical semantic names, source locators, evidence and confidence for the high-confidence rendering core; generated GameClient identifiers are not used as architecture names in the other 3D-rendering documents.
+- New Hagalaz server/web rendering contracts use semantic domain names and do not introduce generated GameClient class/member identifiers into DTOs, APIs, services or TypeScript types.
 - `docs/3d-rendering` contains a byte-level map codec guide that distinguishes real cache files from the internal `MapCodec` stream and gives deterministic instructions for terrain/location decode, semantic encode, smart/huge-smart coding, source/effective planes, XTEA container handling, corruption guards and persisted-write verification.
 - Known limitations of the current reduced encoder are explicitly documented rather than described as cache-faithful round-trip support.
 - The server can represent one renderable region with all terrain semantics needed for correct four-plane geometry and base floor coloration without changing the gameplay meaning of `IMapType.TerrainData`.
@@ -84,6 +91,7 @@ Expected implementation areas:
 - `Hagalaz.Services.Cache` for one bounded region-render endpoint/DTO.
 - cache/service tests for client-parity coverage.
 - `Hagalaz.Web.App` for the single-region map page, terrain assembly and renderer adapter.
-- `docs/3d-rendering` for long-lived renderer and codec knowledge.
+- `docs/3d-rendering` for long-lived renderer, deobfuscation and codec knowledge.
+- `Hagalaz.GameClient` issue #141 for the behavior-preserving source-level rename of the high-confidence rendering classes/members.
 
 The current documentation-only foundation commit adds no runtime dependency, API, migration, configuration or distributed-topology change.

--- a/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/proposal.md
@@ -1,60 +1,67 @@
 ## Why
 
-Hagalaz cannot currently reproduce RuneScape 3D map scenes in the web UI from authoritative cache data. The Angular app has no active 3D map feature, while the cache map decoder retains only terrain flags and object placements. The real game client additionally uses tile heights, overlays, underlays, floor definitions, object shape-to-model mappings, model geometry, textures and object transforms before handing a scene to a renderer-independent graphics toolkit.
+Hagalaz cannot currently display an authoritative RuneScape terrain region in the web UI. `Hagalaz.Web.App` has no active 3D map feature, while the current cache map decoder retains only terrain flags and object placements. The verified game client additionally uses tile heights, overlays, underlays, floor definitions, tile shapes and rotations before handing terrain to its renderer-independent graphics toolkit.
 
-Without a documented rendering model and server-side render-data boundary, frontend work would either use placeholders or duplicate proprietary cache decoding in TypeScript. Both would create a second source of truth and make later fidelity work expensive.
+Starting in Angular with placeholder geometry or a second TypeScript cache decoder would create the wrong ownership boundary. The smallest useful foundation is therefore one real 64×64 region whose terrain is decoded once by the existing cache stack, exposed through a bounded render-data contract, and rendered in the browser with a single coordinate-conversion owner.
 
 ## What Changes
 
-- Document the verified `Hagalaz.GameClient` terrain, object, model, scene and graphics-backend pipeline in human-readable terms.
-- Establish a render-focused cache/service contract separate from gameplay-oriented `IMapType` and `IObjectType`.
-- Preserve the full visible terrain semantics required for rendering: height, overlay, underlay, shape, rotation and terrain flags.
-- Define the object/model/material data required for static object rendering.
-- Establish one coordinate conversion and region-local scene-origin convention for the web viewer.
-- Define a small web renderer boundary and a phased implementation that proves one real region before multi-region streaming or visual effects.
-- Record Three.js as the recommended first dedicated 3D engine and MapLibre as unsuitable for the core RuneScape scene renderer, while deferring any new dependency to the implementation change that proves the first vertical slice.
-- Add client-parity decoder/geometry/API tests before relying on visual inspection.
+- Document the verified `Hagalaz.GameClient` terrain/scene/renderer pipeline and the broader object/model findings for future work.
+- Add a render-focused terrain projection that reuses the existing Hagalaz cache access path while preserving height, overlay, underlay, shape, rotation and terrain flags.
+- Expose one bounded cache-service region-render contract instead of sending raw cache bytes to the browser.
+- Establish one region-local coordinate conversion and a small browser renderer boundary.
+- Implement one real four-plane region terrain vertical slice with diagnostic camera and plane controls.
+- Use deterministic client-parity decoder/geometry tests as the correctness gate.
+- Record Three.js as the recommended dedicated renderer for the implementation slice, while adding no graphics dependency in this documentation-only foundation commit.
+
+### Existing Mechanisms Reused
+
+- `ICacheAPI`, `IMapProvider`, `MapProvider` and the current cache container/XTEA access path remain the only cache ownership mechanism.
+- `Hagalaz.Services.Cache` keeps the existing Minimal API feature/DTO/error patterns for the new bounded render endpoint.
+- `Hagalaz.Web.App` keeps its existing Angular routing/HTTP/application structure; the map feature is additive.
 
 ### In Scope
 
-- Static 64×64 map-region terrain across four planes.
-- Dynamic 8×8 region-part semantics needed to keep the data model correct, even if dynamic-map UI support ships after the single-region slice.
-- Floor overlay/underlay data required to render representative regions.
-- Static object placement, shape-to-model selection and model transforms.
-- Static model mesh geometry/material inputs.
-- Cache-service render DTOs/endpoints.
-- Angular scene assembly, diagnostic camera, plane controls and renderer boundary.
-- Documentation and targeted client deobfuscation needed by these milestones.
+- Documentation of the verified game-client 3D pipeline and current Hagalaz gaps.
+- Static terrain for one 64×64 region across four planes.
+- Terrain height, terrain flags, overlay ID, underlay ID, overlay shape/path and overlay rotation.
+- Floor definition fields needed to render base colors for the chosen representative region.
+- Deterministic region-border/corner-height semantics so the contract does not bake in a seam bug.
+- A bounded render-region endpoint/DTO.
+- One web map route/page, scene assembler, renderer boundary, orbit/pan/zoom diagnostics and plane visibility controls.
+- Tests for cache decoding, API completeness and pure TypeScript terrain geometry/coordinate conversion.
 
 ### Non-goals
 
-- Port the original `GraphicsToolkit` API or scene tile graph verbatim.
-- Decode RuneScape cache formats in Angular.
-- Make MapLibre a custom-layer host for the 3D game scene.
-- Match the gameplay camera, roof hiding, occlusion, atmosphere, water, animated objects, NPCs or players in the first vertical slice.
-- Add browser persistent caching, worker pools, LOD, instancing or custom shaders before profiling demonstrates a need.
-- Add render-only fields indiscriminately to gameplay `IMapType` / `IObjectType` contracts.
+- Static object/model rendering. The client object/model analysis is documented now, but its API/renderer implementation is a follow-up change.
+- Model geometry endpoints, object render-definition endpoints, animation or live GameWorld entities.
+- Multi-region streaming or dynamic 8×8 region-part rendering.
+- Decoded floor textures, custom shaders, lighting, shadows, atmosphere, water, roof hiding or occlusion.
+- Porting `GraphicsToolkit`, `Class356`, or another client renderer structure verbatim.
+- Decoding RuneScape cache formats in Angular.
+- Making MapLibre a custom-layer host for the RuneScape 3D scene.
+- Browser persistent caching, worker pools, LOD or speculative performance mechanisms.
+- Adding render-only fields indiscriminately to gameplay `IMapType` / `IObjectType` contracts.
 
 ### Acceptance Criteria
 
-- The engine reference documents verified client class responsibilities, terrain opcode semantics, object/model construction, renderer backends, units and open deobfuscation areas.
-- The web foundation document identifies the current Hagalaz data/API gaps and defines explicit ownership boundaries and phased milestones.
-- A future implementation can request one representative region from the cache service with enough semantic data to build its real terrain without placeholder height/material data.
-- Static object rendering can obtain a shape-appropriate model plus the definition transformations needed to place it correctly.
-- The browser does not need raw map/model cache decoding logic.
-- Coordinate conversion has exactly one owner and uses region-local scene origins.
-- The first renderer implementation is tested numerically for decoder/geometry parity before visual-regression coverage is treated as a correctness signal.
-- New graphics dependencies are introduced only in the implementation change that exercises them.
+- `docs/3d-rendering` explains the verified client pipeline, terrain opcode semantics, coordinate units, broader object/model requirements, current Hagalaz gaps, and follow-up milestones.
+- The server can represent one renderable region with all terrain semantics needed for correct four-plane geometry and base floor coloration without changing the gameplay meaning of `IMapType.TerrainData`.
+- A bounded cache-service endpoint returns that semantic region representation; the browser does not decode raw terrain cache bytes.
+- The web viewer renders the chosen representative region from real decoded heights and floor shape/rotation/material data, with no generated placeholder height map.
+- Coordinate conversion has exactly one owner, uses a region-local scene origin, and keeps terrain units internally consistent.
+- Decoder/API/geometry tests cover the verified client semantics before screenshot comparison is used as a fidelity signal.
+- No new queue, store, retry mechanism, persistent browser cache or unrelated graphics abstraction is introduced.
 
 ### Stop Conditions
 
-Pause and split follow-up work if the first static-region vertical slice requires gameplay contract redesign, live GameWorld entity streaming, full animation/skinning, a new distributed cache, or broad client deobfuscation unrelated to the representative scene.
+Pause and create a follow-up change if the representative terrain slice requires static object/model rendering, live GameWorld data, texture/shader fidelity, multi-region streaming, dynamic-region assembly, gameplay contract redesign, a second cache-access mechanism, or a new distributed state/cache owner.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `web-3d-map-rendering`: Hagalaz exposes authoritative render-focused scene data and the web UI assembles it into an inspectable 3D RuneScape map scene without duplicating cache decoding.
+- `web-3d-map-rendering`: Hagalaz exposes authoritative render-focused terrain data and the web UI can assemble one real RuneScape map region into an inspectable 3D terrain scene without duplicating cache decoding.
 
 ### Modified Capabilities
 
@@ -64,10 +71,10 @@ Pause and split follow-up work if the first static-region vertical slice require
 
 Expected implementation areas:
 
-- `Hagalaz.Cache` / `Hagalaz.Cache.Abstractions` for render-focused decoders/projections that reuse the existing cache API.
-- `Hagalaz.Services.Cache` for bounded rendering endpoints/DTOs.
-- `Hagalaz.Cache.Tests` and cache-service tests for client-parity coverage.
-- `Hagalaz.Web.App` for the map feature, scene assembly and renderer adapter.
+- `Hagalaz.Cache` / `Hagalaz.Cache.Abstractions` for the render-focused terrain projection reusing existing cache access.
+- `Hagalaz.Services.Cache` for one bounded region-render endpoint/DTO.
+- cache/service tests for client-parity coverage.
+- `Hagalaz.Web.App` for the single-region map page, terrain assembly and renderer adapter.
 - `docs/3d-rendering` for long-lived renderer knowledge.
 
-The documentation-only foundation change itself adds no runtime dependency, API, migration, configuration or distributed-topology change.
+The current documentation-only foundation commit adds no runtime dependency, API, migration, configuration or distributed-topology change.

--- a/openspec/changes/establish-web-3d-rendering-foundation/specs/web-3d-map-rendering/spec.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/specs/web-3d-map-rendering/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Rendering uses authoritative decoded map data
+
+Hagalaz MUST decode RuneScape map rendering semantics on the server and MUST expose semantic rendering data to the web UI without requiring the browser to decode raw cache containers.
+
+#### Scenario: A region is requested for 3D rendering
+- **WHEN** the web UI requests a renderable map region
+- **THEN** the response MUST contain or reference enough semantic data to reconstruct the visible terrain and placed static objects for that region
+- **AND** the browser MUST NOT need to interpret the original terrain/object cache bytecode
+
+#### Scenario: Existing gameplay map consumers continue to use gameplay contracts
+- **WHEN** render-specific terrain, object, model or material fields are introduced
+- **THEN** they MUST be exposed through a rendering projection or another explicitly render-focused boundary rather than making the existing gameplay contracts engine-specific
+
+### Requirement: Region terrain preserves client-parity floor semantics
+
+A renderable map region MUST preserve the terrain information consumed by the verified game-client floor builder: heights, terrain flags, overlay ID, underlay ID, overlay shape/path and overlay rotation for four planes.
+
+#### Scenario: Explicit and implicit height opcodes are decoded
+- **WHEN** a terrain tile contains opcode `0` or `1`
+- **THEN** its render height MUST follow the verified client height semantics, including upper-plane default spacing relative to the plane below
+
+#### Scenario: Overlay tile data is decoded
+- **WHEN** a terrain tile contains an opcode from `2` through `49`
+- **THEN** the overlay ID MUST be preserved
+- **AND** the overlay shape/path MUST be derived from `(opcode - 2) / 4`
+- **AND** the overlay rotation MUST include the region-part rotation with the same modulo-four behavior as the client
+
+#### Scenario: Terrain flag and underlay data are decoded
+- **WHEN** a terrain tile contains an opcode from `50` through `81`
+- **THEN** the terrain flag MUST be preserved as `opcode - 49`
+- **WHEN** a terrain tile contains an opcode above `81`
+- **THEN** the underlay ID MUST be preserved as `opcode - 81`
+
+#### Scenario: Adjacent regions are rendered together
+- **WHEN** two neighboring 64×64 region surfaces share a border
+- **THEN** the terrain height contract/build process MUST determine the shared edge without browser-side guessing or duplicated last-row/last-column placeholders
+
+### Requirement: Static objects use their render definitions and placement shape
+
+The renderer MUST use both object placement data and the object's render definition when constructing a static scene object.
+
+#### Scenario: A placed object supports multiple shapes
+- **WHEN** an object placement specifies a shape and rotation
+- **THEN** the renderer MUST select the model group associated with that shape
+- **AND** MUST apply the placement orientation using the documented client-parity rotation semantics
+
+#### Scenario: An object definition transforms its model
+- **WHEN** a selected object render definition contains required static inversion, recolor, retexture, scale, offset or ground-contour data
+- **THEN** those transformations MUST be represented in the server rendering contract and applied before the final object is placed in the scene
+
+### Requirement: Model geometry is exposed without engine coupling
+
+Hagalaz MUST provide decoded model data sufficient for the web renderer to construct static object geometry without exposing browser-engine objects or requiring client cache-format decoding.
+
+#### Scenario: A static model is requested
+- **WHEN** a referenced model is fetched for rendering
+- **THEN** the response MUST preserve the vertex and triangle geometry and the proven face/material inputs required by representative static models
+- **AND** the response MUST NOT depend on Three.js, MapLibre, Babylon or another browser-engine object model
+
+### Requirement: The web scene has one coordinate conversion owner
+
+The web implementation MUST convert RuneScape legacy scene coordinates to browser-renderer coordinates in one scene-assembly boundary.
+
+#### Scenario: A region is assembled for the browser renderer
+- **WHEN** legacy terrain and model data are placed into a browser scene
+- **THEN** the scene MUST use a region-local origin
+- **AND** the conversion MUST consistently map legacy map axes and height to the chosen web axes
+- **AND** terrain and model geometry MUST use one shared scale, initially preserving the legacy 512 scene units per tile
+
+### Requirement: The browser renderer is independent from scene semantics
+
+RuneScape terrain/object/model assembly MUST remain project code independent from the selected browser graphics engine, while the engine-specific lifecycle is owned by a small renderer adapter.
+
+#### Scenario: The first dedicated renderer is introduced
+- **WHEN** a browser graphics dependency is added for the real-region vertical slice
+- **THEN** Angular components MUST NOT directly own cache decoding or triangle construction
+- **AND** engine-specific initialization, resize, render and disposal behavior MUST be isolated from the render-data decoding contract
+
+#### Scenario: MapLibre remains available for geographic overview use
+- **WHEN** the RuneScape 3D scene renderer is implemented
+- **THEN** it MUST NOT depend on MapLibre's geographic camera/custom-layer coordinate model as its core scene representation
+
+### Requirement: The first web milestone renders real terrain before visual effects
+
+The first 3D-map vertical slice MUST render one real cache region using authoritative terrain data before multi-region streaming or advanced visual effects are required.
+
+#### Scenario: The representative region is displayed
+- **WHEN** the Phase 1 viewer is complete
+- **THEN** all four planes MUST be constructible from decoded real heights
+- **AND** floor overlay/underlay shape, rotation and available base material data MUST come from decoded cache semantics rather than generated placeholder data
+- **AND** the viewer MUST provide diagnostic camera controls and plane visibility controls sufficient to inspect the result
+
+### Requirement: Rendering correctness is covered below the screenshot level
+
+Decoder, API and scene geometry behavior MUST be verifiable with deterministic automated tests independent from GPU screenshot comparison.
+
+#### Scenario: Terrain decoding changes
+- **WHEN** terrain decoder behavior is modified
+- **THEN** focused fixtures MUST cover height opcodes, overlay shape/rotation, terrain flags, underlays and plane spacing
+
+#### Scenario: Object/model rendering changes
+- **WHEN** object render definitions or model projection behavior is modified
+- **THEN** tests MUST cover shape-to-model selection and the relevant geometry/transformation invariants before visual-regression screenshots are used as an acceptance signal

--- a/openspec/changes/establish-web-3d-rendering-foundation/specs/web-3d-map-rendering/spec.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/specs/web-3d-map-rendering/spec.md
@@ -16,6 +16,22 @@ Hagalaz MUST decode RuneScape terrain rendering semantics on the server and MUST
 - **THEN** they MUST be exposed through an explicitly render-focused projection or another backward-compatible boundary
 - **AND** existing gameplay terrain-flag semantics MUST NOT silently change
 
+### Requirement: Rendering architecture uses semantic domain names
+
+Hagalaz MUST use evidence-backed semantic rendering names rather than generated GameClient/decompiler identifiers in new server and web architecture.
+
+#### Scenario: A render-focused server or web type is introduced
+- **GIVEN** the GameClient source still contains generated identifiers for part of the rendering subsystem
+- **WHEN** a new Hagalaz DTO, API contract, service, TypeScript type, renderer abstraction or architecture document represents that concept
+- **THEN** it MUST use the canonical semantic vocabulary from `docs/3d-rendering/client-rendering-deobfuscation.md`
+- **AND** it MUST NOT expose a generated `Class###`, `Entity_Sub*`, `method####` or equivalent decompiler name as the public/domain concept
+
+#### Scenario: A client field is not understood well enough to name
+- **GIVEN** a GameClient render field or behavior remains ambiguous after source tracing
+- **WHEN** the bounded terrain-render contract is designed
+- **THEN** the implementation MUST either keep that detail internal/unresolved or perform further deobfuscation before exposing it
+- **AND** MUST NOT invent a precise public name solely to remove an obfuscated identifier
+
 ### Requirement: Region terrain preserves client-parity floor semantics
 
 A renderable map region MUST preserve the terrain information consumed by the verified game-client floor builder: heights, terrain flags, overlay ID, underlay ID, overlay shape/path and overlay rotation for four planes.

--- a/openspec/changes/establish-web-3d-rendering-foundation/specs/web-3d-map-rendering/spec.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/specs/web-3d-map-rendering/spec.md
@@ -1,105 +1,110 @@
 ## ADDED Requirements
 
-### Requirement: Rendering uses authoritative decoded map data
+### Requirement: Rendering uses authoritative decoded terrain data
 
-Hagalaz MUST decode RuneScape map rendering semantics on the server and MUST expose semantic rendering data to the web UI without requiring the browser to decode raw cache containers.
+Hagalaz MUST decode RuneScape terrain rendering semantics on the server and MUST expose semantic terrain data to the web UI without requiring the browser to decode raw cache containers.
 
-#### Scenario: A region is requested for 3D rendering
-- **WHEN** the web UI requests a renderable map region
-- **THEN** the response MUST contain or reference enough semantic data to reconstruct the visible terrain and placed static objects for that region
-- **AND** the browser MUST NOT need to interpret the original terrain/object cache bytecode
+#### Scenario: A region is requested for 3D terrain rendering
+- **GIVEN** a cache region is available through the existing Hagalaz cache access path
+- **WHEN** the web UI requests that region for 3D rendering
+- **THEN** the response MUST contain enough semantic data to reconstruct all four terrain planes
+- **AND** the browser MUST NOT need to interpret the original terrain cache bytecode
 
-#### Scenario: Existing gameplay map consumers continue to use gameplay contracts
-- **WHEN** render-specific terrain, object, model or material fields are introduced
-- **THEN** they MUST be exposed through a rendering projection or another explicitly render-focused boundary rather than making the existing gameplay contracts engine-specific
+#### Scenario: Existing gameplay map consumers remain gameplay-focused
+- **GIVEN** existing consumers use the current gameplay meaning of `IMapType.TerrainData`
+- **WHEN** render-specific height and floor fields are introduced
+- **THEN** they MUST be exposed through an explicitly render-focused projection or another backward-compatible boundary
+- **AND** existing gameplay terrain-flag semantics MUST NOT silently change
 
 ### Requirement: Region terrain preserves client-parity floor semantics
 
 A renderable map region MUST preserve the terrain information consumed by the verified game-client floor builder: heights, terrain flags, overlay ID, underlay ID, overlay shape/path and overlay rotation for four planes.
 
 #### Scenario: Explicit and implicit height opcodes are decoded
-- **WHEN** a terrain tile contains opcode `0` or `1`
-- **THEN** its render height MUST follow the verified client height semantics, including upper-plane default spacing relative to the plane below
+- **GIVEN** a terrain tile contains opcode `0` or `1`
+- **WHEN** the render terrain projection decodes the tile
+- **THEN** its height MUST follow the verified client semantics
+- **AND** upper-plane implicit height MUST preserve the verified spacing relative to the plane below
 
 #### Scenario: Overlay tile data is decoded
-- **WHEN** a terrain tile contains an opcode from `2` through `49`
+- **GIVEN** a terrain tile contains an opcode from `2` through `49`
+- **WHEN** the render terrain projection decodes the tile
 - **THEN** the overlay ID MUST be preserved
 - **AND** the overlay shape/path MUST be derived from `(opcode - 2) / 4`
-- **AND** the overlay rotation MUST include the region-part rotation with the same modulo-four behavior as the client
+- **AND** overlay rotation MUST use the same modulo-four behavior as the verified client decoder
 
 #### Scenario: Terrain flag and underlay data are decoded
-- **WHEN** a terrain tile contains an opcode from `50` through `81`
+- **GIVEN** a terrain tile contains an opcode from `50` through `81`
+- **WHEN** the render terrain projection decodes the tile
 - **THEN** the terrain flag MUST be preserved as `opcode - 49`
-- **WHEN** a terrain tile contains an opcode above `81`
+- **GIVEN** a terrain tile contains an opcode above `81`
+- **WHEN** the render terrain projection decodes the tile
 - **THEN** the underlay ID MUST be preserved as `opcode - 81`
 
-#### Scenario: Adjacent regions are rendered together
-- **WHEN** two neighboring 64×64 region surfaces share a border
-- **THEN** the terrain height contract/build process MUST determine the shared edge without browser-side guessing or duplicated last-row/last-column placeholders
+#### Scenario: A region surface needs its far-edge vertices
+- **GIVEN** a 64×64 terrain region is projected for mesh construction
+- **WHEN** the render contract supplies its corner heights
+- **THEN** the far X and Y edges MUST be derived deterministically from authoritative terrain data
+- **AND** the browser MUST NOT create missing edge heights by repeating a last row or column placeholder
 
-### Requirement: Static objects use their render definitions and placement shape
+### Requirement: Floor definitions expose the semantic base-color data used by the terrain slice
 
-The renderer MUST use both object placement data and the object's render definition when constructing a static scene object.
+The render terrain contract MUST make the proven overlay/underlay semantic color inputs required by the representative region available without exposing unexplained obfuscated fields.
 
-#### Scenario: A placed object supports multiple shapes
-- **WHEN** an object placement specifies a shape and rotation
-- **THEN** the renderer MUST select the model group associated with that shape
-- **AND** MUST apply the placement orientation using the documented client-parity rotation semantics
-
-#### Scenario: An object definition transforms its model
-- **WHEN** a selected object render definition contains required static inversion, recolor, retexture, scale, offset or ground-contour data
-- **THEN** those transformations MUST be represented in the server rendering contract and applied before the final object is placed in the scene
-
-### Requirement: Model geometry is exposed without engine coupling
-
-Hagalaz MUST provide decoded model data sufficient for the web renderer to construct static object geometry without exposing browser-engine objects or requiring client cache-format decoding.
-
-#### Scenario: A static model is requested
-- **WHEN** a referenced model is fetched for rendering
-- **THEN** the response MUST preserve the vertex and triangle geometry and the proven face/material inputs required by representative static models
-- **AND** the response MUST NOT depend on Three.js, MapLibre, Babylon or another browser-engine object model
+#### Scenario: A tile references an overlay or underlay
+- **GIVEN** the selected representative region references a decoded floor definition
+- **WHEN** that tile is assembled for the terrain scene
+- **THEN** the renderer MUST obtain the definition's proven base color semantics from the server-side cache projection
+- **AND** MUST NOT substitute a generated placeholder color for data that is available in the cache
 
 ### Requirement: The web scene has one coordinate conversion owner
 
 The web implementation MUST convert RuneScape legacy scene coordinates to browser-renderer coordinates in one scene-assembly boundary.
 
 #### Scenario: A region is assembled for the browser renderer
-- **WHEN** legacy terrain and model data are placed into a browser scene
-- **THEN** the scene MUST use a region-local origin
-- **AND** the conversion MUST consistently map legacy map axes and height to the chosen web axes
-- **AND** terrain and model geometry MUST use one shared scale, initially preserving the legacy 512 scene units per tile
+- **GIVEN** legacy terrain data is returned by the cache service
+- **WHEN** the web scene assembler creates terrain geometry
+- **THEN** it MUST use a region-local scene origin
+- **AND** it MUST consistently map legacy map axes and height to the selected web axes
+- **AND** the initial terrain scale MUST preserve the legacy 512 scene units per tile
 
-### Requirement: The browser renderer is independent from scene semantics
+### Requirement: The browser renderer is independent from terrain semantics
 
-RuneScape terrain/object/model assembly MUST remain project code independent from the selected browser graphics engine, while the engine-specific lifecycle is owned by a small renderer adapter.
+RuneScape terrain assembly MUST remain project code independent from the selected browser graphics engine, while engine-specific lifecycle is owned by a small renderer boundary.
 
-#### Scenario: The first dedicated renderer is introduced
-- **WHEN** a browser graphics dependency is added for the real-region vertical slice
-- **THEN** Angular components MUST NOT directly own cache decoding or triangle construction
-- **AND** engine-specific initialization, resize, render and disposal behavior MUST be isolated from the render-data decoding contract
+#### Scenario: The dedicated browser renderer is introduced
+- **GIVEN** the real-region vertical slice needs a 3D rendering library
+- **WHEN** that dependency is added
+- **THEN** Angular page components MUST NOT own cache decoding or individual triangle construction
+- **AND** engine-specific initialization, resize, render and disposal behavior MUST be isolated from the server terrain contract and coordinate semantics
 
-#### Scenario: MapLibre remains available for geographic overview use
-- **WHEN** the RuneScape 3D scene renderer is implemented
-- **THEN** it MUST NOT depend on MapLibre's geographic camera/custom-layer coordinate model as its core scene representation
+#### Scenario: MapLibre remains installed for other map use cases
+- **GIVEN** MapLibre may be useful for a separate geographic-style overview
+- **WHEN** the RuneScape 3D terrain scene is implemented
+- **THEN** the core scene MUST NOT depend on MapLibre's geographic camera/custom-layer coordinate model
 
-### Requirement: The first web milestone renders real terrain before visual effects
+### Requirement: The first web milestone renders one real terrain region
 
-The first 3D-map vertical slice MUST render one real cache region using authoritative terrain data before multi-region streaming or advanced visual effects are required.
+The first 3D-map vertical slice MUST render one representative cache region from authoritative terrain data before multi-region streaming, object models or advanced visual effects are required.
 
 #### Scenario: The representative region is displayed
-- **WHEN** the Phase 1 viewer is complete
+- **GIVEN** the representative region render contract is available
+- **WHEN** the web terrain viewer loads it
 - **THEN** all four planes MUST be constructible from decoded real heights
-- **AND** floor overlay/underlay shape, rotation and available base material data MUST come from decoded cache semantics rather than generated placeholder data
+- **AND** floor overlay/underlay identity, overlay shape/rotation and available base color data MUST come from decoded cache semantics
+- **AND** no generated placeholder height map MUST be required
 - **AND** the viewer MUST provide diagnostic camera controls and plane visibility controls sufficient to inspect the result
 
 ### Requirement: Rendering correctness is covered below the screenshot level
 
-Decoder, API and scene geometry behavior MUST be verifiable with deterministic automated tests independent from GPU screenshot comparison.
+Decoder, API and scene-geometry behavior MUST be verifiable with deterministic automated tests independent from GPU screenshot comparison.
 
 #### Scenario: Terrain decoding changes
-- **WHEN** terrain decoder behavior is modified
-- **THEN** focused fixtures MUST cover height opcodes, overlay shape/rotation, terrain flags, underlays and plane spacing
+- **GIVEN** the render-focused terrain decoder is modified
+- **WHEN** its focused tests run
+- **THEN** fixtures MUST verify height opcodes, overlay shape/rotation, terrain flags, underlays and plane spacing
 
-#### Scenario: Object/model rendering changes
-- **WHEN** object render definitions or model projection behavior is modified
-- **THEN** tests MUST cover shape-to-model selection and the relevant geometry/transformation invariants before visual-regression screenshots are used as an acceptance signal
+#### Scenario: Web terrain geometry changes
+- **GIVEN** coordinate conversion or terrain mesh generation is modified
+- **WHEN** the pure TypeScript geometry tests run
+- **THEN** they MUST verify coordinate conversion, representative flat/sloped tiles, overlay rotations and edge/corner positions without requiring a browser GPU

--- a/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
@@ -1,0 +1,57 @@
+## 1. Foundation and Client-Parity Reference
+
+- [x] 1.1 Inventory the current `Hagalaz.Web.App` map/rendering implementation and verify whether the installed MapLibre dependency is actively used.
+- [x] 1.2 Trace the authoritative `Hagalaz.GameClient` region, terrain, object, model, scene and graphics-backend paths and separate verified behavior from still-obfuscated details.
+- [x] 1.3 Document region/chunk structure, terrain opcodes, legacy units, height conventions, floor material inputs, object shape-to-model selection and model geometry.
+- [x] 1.4 Document the current Hagalaz cache/service gaps and the target web ownership boundaries, renderer decision and phased milestones.
+
+## 2. Render-Focused Cache Decoding
+
+- [ ] 2.1 Add focused failing tests for terrain opcode 0/1 height semantics, overlay ID/path/rotation, terrain flags, underlay IDs and upper-plane spacing using small deterministic byte fixtures.
+- [ ] 2.2 Introduce a render-focused terrain representation that preserves visible height/floor data without changing the existing gameplay meaning of `IMapType.TerrainData`.
+- [ ] 2.3 Define and test deterministic region-border height handling so adjacent 64×64 terrain meshes can share the correct seam.
+- [ ] 2.4 Add floor overlay and underlay decoders/projections for the semantic fields required by a selected representative region.
+- [ ] 2.5 Add a static model-definition decoder/projection covering vertices, triangle indices, colors/alpha and the texture mapping data required by representative models.
+- [ ] 2.6 Add a separate object render-definition projection containing shape-to-model groups plus required static recolor/retexture/scale/offset/contour metadata.
+- [ ] 2.7 Add client-parity tests for object shape selection, transforms, representative model bounds/counts and dynamic 8×8 chunk rotations.
+
+## 3. Cache-Service Rendering Contracts
+
+- [ ] 3.1 Define bounded region-render DTOs/endpoints that expose four planes of terrain input plus object placements without requiring raw cache decoding in the browser.
+- [ ] 3.2 Define bounded object-render-definition and model-mesh endpoints/DTOs.
+- [ ] 3.3 Define floor material/texture delivery endpoints required by the representative region; do not expose unexplained obfuscated fields.
+- [ ] 3.4 Add API validation/contract tests, including invalid IDs, XTEA requirements, response bounds and representative payload completeness.
+- [ ] 3.5 Record representative response sizes and latency before selecting JSON versus a more compact mesh transport.
+
+## 4. Single-Region Web Vertical Slice
+
+- [ ] 4.1 Add the dedicated 3D rendering dependency in the implementation change that consumes it; Three.js is the current recommended choice and the dependency justification must be recorded there.
+- [ ] 4.2 Add a map route/page plus a minimal render-data service, scene assembler and renderer adapter; avoid empty speculative abstractions.
+- [ ] 4.3 Implement one coordinate conversion owner using a region-local scene origin and 512 legacy units per tile.
+- [ ] 4.4 Build real four-plane terrain meshes from the render-region contract, including correct heights and overlay shape/rotation.
+- [ ] 4.5 Resolve decoded floor colors/material inputs for the representative region without placeholder height/material generation.
+- [ ] 4.6 Add diagnostic orbit/pan/zoom controls, focus/reset and per-plane visibility controls.
+- [ ] 4.7 Add pure TypeScript geometry tests for coordinate conversion, flat/sloped tiles, overlay rotations and region-edge coordinates.
+
+## 5. Static Object Rendering
+
+- [ ] 5.1 Select model groups from the object placement shape and fetch/reuse required model meshes.
+- [ ] 5.2 Apply model combination, inversion, placement rotation, definition scale/offset, recolor/retexture and required ground contouring.
+- [ ] 5.3 Render representative walls, decorations, standard objects and floor decorations at verified locations/orientations.
+- [ ] 5.4 Add object picking/inspection that exposes object ID, shape, rotation and local/world coordinates for debugging.
+- [ ] 5.5 Add deterministic object geometry/placement tests before adding screenshot regression coverage.
+
+## 6. Multi-Region and Fidelity Follow-ups
+
+- [ ] 6.1 Add adjacent-region loading and verify height/material seams and resource cleanup.
+- [ ] 6.2 Add dynamic 8×8 region-part assembly if required by the viewer workflow, using the same tested rotation semantics as the cache/client path.
+- [ ] 6.3 Profile representative dense scenes and record payload, assembly, draw-call, frame-time and unload-memory measurements before adding batching/instancing/workers/persistent browser caching.
+- [ ] 6.4 Investigate and add decoded textures, then only the material/shader behavior proven necessary by fidelity tests.
+- [ ] 6.5 Investigate roof hiding, occlusion, atmosphere/skybox/fog, lighting/shadows and water as independent fidelity increments.
+- [ ] 6.6 Treat animation/transformed live entities as optional later scope rather than a prerequisite for the static map viewer.
+
+## 7. Documentation and Verification
+
+- [ ] 7.1 Keep `docs/3d-rendering/game-client-renderer.md` updated whenever relevant GameClient classes are deobfuscated or a documented inference becomes verified.
+- [ ] 7.2 Record texture/material and roof/occlusion/camera findings before adding their semantics to stable render DTOs.
+- [ ] 7.3 For each implementation phase, run focused decoder/API/web tests, relevant project tests/builds, strict OpenSpec validation and `git diff --check`.

--- a/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
@@ -6,6 +6,7 @@
 - [x] 1.4 Document the current Hagalaz gaps, target ownership boundaries, renderer decision and explicitly separated follow-up milestones.
 - [x] 1.5 Document byte-level map decode/encode behavior: cache-container versus payload boundaries, `mX_Y` terrain, `lX_Y` object delta coding, smart/huge-smart integers, XTEA, source/effective plane handling, canonical encoding, corruption guards, write-back order and round-trip fixtures.
 - [x] 1.6 Record known encoder hazards that must not be treated as cache-faithful behavior: the synthetic `MapCodec` length prefix, bridge-adjusted source-plane loss, unsorted per-object location deltas, `WriteHugeSmart` boundary behavior and the missing XTEA-aware cache writer.
+- [x] 1.7 Deobfuscate the rendering documentation vocabulary: define evidence-backed semantic names for terrain, scene graph, tiles, floor definitions, occlusion, scene entities, lights and model members; keep generated GameClient identifiers only in one source-locator map and track source-level renaming separately in `Hagalaz.GameClient`.
 
 ## 2. Render-Focused Terrain Decoding
 
@@ -41,3 +42,4 @@
 - [ ] 5.4 Run the relevant solution/project build, strict OpenSpec validation and `git diff --check`.
 - [ ] 5.5 If implementation requires object/model rendering, decoded textures/shaders, multi-region streaming, dynamic-map assembly, live entities or a second cache/state owner, stop and create a separate OpenSpec change instead of expanding this one.
 - [ ] 5.6 Do not claim cache write/round-trip support from the existing reduced `MapCodec` tests. Any future mutation milestone must separately prove payload encode/decode parity, XTEA-aware persisted writes and read-back validation against a disposable cache fixture.
+- [ ] 5.7 New Hagalaz server/web rendering types MUST use semantic domain names from the deobfuscation map and MUST NOT introduce generated GameClient identifiers into DTOs, APIs, services or TypeScript architecture.

--- a/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
@@ -1,57 +1,40 @@
 ## 1. Foundation and Client-Parity Reference
 
 - [x] 1.1 Inventory the current `Hagalaz.Web.App` map/rendering implementation and verify whether the installed MapLibre dependency is actively used.
-- [x] 1.2 Trace the authoritative `Hagalaz.GameClient` region, terrain, object, model, scene and graphics-backend paths and separate verified behavior from still-obfuscated details.
-- [x] 1.3 Document region/chunk structure, terrain opcodes, legacy units, height conventions, floor material inputs, object shape-to-model selection and model geometry.
-- [x] 1.4 Document the current Hagalaz cache/service gaps and the target web ownership boundaries, renderer decision and phased milestones.
+- [x] 1.2 Trace the authoritative `Hagalaz.GameClient` region, terrain, object, model, scene and graphics-backend paths, separating verified behavior from still-obfuscated details.
+- [x] 1.3 Document region/chunk structure, terrain opcodes, legacy units, floor material inputs and the broader object/model requirements that future changes will need.
+- [x] 1.4 Document the current Hagalaz gaps, target ownership boundaries, renderer decision and explicitly separated follow-up milestones.
 
-## 2. Render-Focused Cache Decoding
+## 2. Render-Focused Terrain Decoding
 
-- [ ] 2.1 Add focused failing tests for terrain opcode 0/1 height semantics, overlay ID/path/rotation, terrain flags, underlay IDs and upper-plane spacing using small deterministic byte fixtures.
-- [ ] 2.2 Introduce a render-focused terrain representation that preserves visible height/floor data without changing the existing gameplay meaning of `IMapType.TerrainData`.
-- [ ] 2.3 Define and test deterministic region-border height handling so adjacent 64×64 terrain meshes can share the correct seam.
-- [ ] 2.4 Add floor overlay and underlay decoders/projections for the semantic fields required by a selected representative region.
-- [ ] 2.5 Add a static model-definition decoder/projection covering vertices, triangle indices, colors/alpha and the texture mapping data required by representative models.
-- [ ] 2.6 Add a separate object render-definition projection containing shape-to-model groups plus required static recolor/retexture/scale/offset/contour metadata.
-- [ ] 2.7 Add client-parity tests for object shape selection, transforms, representative model bounds/counts and dynamic 8×8 chunk rotations.
+- [ ] 2.1 Add focused failing tests for terrain opcode `0`/`1` height semantics, overlay ID/path/rotation, terrain flags, underlay IDs and upper-plane spacing using deterministic byte fixtures.
+- [ ] 2.2 Introduce a render-focused terrain representation that preserves visible terrain data without changing the gameplay meaning of `IMapType.TerrainData`.
+- [ ] 2.3 Reuse/factor the existing terrain-flag opcode logic so gameplay and render projections do not maintain conflicting copies of the same decode semantics.
+- [ ] 2.4 Define and test deterministic far-edge/border heights suitable for a 64×64 region mesh, using an adjacent-region fixture to prevent seam-by-placeholder behavior.
+- [ ] 2.5 Decode/project the minimum overlay and underlay semantic color fields required by the selected representative region; retain texture identity only as future-compatible data rather than expanding into texture rendering.
 
-## 3. Cache-Service Rendering Contracts
+## 3. Cache-Service Region Contract
 
-- [ ] 3.1 Define bounded region-render DTOs/endpoints that expose four planes of terrain input plus object placements without requiring raw cache decoding in the browser.
-- [ ] 3.2 Define bounded object-render-definition and model-mesh endpoints/DTOs.
-- [ ] 3.3 Define floor material/texture delivery endpoints required by the representative region; do not expose unexplained obfuscated fields.
-- [ ] 3.4 Add API validation/contract tests, including invalid IDs, XTEA requirements, response bounds and representative payload completeness.
-- [ ] 3.5 Record representative response sizes and latency before selecting JSON versus a more compact mesh transport.
+- [ ] 3.1 Select and record a representative region with non-flat terrain and multiple floor IDs/shapes/rotations.
+- [ ] 3.2 Define one bounded render-region DTO/endpoint exposing four planes of real terrain input without raw cache bytes or an unbounded map operation.
+- [ ] 3.3 Keep existing gameplay map endpoint semantics compatible unless a backward-compatible extension is demonstrably simpler than a separate render route.
+- [ ] 3.4 Add API validation/contract tests for invalid region input, XTEA handling where applicable, complete terrain semantics and the absence of invented flat fallback data.
+- [ ] 3.5 Measure and record the representative JSON payload size/latency; keep straightforward semantic JSON unless that measurement proves it inadequate.
 
 ## 4. Single-Region Web Vertical Slice
 
-- [ ] 4.1 Add the dedicated 3D rendering dependency in the implementation change that consumes it; Three.js is the current recommended choice and the dependency justification must be recorded there.
-- [ ] 4.2 Add a map route/page plus a minimal render-data service, scene assembler and renderer adapter; avoid empty speculative abstractions.
-- [ ] 4.3 Implement one coordinate conversion owner using a region-local scene origin and 512 legacy units per tile.
-- [ ] 4.4 Build real four-plane terrain meshes from the render-region contract, including correct heights and overlay shape/rotation.
-- [ ] 4.5 Resolve decoded floor colors/material inputs for the representative region without placeholder height/material generation.
-- [ ] 4.6 Add diagnostic orbit/pan/zoom controls, focus/reset and per-plane visibility controls.
-- [ ] 4.7 Add pure TypeScript geometry tests for coordinate conversion, flat/sloped tiles, overlay rotations and region-edge coordinates.
+- [ ] 4.1 Add the dedicated 3D rendering dependency in the implementation commit that consumes it; Three.js is the recommended choice and the dependency justification must be recorded.
+- [ ] 4.2 Add one map route/page plus only the render-data service, scene assembler, terrain builder and renderer boundary required by the vertical slice.
+- [ ] 4.3 Implement one coordinate-conversion owner using a region-local scene origin and 512 legacy units per tile.
+- [ ] 4.4 Build all four terrain planes from real decoded height data, including deterministic region-edge coordinates.
+- [ ] 4.5 Apply overlay/underlay base colors plus overlay shape/rotation from decoded semantic data; do not generate placeholder height/material data.
+- [ ] 4.6 Add diagnostic orbit/pan/zoom, focus/reset and per-plane visibility controls.
+- [ ] 4.7 Add pure TypeScript tests for coordinate conversion, flat/sloped terrain, overlay rotations and edge/corner geometry without requiring a GPU.
 
-## 5. Static Object Rendering
+## 5. Verification and Scope Gate
 
-- [ ] 5.1 Select model groups from the object placement shape and fetch/reuse required model meshes.
-- [ ] 5.2 Apply model combination, inversion, placement rotation, definition scale/offset, recolor/retexture and required ground contouring.
-- [ ] 5.3 Render representative walls, decorations, standard objects and floor decorations at verified locations/orientations.
-- [ ] 5.4 Add object picking/inspection that exposes object ID, shape, rotation and local/world coordinates for debugging.
-- [ ] 5.5 Add deterministic object geometry/placement tests before adding screenshot regression coverage.
-
-## 6. Multi-Region and Fidelity Follow-ups
-
-- [ ] 6.1 Add adjacent-region loading and verify height/material seams and resource cleanup.
-- [ ] 6.2 Add dynamic 8×8 region-part assembly if required by the viewer workflow, using the same tested rotation semantics as the cache/client path.
-- [ ] 6.3 Profile representative dense scenes and record payload, assembly, draw-call, frame-time and unload-memory measurements before adding batching/instancing/workers/persistent browser caching.
-- [ ] 6.4 Investigate and add decoded textures, then only the material/shader behavior proven necessary by fidelity tests.
-- [ ] 6.5 Investigate roof hiding, occlusion, atmosphere/skybox/fog, lighting/shadows and water as independent fidelity increments.
-- [ ] 6.6 Treat animation/transformed live entities as optional later scope rather than a prerequisite for the static map viewer.
-
-## 7. Documentation and Verification
-
-- [ ] 7.1 Keep `docs/3d-rendering/game-client-renderer.md` updated whenever relevant GameClient classes are deobfuscated or a documented inference becomes verified.
-- [ ] 7.2 Record texture/material and roof/occlusion/camera findings before adding their semantics to stable render DTOs.
-- [ ] 7.3 For each implementation phase, run focused decoder/API/web tests, relevant project tests/builds, strict OpenSpec validation and `git diff --check`.
+- [ ] 5.1 Verify targeted cache decoder tests and region-render API contract tests.
+- [ ] 5.2 Verify focused web geometry tests and the relevant Angular build/tests.
+- [ ] 5.3 Inspect the representative region in the browser and add screenshot regression only if the render output is deterministic enough to be useful.
+- [ ] 5.4 Run the relevant solution/project build, strict OpenSpec validation and `git diff --check`.
+- [ ] 5.5 If implementation requires object/model rendering, decoded textures/shaders, multi-region streaming, dynamic-map assembly, live entities or a second cache/state owner, stop and create a separate OpenSpec change instead of expanding this one.

--- a/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
+++ b/openspec/changes/establish-web-3d-rendering-foundation/tasks.md
@@ -4,11 +4,13 @@
 - [x] 1.2 Trace the authoritative `Hagalaz.GameClient` region, terrain, object, model, scene and graphics-backend paths, separating verified behavior from still-obfuscated details.
 - [x] 1.3 Document region/chunk structure, terrain opcodes, legacy units, floor material inputs and the broader object/model requirements that future changes will need.
 - [x] 1.4 Document the current Hagalaz gaps, target ownership boundaries, renderer decision and explicitly separated follow-up milestones.
+- [x] 1.5 Document byte-level map decode/encode behavior: cache-container versus payload boundaries, `mX_Y` terrain, `lX_Y` object delta coding, smart/huge-smart integers, XTEA, source/effective plane handling, canonical encoding, corruption guards, write-back order and round-trip fixtures.
+- [x] 1.6 Record known encoder hazards that must not be treated as cache-faithful behavior: the synthetic `MapCodec` length prefix, bridge-adjusted source-plane loss, unsorted per-object location deltas, `WriteHugeSmart` boundary behavior and the missing XTEA-aware cache writer.
 
 ## 2. Render-Focused Terrain Decoding
 
 - [ ] 2.1 Add focused failing tests for terrain opcode `0`/`1` height semantics, overlay ID/path/rotation, terrain flags, underlay IDs and upper-plane spacing using deterministic byte fixtures.
-- [ ] 2.2 Introduce a render-focused terrain representation that preserves visible terrain data without changing the gameplay meaning of `IMapType.TerrainData`.
+- [ ] 2.2 Introduce a render-focused terrain representation that preserves visible terrain data without changing the gameplay meaning of `IMapType.TerrainData`; preserve source encoding information needed for later safe semantic re-encoding rather than retaining only derived values.
 - [ ] 2.3 Reuse/factor the existing terrain-flag opcode logic so gameplay and render projections do not maintain conflicting copies of the same decode semantics.
 - [ ] 2.4 Define and test deterministic far-edge/border heights suitable for a 64×64 region mesh, using an adjacent-region fixture to prevent seam-by-placeholder behavior.
 - [ ] 2.5 Decode/project the minimum overlay and underlay semantic color fields required by the selected representative region; retain texture identity only as future-compatible data rather than expanding into texture rendering.
@@ -38,3 +40,4 @@
 - [ ] 5.3 Inspect the representative region in the browser and add screenshot regression only if the render output is deterministic enough to be useful.
 - [ ] 5.4 Run the relevant solution/project build, strict OpenSpec validation and `git diff --check`.
 - [ ] 5.5 If implementation requires object/model rendering, decoded textures/shaders, multi-region streaming, dynamic-map assembly, live entities or a second cache/state owner, stop and create a separate OpenSpec change instead of expanding this one.
+- [ ] 5.6 Do not claim cache write/round-trip support from the existing reduced `MapCodec` tests. Any future mutation milestone must separately prove payload encode/decode parity, XTEA-aware persisted writes and read-back validation against a disposable cache fixture.


### PR DESCRIPTION
## Summary

Establishes the technical foundation for rendering real RuneScape map terrain in `Hagalaz.Web.App`, preserves the reverse-engineering findings from `Hagalaz.GameClient`, documents the actual map decode/encode formats, and replaces generated GameClient names in the architecture with evidence-backed semantic names.

### Main findings

- `Hagalaz.Web.App` has `maplibre-gl` installed but no active 3D scene feature on `main`.
- The current `MapCodec` is gameplay-oriented: it consumes rendering data but retains only terrain flags plus object placements.
- The current cache-service map response does not expose terrain data.
- The game client builds terrain from heights + overlays + underlays + shapes + rotations + flags and uses 512 scene units per tile.
- Static object fidelity later requires shape-to-model selection, real model geometry, recolor/retexture, scale/offset, contouring and related render-definition semantics.

## Deobfuscation foundation

The renderer documentation no longer treats names such as `Class274`, `Class356`, `Class491`, `Class_xa` or `Entity_Sub1_Sub*` as architecture.

The first local reverse-engineering pass established responsibilities from construction/data flow/call sites. A subsequent public-source triangulation found `LostCityRS/RS742`, a heavily refactored 742.1 client that `Avexiis/RSPSi-742` explicitly credits as its deobfuscated 742 reference. Where the local class structure matches, this gives stronger revision-specific names than the initial generic aliases.

Examples now recorded in the foundation include:

- `Class274` -> `MapLoader`;
- current `Map` -> `ClientMapLoader`;
- `Class356` -> `Scene`;
- `Class340` -> `Tile`;
- `Class_xa` -> `FloorModel`;
- `GraphicsToolkit` -> `RendererToolkit`;
- `Entity_Sub1` -> `GraphEntity`;
- `Entity_Sub1_Sub1` -> `PrimaryLayerEntity`;
- `Entity_Sub1_Sub2` -> `ObjLayerEntity`;
- wall/wall-decoration/ground-decoration layer entity names;
- `Class80` -> `ScreenBoundingBox`;
- `Class348` -> `EntityBounds`;
- `Class338` -> `PickableEntityList`;
- `Class353` -> `PickableEntity`;
- `Node_Sub14` -> `Light`;
- `MapFlickeringEffect` -> `StaticPointLight`;
- floor cache records using `FloorUnderlayType` / `FloorOverlayType` and `*TypeList` terminology;
- `Class512` / `Class519` -> `LightType` / `LightTypeList`;
- local `ModelDefinition` structurally corresponding to the reference `ModelUnlit`, pending the final source-level rename decision.

The public reference also identifies renderer concepts such as `PureJavaToolkit`, `SoftwareToolkit`, `GlToolkit`, `GlxToolkit`, `DxToolkit` and shared `GpuToolkit`, allowing future GameClient cleanup to avoid numeric `GraphicsToolkit_Sub*` names.

The revision caveat is explicit: LostCity documents its client as **742.1**, while the historically circulated client was **742.2** and packet read/write alternative methods differ. External sources are therefore used for semantic/structural naming only after local verification; their protocol byte operations are not copied blindly.

`docs/3d-rendering/client-rendering-deobfuscation.md` retains the local source-locator/evidence map, while `docs/3d-rendering/external-742-reference.md` records the stronger public cross-check, superseded aliases, source hierarchy, backend vocabulary and evidence policy.

Generated source identifiers remain temporary source locators only. New Hagalaz DTOs/APIs/services/TypeScript types are explicitly required by OpenSpec to use semantic names.

Source-level mechanical renaming in the Java client is coordinated through `frankvdb7/Hagalaz.GameClient#141`, with the actual work owned by the existing subsystem issues rather than duplicate tickets.

## Decode / encode reference

The foundation documents the byte-level map formats and the boundaries that must remain separate:

- Real index-5 region files are separate `m{regionX}_{regionY}` terrain and `l{regionX}_{regionY}` location files. The current `MapCodec` four-byte terrain-length prefix is Hagalaz-internal and must never be written as either cache file.
- Terrain decode/encode covers exact opcode `0`/`1` height rules, overlays, shape/rotation, flags and underlays.
- Plane-0 opcode-`0` height generation is traced through deterministic integer noise, smoothing, cosine interpolation, the 16,384-entry lookup table and final `-32` scene-height scaling.
- `lX_Y` location data is documented as object-ID huge-smart deltas plus packed-location smart deltas, including canonical sort order.
- Raw `SourcePlane` and bridge-adjusted `EffectivePlane` are separate so bridged objects remain round-trip safe.
- `ReadSmart` / `ReadHugeSmart` and the correct inverse writer are documented; the current `WriteHugeSmart` requires boundary correction/tests before arbitrary deltas are trusted.
- XTEA belongs at the encoded container boundary before decompression. Current cache writing has no symmetric XTEA-aware path, so encrypted `lX_Y` mutation is explicitly not claimed as supported.
- Persisted encrypted writes must calculate CRC/Whirlpool from the final encrypted bytes and read back/verify the result.
- Semantic round-trip and byte-identical round-trip are deliberately distinguished.
- Both legacy and newer model binary formats are recorded, but no unverified model encoder is invented.

## Documentation

`docs/3d-rendering/` contains:

- `README.md` — entry point, terminology, naming/evidence rules and foundation rules;
- `client-rendering-deobfuscation.md` — local semantic/source-locator map with confidence and evidence;
- `external-742-reference.md` — public 742 cross-check, revision caveats, stronger class names, entity hierarchy, toolkit backends and secondary sources;
- `game-client-renderer.md` — verified renderer architecture and behavior;
- `cache-map-codecs.md` — terrain/location/container decode and semantic encode guide, XTEA/write-back rules, corruption guards and fixture matrix;
- `terrain-height-generation.md` — exact opcode-`0` implicit height algorithm with parity-test instructions;
- `web-renderer-foundation.md` — Hagalaz gap analysis, target contracts, ownership, renderer choice, performance/test strategy and phased follow-ups.

## OpenSpec

`establish-web-3d-rendering-foundation` remains deliberately scoped to one concrete implementation goal:

1. preserve authoritative render-focused terrain semantics server-side without discarding source information needed for later safe encoding;
2. expose one bounded region-render contract;
3. render one real 64x64 four-plane region in Angular through one coordinate-conversion owner and a small renderer boundary.

Static object/model rendering, texture/shader fidelity, multi-region streaming, dynamic maps, atmosphere/occlusion, live entities, production map mutation/write-back and completing the full GameClient source deobfuscation remain explicit follow-up work.

Three.js is the recommended dedicated renderer for the first implementation slice; this documentation PR does not add the dependency.

## Validation

- Local analysis is grounded in `Hagalaz/main@ba134cbcd531a6cd3b35c19b20404084e926bbfc` and `Hagalaz.GameClient/main@6eac3762cc46cec484131369691b5221fd1277bf`.
- Renderer class names were derived from local construction, ownership and placement call sites before external triangulation.
- Stronger revision-specific names were then structurally compared against `LostCityRS/RS742`; exact matches such as local `Class_xa` / reference obfuscated `xa` (`FloorModel`) and local `Class_ra` / reference `ra` (`RendererToolkit`) provide particularly strong corroboration.
- `2011Scape/2011scape-client` is documented only as a secondary terminology source because it targets revision 667, despite its stated use of Jagex/canonical naming where available.
- `RSPSi-742` is treated as an experimental map-editor implementation and secondary edge-case source, not as the authoritative binary-format specification.
- Terrain height/opcode behavior, smart/location packing, model-format selection and renderer structure remain cross-checked against the local client source.
- The active OpenSpec still has one concrete terrain vertical-slice goal.
- No runtime code or dependencies are changed by this PR, so application/build tests were not run.