### PR TITLE
Remove obsolete script and combat model APIs

### DIFF
--- a/Hagalaz.Game.Abstractions/Model/Creatures/Npcs/INpcScript.cs
+++ b/Hagalaz.Game.Abstractions/Model/Creatures/Npcs/INpcScript.cs
@@ -1,4 +1,3 @@
-using System;
 using Hagalaz.Game.Abstractions.Model.Combat;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Items;
@@ -11,13 +10,6 @@ namespace Hagalaz.Game.Abstractions.Model.Creatures.Npcs
     /// </summary>
     public interface INpcScript : ICreatureScript
     {
-        /// <summary>
-        /// Gets the NPC IDs that this script is suitable for.
-        /// </summary>
-        /// <returns>An array of NPC IDs.</returns>
-        [Obsolete("Please use NpcScriptMetaData attribute instead")]
-        int[] GetSuitableNpcs();
-
         /// <summary>
         /// Gets the pathfinder the NPC will use.
         /// </summary>

--- a/Hagalaz.Game.Abstractions/Model/GameObjects/IGameObjectScript.cs
+++ b/Hagalaz.Game.Abstractions/Model/GameObjects/IGameObjectScript.cs
@@ -1,4 +1,3 @@
-using System;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Items;
@@ -10,13 +9,6 @@ namespace Hagalaz.Game.Abstractions.Model.GameObjects
     /// </summary>
     public interface IGameObjectScript
     {
-        /// <summary>
-        /// Gets the object IDs that this script is suitable for.
-        /// </summary>
-        /// <returns>An array of object IDs.</returns>
-        [Obsolete("Please use GameObjectScriptMetaData attribute instead")]
-        int[] GetSuitableObjects();
-
         /// <summary>
         /// Initializes the script with its owning game object.
         /// </summary>

--- a/Hagalaz.Game.Scripts/Model/Creatures/Npcs/NpcScriptBase.cs
+++ b/Hagalaz.Game.Scripts/Model/Creatures/Npcs/NpcScriptBase.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System;
 using Hagalaz.Game.Abstractions.Authorization;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
 using Hagalaz.Game.Abstractions.Model;
@@ -28,14 +27,6 @@ namespace Hagalaz.Game.Scripts.Model.Creatures.Npcs
         /// </summary>
         /// <value>The owner.</value>
         protected INpc Owner;
-
-        /// <summary>
-        /// <summary>
-        /// Get's npcIDS which are suitable for this script.
-        /// </summary>
-        /// <returns>System.Int32[][].</returns>
-        [Obsolete("Use an NpcScriptFactory or NpcScriptMetaData instead")]
-        public virtual int[] GetSuitableNpcs() => [];
 
         /// <summary>
         /// Get's called when owner is found.

--- a/Hagalaz.Game.Scripts/Model/GameObjects/GameObjectScript.cs
+++ b/Hagalaz.Game.Scripts/Model/GameObjects/GameObjectScript.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using Hagalaz.Game.Abstractions.Authorization;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
@@ -20,13 +19,6 @@ namespace Hagalaz.Game.Scripts.Model.GameObjects
         /// Contains owner object.
         /// </summary>
         protected IGameObject Owner { get; private set; } = default!;
-
-        /// <summary>
-        /// Get's objectIDS which are suitable for this script.
-        /// </summary>
-        /// <returns></returns>
-        [Obsolete("Use the GameObjectScriptMetadata attribute instead")]
-        public virtual int[] GetSuitableObjects() => [];
 
         /// <summary>
         /// Get's called when owner is found.

--- a/Hagalaz.Game.Scripts/Skills/Thieving/PickPockatableNPC.rsnpc.cs
+++ b/Hagalaz.Game.Scripts/Skills/Thieving/PickPockatableNPC.rsnpc.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
 using Hagalaz.Game.Scripts.Model.Creatures.Npcs;
@@ -7,6 +6,26 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
 {
     /// <summary>
     /// </summary>
+    [NpcScriptMetaData([
+        1, 2, 3, 4, 5, 6, 16, 24, 170,
+        7, 1757, 1758, 1760,
+        1715,
+        1714, 1716,
+        1710, 1711, 1712,
+        15, 18,
+        187, 2267, 2268, 2269, 8122,
+        5752, 5753, 5754, 5755, 5756, 5757, 5758, 5759, 5760, 5761, 5762, 5763, 5764, 5765, 5766, 5767,
+        2234, 2235,
+        9, 32, 206, 296, 297, 298, 299, 344, 346, 368, 678, 812, 3228, 3229, 3230, 3231, 3407, 3408,
+        2462,
+        23, 26,
+        1905,
+        20, 2256,
+        13195, 13212, 13213,
+        66, 67, 68, 168, 169, 2249, 2250, 2251, 2371, 2649, 2650, 6002, 6004,
+        21,
+        2109, 2110, 2111, 2112, 2113, 2114, 2115, 2116, 2117, 2118, 2119, 2120, 2121, 2122, 2123, 2124, 2125, 2126
+    ])]
     public class PickPockatableNpc : NpcScriptBase
     {
         /// <summary>
@@ -31,24 +50,6 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
             }
 
             base.OnCharacterClickPerform(clicker, clickType);
-        }
-
-        /// <summary>
-        ///     Get's npcIDS which are suitable for this script.
-        /// </summary>
-        /// <returns>
-        ///     System.Int32[][].
-        /// </returns>
-        public override int[] GetSuitableNpcs()
-        {
-            var npcs = new List<int>();
-            foreach (var def in Thieving.Ppd)
-            foreach (var npcId in def.NpcIDs)
-            {
-                npcs.Add(npcId);
-            }
-
-            return npcs.ToArray();
         }
 
         /// <summary>

--- a/Hagalaz.Game.Scripts/Skills/Thieving/Stall.rsobj.cs
+++ b/Hagalaz.Game.Scripts/Skills/Thieving/Stall.rsobj.cs
@@ -10,6 +10,7 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
 {
     /// <summary>
     /// </summary>
+    [GameObjectScriptMetaData([4706, 4708, 34384, 34383, 14011, 34387, 34382, 34386, 4111, 4116, 4121, 4126, 59731])]
     public class Stall : GameObjectScript
     {
         private readonly IMapRegionService _mapRegionService;
@@ -52,17 +53,6 @@ namespace Hagalaz.Game.Scripts.Skills.Thieving
             }
 
             base.OnCharacterClickPerform(clicker, clickType);
-        }
-
-        /// <summary>
-        ///     Get's objectIDS which are suitable for this script.
-        /// </summary>
-        /// <returns></returns>
-        public override int[] GetSuitableObjects()
-        {
-            var objects = new List<int>();
-            objects.AddRange(Thieving.Sd.SelectMany(sd => sd.GameObjectIDs));
-            return objects.ToArray();
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Factories/NpcScriptMetaDataFactory.cs
+++ b/Hagalaz.Services.GameWorld/Factories/NpcScriptMetaDataFactory.cs
@@ -8,19 +8,16 @@ using System.Threading.Tasks;
 using Hagalaz.Game.Abstractions.Factories;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
 using Hagalaz.Services.GameWorld.Providers;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Factories
 {
     public class NpcScriptMetaDataFactory : INpcScriptFactory
     {
         private readonly IServiceDescriptorProvider _serviceDescriptorProvider;
-        private readonly IServiceProvider _serviceProvider;
 
-        public NpcScriptMetaDataFactory(IServiceDescriptorProvider serviceDescriptorProvider, IServiceProvider serviceProvider)
+        public NpcScriptMetaDataFactory(IServiceDescriptorProvider serviceDescriptorProvider)
         {
             _serviceDescriptorProvider = serviceDescriptorProvider;
-            _serviceProvider = serviceProvider;
         }
 
         public async IAsyncEnumerable<(int npcId, Type scriptType)> GetScripts([EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -38,22 +35,14 @@ namespace Hagalaz.Services.GameWorld.Factories
                     continue;
                 }
 
-                if (metaData is not null)
+                if (metaData is null)
                 {
-                    foreach (var npcId in metaData.NpcIds)
-                    {
-                        yield return (npcId, scriptType);
-                    }
+                    continue;
                 }
-                else
+
+                foreach (var npcId in metaData.NpcIds)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    var script = (INpcScript)_serviceProvider.GetRequiredService(scriptType);
-                    foreach (var npcId in script.GetSuitableNpcs())
-                    {
-                        yield return (npcId, scriptType);
-                    }
-#pragma warning restore CS0618 // Type or member is obsolete
+                    yield return (npcId, scriptType);
                 }
             }
         }

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Combat/HitSplat.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Combat/HitSplat.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Combat;
 
@@ -50,63 +49,6 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Combat
         /// </summary>
         public int Delay { get; init; }
 
-        public HitSplat() { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HitSplat" /> class.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        [Obsolete("Use the IHitSplatBuilder instead")]
-        public HitSplat(IRuneObject? sender) => Sender = sender;
-
-        /// <summary>
-        /// Set's first splat in this hitsplat.
-        /// </summary>
-        /// <param name="type">Type of the hitsplat.</param>
-        /// <param name="damage">Damage of the hitsplat.</param>  
-        /// <param name="golden">Wheter hit is golden.</param>
-        /// <returns></returns>
-        public HitSplat SetFirstSplat(HitSplatType type, int damage, bool golden)
-        {
-            FirstSplatType = type;
-            FirstSplatDamage = damage;
-            FirstSplatCritical = golden;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the first splat.
-        /// If the damage is 90% of the max damage, the splat is golden.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <param name="damage">The damage.</param>
-        /// <param name="maxDamage">The maximum damage.</param>
-        /// <returns></returns>
-        public HitSplat SetFirstSplat(HitSplatType type, int damage, int maxDamage) => SetFirstSplat(type, damage, maxDamage <= damage * 0.9);
-
-        /// <summary>
-        /// Set's second splat in this hitsplat.
-        /// </summary>
-        /// <param name="type">Type of the hitsplat.</param>
-        /// <param name="damage">Damage of the hitsplat.</param>
-        /// <param name="golden">Wheter hit is golden.</param>
-        /// <returns></returns>
-        public HitSplat SetSecondSplat(HitSplatType type, int damage, bool golden)
-        {
-            SecondSplatType = type;
-            SecondSplatDamage = damage;
-            SecondSplatCritical = golden;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the second splat.
-        /// If the damage is 90% of the max damage, the splat is golden.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <param name="damage">The damage.</param>
-        /// <param name="maxDamage">The maximum damage.</param>
-        /// <returns></returns>
-        public HitSplat SetSecondSplat(HitSplatType type, int damage, int maxDamage) => SetSecondSplat(type, damage, maxDamage <= damage * 0.9);
+        internal HitSplat() { }
     }
 }

--- a/Hagalaz.Services.GameWorld/Model/Projectile.cs
+++ b/Hagalaz.Services.GameWorld/Model/Projectile.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 
@@ -109,7 +108,6 @@ namespace Hagalaz.Services.GameWorld.Model
         /// Construct's new projectile.
         /// </summary>
         /// <param name="graphicID">Id of the graphic projectile should be displaying.</param>
-        [Obsolete("Use the IProjectileBuilder instead")]
-        public Projectile(int graphicID) => GraphicId = graphicID;
+        internal Projectile(int graphicID) => GraphicId = graphicID;
     }
 }


### PR DESCRIPTION
## Summary
- Replace legacy NPC and game-object script ID methods with metadata attributes
- Make NPC script discovery metadata-only
- Remove obsolete HitSplat mutators and public Projectile constructor

## Testing
- Not run (not requested)