### PR TITLE
Harden handshake payload validation and cleanup for issue #348

### DIFF
--- a/Hagalaz.Services.GameWorld.Tests/HandshakeDecoderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/HandshakeDecoderTests.cs
@@ -1,11 +1,18 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Numerics;
+using System.Text;
+using Hagalaz.Cache.Abstractions;
+using Hagalaz.Security;
+using Hagalaz.Services.GameWorld.Configuration.Model;
 using Hagalaz.Services.GameWorld.Network.Handshake.Decoders;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 
 namespace Hagalaz.Services.GameWorld.Tests
 {
     [TestClass]
-    public class HandshakeDecoderTests
+    public sealed class HandshakeDecoderTests
     {
         [TestMethod]
         public void TryParseRsaHeader_ValidData_ReturnsTrue()
@@ -62,6 +69,303 @@ namespace Hagalaz.Services.GameWorld.Tests
             // Assert
             Assert.IsFalse(result);
             Assert.AreEqual(BigInteger.MinusOne, rsaBigInteger);
+        }
+
+        [TestMethod]
+        public void TryParsePacketHeader_TrailingBytesAfterDeclaredPayload_ReturnsFalse()
+        {
+            var input = new byte[]
+            {
+                0, 8,
+                0, 0, 0, 1,
+                0, 0, 0, 2,
+                0x7F
+            };
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(input));
+
+            var result = HandshakeDecoderHelper.TryParsePacketHeader(ref reader, out _, out _);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void TryParseXteaBlock_MultiSegmentInput_ParsesExactDecryptedPayload()
+        {
+            var keys = new uint[] { 1, 2, 3, 4 };
+            var plaintext = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var encrypted = new byte[plaintext.Length];
+            XTEA.Encrypt(plaintext, encrypted, keys);
+            var input = CreateSequence(encrypted[..3], encrypted[3..]);
+            var reader = new SequenceReader<byte>(input);
+            byte[]? parsedPayload = null;
+
+            var result = HandshakeDecoderHelper.TryParseXteaBlock(
+                ref reader,
+                keys,
+                (in ReadOnlySequence<byte> payload) =>
+                {
+                    Assert.IsTrue(payload.IsSingleSegment);
+                    Assert.AreEqual(plaintext.Length, payload.Length);
+                    parsedPayload = payload.ToArray();
+                    return true;
+                });
+
+            Assert.IsTrue(result);
+            CollectionAssert.AreEqual(plaintext, parsedPayload);
+        }
+
+        [TestMethod]
+        public void TryParseXteaBlock_NonBlockAlignedPayload_ReturnsFalseWithoutInvokingParser()
+        {
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(new byte[7]));
+            var parserInvoked = false;
+
+            var result = HandshakeDecoderHelper.TryParseXteaBlock(
+                ref reader,
+                [1, 2, 3, 4],
+                (in ReadOnlySequence<byte> _) =>
+                {
+                    parserInvoked = true;
+                    return true;
+                });
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(parserInvoked);
+        }
+
+        [TestMethod]
+        public void TryParseXteaBlock_ClearsUsedBufferBeforeReturningItToPool()
+        {
+            var keys = new uint[] { 1, 2, 3, 4 };
+            var plaintext = new byte[] { 10, 20, 30, 40, 50, 60, 70, 80 };
+            var encrypted = new byte[plaintext.Length];
+            XTEA.Encrypt(plaintext, encrypted, keys);
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(encrypted));
+            var pool = new RecordingByteArrayPool();
+
+            var result = HandshakeDecoderHelper.TryParseXteaBlock(
+                ref reader,
+                keys,
+                (in ReadOnlySequence<byte> _) => true,
+                pool);
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(pool.ReturnedWithClearArray);
+            Assert.IsNotNull(pool.ReturnedBuffer);
+            Assert.IsTrue(pool.ReturnedBuffer!.AsSpan(0, plaintext.Length).IndexOfAnyExcept((byte)0) < 0);
+        }
+
+        [TestMethod]
+        public void TryParseHardwareBlock_TruncatedMediumValue_ReturnsFalse()
+        {
+            var input = new byte[14];
+            input[0] = 6;
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(input));
+
+            var result = HandshakeDecoderHelper.TryParseHardwareBlock(ref reader);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void WorldHandshakeDecoder_NonBlockAlignedEncryptedPayload_ReturnsFalse()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var decoder = new WorldHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                Substitute.For<ICacheAPI>());
+
+            var result = decoder.TryDecodeMessage(CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: true, encryptedPayload: new byte[7]), out var message);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(message);
+        }
+
+        [TestMethod]
+        public void LobbyHandshakeDecoder_NonBlockAlignedEncryptedPayload_ReturnsFalse()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var decoder = new LobbyHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                Substitute.For<ICacheAPI>());
+
+            var result = decoder.TryDecodeMessage(CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: false, encryptedPayload: new byte[7]), out var message);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(message);
+        }
+
+        [TestMethod]
+        public void WorldHandshakeDecoder_SettingsLengthBeyondPayload_ReturnsFalse()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var decoder = new WorldHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                Substitute.For<ICacheAPI>());
+            var encryptedPayload = EncryptPayload(CreatePayloadWithTruncatedSettings(world: true));
+
+            var result = decoder.TryDecodeMessage(
+                CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: true, encryptedPayload: encryptedPayload),
+                out var message);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(message);
+        }
+
+        [TestMethod]
+        public void LobbyHandshakeDecoder_SettingsLengthBeyondPayload_ReturnsFalse()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var decoder = new LobbyHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                Substitute.For<ICacheAPI>());
+            var encryptedPayload = EncryptPayload(CreatePayloadWithTruncatedSettings(world: false));
+
+            var result = decoder.TryDecodeMessage(
+                CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: false, encryptedPayload: encryptedPayload),
+                out var message);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(message);
+        }
+
+        private static ReadOnlySequence<byte> CreateSequence(params byte[][] segments)
+        {
+            var first = new BufferSegment(segments[0]);
+            var last = first;
+            for (var i = 1; i < segments.Length; i++)
+            {
+                last = last.Append(segments[i]);
+            }
+            return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+        }
+
+        private static byte[] CreateRsaBlock()
+        {
+            var block = new List<byte> { 10 };
+            AppendInt32(block, 1);
+            AppendInt32(block, 2);
+            AppendInt32(block, 3);
+            AppendInt32(block, 4);
+            AppendInt64(block, 0);
+            block.AddRange(Encoding.ASCII.GetBytes("password"));
+            block.Add(0);
+            AppendInt64(block, 0);
+            AppendInt64(block, 0);
+            return block.ToArray();
+        }
+
+        private static RsaClientConfig CreateRsaConfig(byte[] rsaBlock) => new()
+        {
+            PrivateKey = BigInteger.One,
+            ModulusKey = BigInteger.One << (rsaBlock.Length * 8)
+        };
+
+        private static byte[] CreatePayloadWithTruncatedSettings(bool world)
+        {
+            var payload = new List<byte> { 0 };
+            AppendInt64(payload, 1);
+            if (world)
+            {
+                payload.Add(0);
+                AppendInt16(payload, 800);
+                AppendInt16(payload, 600);
+                payload.Add(0);
+                AppendInt32(payload, 0);
+            }
+            else
+            {
+                payload.Add(0);
+                payload.Add(0);
+            }
+            payload.AddRange(new byte[24]);
+            payload.Add(0);
+            payload.Add(byte.MaxValue);
+            while (payload.Count % 8 != 0)
+            {
+                payload.Add(0);
+            }
+            return payload.ToArray();
+        }
+
+        private static byte[] EncryptPayload(byte[] plaintext)
+        {
+            var encrypted = new byte[plaintext.Length];
+            XTEA.Encrypt(plaintext, encrypted, [1, 2, 3, 4]);
+            return encrypted;
+        }
+
+        private static ReadOnlySequence<byte> CreateHandshakeInput(byte[] rsaBlock, bool includeWorldLoginFlag, byte[] encryptedPayload)
+        {
+            var input = new List<byte> { 0, 0 };
+            AppendInt32(input, 742);
+            AppendInt32(input, 0);
+            if (includeWorldLoginFlag)
+            {
+                input.Add(0);
+            }
+            AppendInt16(input, rsaBlock.Length);
+            input.AddRange(rsaBlock);
+            input.AddRange(encryptedPayload);
+            var packetSize = input.Count - 2;
+            input[0] = (byte)(packetSize >> 8);
+            input[1] = (byte)packetSize;
+            return new ReadOnlySequence<byte>(input.ToArray());
+        }
+
+        private static void AppendInt16(List<byte> buffer, int value)
+        {
+            Span<byte> bytes = stackalloc byte[2];
+            BinaryPrimitives.WriteInt16BigEndian(bytes, (short)value);
+            buffer.AddRange(bytes.ToArray());
+        }
+
+        private static void AppendInt32(List<byte> buffer, int value)
+        {
+            Span<byte> bytes = stackalloc byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+            buffer.AddRange(bytes.ToArray());
+        }
+
+        private static void AppendInt64(List<byte> buffer, long value)
+        {
+            Span<byte> bytes = stackalloc byte[8];
+            BinaryPrimitives.WriteInt64BigEndian(bytes, value);
+            buffer.AddRange(bytes.ToArray());
+        }
+
+        private sealed class BufferSegment : ReadOnlySequenceSegment<byte>
+        {
+            public BufferSegment(byte[] bytes) => Memory = bytes;
+
+            public BufferSegment Append(byte[] bytes)
+            {
+                var next = new BufferSegment(bytes)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
+                Next = next;
+                return next;
+            }
+        }
+
+        private sealed class RecordingByteArrayPool : ArrayPool<byte>
+        {
+            public byte[]? ReturnedBuffer { get; private set; }
+            public bool ReturnedWithClearArray { get; private set; }
+
+            public override byte[] Rent(int minimumLength)
+            {
+                var buffer = new byte[Math.Max(minimumLength, 32)];
+                Array.Fill(buffer, (byte)0xA5);
+                return buffer;
+            }
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
+                ReturnedBuffer = array;
+                ReturnedWithClearArray = clearArray;
+            }
         }
     }
 }

--- a/Hagalaz.Services.GameWorld.Tests/HandshakeDecoderTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/HandshakeDecoderTests.cs
@@ -6,6 +6,7 @@ using Hagalaz.Cache.Abstractions;
 using Hagalaz.Security;
 using Hagalaz.Services.GameWorld.Configuration.Model;
 using Hagalaz.Services.GameWorld.Network.Handshake.Decoders;
+using Hagalaz.Services.GameWorld.Network.Handshake.Messages;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 
@@ -229,6 +230,94 @@ namespace Hagalaz.Services.GameWorld.Tests
             Assert.IsNull(message);
         }
 
+        [TestMethod]
+        public void WorldHandshakeDecoder_ValidPayload_ContiguousAndMultiSegmentInputProduceEquivalentRequests()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var cacheApi = Substitute.For<ICacheAPI>();
+            cacheApi.GetFileCount(byte.MaxValue).Returns(2);
+            var decoder = new WorldHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                cacheApi);
+            var encryptedPayload = EncryptPayload(CreateValidPayload(world: true));
+
+            var contiguousResult = decoder.TryDecodeMessage(
+                CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: true, encryptedPayload),
+                out var contiguousMessage);
+            var segmentedResult = decoder.TryDecodeMessage(
+                CreateSegmentedHandshakeInput(rsaBlock, includeWorldLoginFlag: true, encryptedPayload),
+                out var segmentedMessage);
+
+            Assert.IsTrue(contiguousResult);
+            Assert.IsTrue(segmentedResult);
+            Assert.IsInstanceOfType<WorldSignInRequest>(contiguousMessage);
+            Assert.IsInstanceOfType<WorldSignInRequest>(segmentedMessage);
+            AssertEquivalentRequests((WorldSignInRequest)contiguousMessage!, (WorldSignInRequest)segmentedMessage!);
+        }
+
+        [TestMethod]
+        public void LobbyHandshakeDecoder_ValidPayload_ContiguousAndMultiSegmentInputProduceEquivalentRequests()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var cacheApi = Substitute.For<ICacheAPI>();
+            cacheApi.GetFileCount(byte.MaxValue).Returns(2);
+            var decoder = new LobbyHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                cacheApi);
+            var encryptedPayload = EncryptPayload(CreateValidPayload(world: false));
+
+            var contiguousResult = decoder.TryDecodeMessage(
+                CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: false, encryptedPayload),
+                out var contiguousMessage);
+            var segmentedResult = decoder.TryDecodeMessage(
+                CreateSegmentedHandshakeInput(rsaBlock, includeWorldLoginFlag: false, encryptedPayload),
+                out var segmentedMessage);
+
+            Assert.IsTrue(contiguousResult);
+            Assert.IsTrue(segmentedResult);
+            Assert.IsInstanceOfType<LobbySignInRequest>(contiguousMessage);
+            Assert.IsInstanceOfType<LobbySignInRequest>(segmentedMessage);
+            AssertEquivalentRequests((LobbySignInRequest)contiguousMessage!, (LobbySignInRequest)segmentedMessage!);
+        }
+
+        [TestMethod]
+        public void WorldHandshakeDecoder_MissingCacheCrc_ReturnsFalse()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var cacheApi = Substitute.For<ICacheAPI>();
+            cacheApi.GetFileCount(byte.MaxValue).Returns(2);
+            var decoder = new WorldHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                cacheApi);
+            var encryptedPayload = EncryptPayload(CreatePayloadWithMissingCacheCrc(world: true));
+
+            var result = decoder.TryDecodeMessage(
+                CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: true, encryptedPayload),
+                out var message);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(message);
+        }
+
+        [TestMethod]
+        public void LobbyHandshakeDecoder_MissingCacheCrc_ReturnsFalse()
+        {
+            var rsaBlock = CreateRsaBlock();
+            var cacheApi = Substitute.For<ICacheAPI>();
+            cacheApi.GetFileCount(byte.MaxValue).Returns(2);
+            var decoder = new LobbyHandshakeRequestDecoder(
+                Options.Create(CreateRsaConfig(rsaBlock)),
+                cacheApi);
+            var encryptedPayload = EncryptPayload(CreatePayloadWithMissingCacheCrc(world: false));
+
+            var result = decoder.TryDecodeMessage(
+                CreateHandshakeInput(rsaBlock, includeWorldLoginFlag: false, encryptedPayload),
+                out var message);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(message);
+        }
+
         private static ReadOnlySequence<byte> CreateSequence(params byte[][] segments)
         {
             var first = new BufferSegment(segments[0]);
@@ -288,6 +377,170 @@ namespace Hagalaz.Services.GameWorld.Tests
             return payload.ToArray();
         }
 
+        private static byte[] CreateValidPayload(bool world)
+        {
+            var payload = CreatePayloadPrefix(world);
+            AppendHardwareBlock(payload);
+
+            if (world)
+            {
+                AppendInt32(payload, 1234);
+                AppendInt64(payload, 987654321);
+                AppendEmptyString(payload);
+                payload.Add(0);
+                payload.Add(0);
+                payload.Add(0);
+                payload.Add(0);
+                payload.Add(3);
+                AppendInt32(payload, 55);
+                AppendEmptyString(payload);
+                payload.Add(0);
+            }
+            else
+            {
+                AppendEmptyString(payload);
+                AppendInt32(payload, 66);
+                AppendInt32(payload, 77);
+                AppendEmptyString(payload);
+            }
+
+            AppendInt32(payload, 0x11223344);
+            while (payload.Count % 8 != 0)
+            {
+                payload.Add(0);
+            }
+            return payload.ToArray();
+        }
+
+        private static byte[] CreatePayloadWithMissingCacheCrc(bool world)
+        {
+            var payload = CreatePayloadPrefix(world);
+            AppendHardwareBlock(payload);
+
+            if (world)
+            {
+                AppendInt32(payload, 1234);
+                AppendInt64(payload, 987654321);
+                AppendEmptyString(payload);
+                payload.Add(0);
+                payload.Add(0);
+                payload.Add(0);
+                payload.Add(0);
+                payload.Add(3);
+                AppendInt32(payload, 55);
+                AppendAlignedServerToken(payload, includeLoggedInFromLobby: true);
+                payload.Add(0);
+            }
+            else
+            {
+                AppendEmptyString(payload);
+                AppendInt32(payload, 66);
+                AppendInt32(payload, 77);
+                AppendAlignedServerToken(payload, includeLoggedInFromLobby: false);
+            }
+
+            Assert.AreEqual(0, payload.Count % 8);
+            return payload.ToArray();
+        }
+
+        private static List<byte> CreatePayloadPrefix(bool world)
+        {
+            var payload = new List<byte> { 0 };
+            AppendInt64(payload, 1);
+            if (world)
+            {
+                payload.Add(2);
+                AppendInt16(payload, 1024);
+                AppendInt16(payload, 768);
+                payload.Add(1);
+                AppendInt32(payload, 0);
+            }
+            else
+            {
+                payload.Add(7);
+                payload.Add(8);
+            }
+
+            for (var index = 0; index < 24; index++)
+            {
+                payload.Add((byte)(index + 1));
+            }
+            AppendEmptyString(payload);
+            if (world)
+            {
+                AppendInt32(payload, 0);
+            }
+            payload.Add(0);
+            return payload;
+        }
+
+        private static void AppendHardwareBlock(List<byte> payload)
+        {
+            payload.Add(6);
+            payload.Add(1);
+            payload.Add(1);
+            payload.Add(2);
+            payload.Add(3);
+            payload.Add(4);
+            payload.Add(5);
+            payload.Add(6);
+            payload.Add(0);
+            AppendInt16(payload, 2048);
+            payload.Add(4);
+            payload.Add(1);
+            payload.Add(2);
+            payload.Add(3);
+            AppendInt16(payload, 100);
+            AppendStartDelimitedEmptyString(payload);
+            AppendStartDelimitedEmptyString(payload);
+            AppendStartDelimitedEmptyString(payload);
+            AppendStartDelimitedEmptyString(payload);
+            payload.Add(1);
+            AppendInt16(payload, 2026);
+            AppendStartDelimitedEmptyString(payload);
+            AppendStartDelimitedEmptyString(payload);
+            payload.Add(8);
+            payload.Add(9);
+            AppendInt32(payload, 10);
+            AppendInt32(payload, 11);
+            AppendInt32(payload, 12);
+            AppendInt32(payload, 13);
+        }
+
+        private static void AppendAlignedServerToken(List<byte> payload, bool includeLoggedInFromLobby)
+        {
+            var suffixLength = includeLoggedInFromLobby ? 2 : 1;
+            var contentLength = (8 - ((payload.Count + suffixLength) % 8)) % 8;
+            for (var index = 0; index < contentLength; index++)
+            {
+                payload.Add((byte)'x');
+            }
+            payload.Add(0);
+        }
+
+        private static void AppendEmptyString(List<byte> buffer) => buffer.Add(0);
+
+        private static void AppendStartDelimitedEmptyString(List<byte> buffer)
+        {
+            buffer.Add(0);
+            buffer.Add(0);
+        }
+
+        private static void AssertEquivalentRequests(ClientSignInRequest expected, ClientSignInRequest actual)
+        {
+            Assert.AreEqual(expected.ClientRevision, actual.ClientRevision);
+            Assert.AreEqual(expected.ClientRevisionPatch, actual.ClientRevisionPatch);
+            Assert.AreEqual(expected.Login, actual.Login);
+            Assert.AreEqual(expected.Password, actual.Password);
+            CollectionAssert.AreEqual(expected.IsaacSeed, actual.IsaacSeed);
+            CollectionAssert.AreEqual(expected.CacheCRCs, actual.CacheCRCs);
+            Assert.AreEqual(expected.ClientId, actual.ClientId);
+            Assert.AreEqual(expected.Language, actual.Language);
+            Assert.AreEqual(expected.DisplayMode, actual.DisplayMode);
+            Assert.AreEqual(expected.ClientSizeX, actual.ClientSizeX);
+            Assert.AreEqual(expected.ClientSizeY, actual.ClientSizeY);
+        }
+
         private static byte[] EncryptPayload(byte[] plaintext)
         {
             var encrypted = new byte[plaintext.Length];
@@ -311,6 +564,13 @@ namespace Hagalaz.Services.GameWorld.Tests
             input[0] = (byte)(packetSize >> 8);
             input[1] = (byte)packetSize;
             return new ReadOnlySequence<byte>(input.ToArray());
+        }
+
+        private static ReadOnlySequence<byte> CreateSegmentedHandshakeInput(byte[] rsaBlock, bool includeWorldLoginFlag, byte[] encryptedPayload)
+        {
+            var contiguousInput = CreateHandshakeInput(rsaBlock, includeWorldLoginFlag, encryptedPayload).ToArray();
+            var splitIndex = contiguousInput.Length - encryptedPayload.Length + 3;
+            return CreateSequence(contiguousInput[..splitIndex], contiguousInput[splitIndex..]);
         }
 
         private static void AppendInt16(List<byte> buffer, int value)

--- a/Hagalaz.Services.GameWorld/Network/Handshake/Decoders/HandshakeDecoderHelper.cs
+++ b/Hagalaz.Services.GameWorld/Network/Handshake/Decoders/HandshakeDecoderHelper.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Buffers;
 using System.Numerics;
+using System.Security.Cryptography;
+using Hagalaz.Security;
 using Raido.Server.Extensions;
 
 namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 {
     public static class HandshakeDecoderHelper
     {
+        internal delegate bool XteaPayloadParser(in ReadOnlySequence<byte> payload);
         public static bool TryParsePacketHeader(ref SequenceReader<byte> reader, out int clientRevision, out int clientRevisionPatch)
         {
-            if (!reader.TryReadBigEndian(out short packetSize) || reader.Remaining < packetSize)
+            if (!reader.TryReadBigEndian(out short packetSize) || packetSize < 0 || reader.Remaining != packetSize)
             {
                 clientRevision = default;
                 clientRevisionPatch = default;
@@ -29,7 +32,7 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 
         public static bool TryParseRsaHeader(ref SequenceReader<byte> reader, BigInteger privateKey, BigInteger modulusKey, out BigInteger rsaBigInteger)
         {
-            if (!reader.TryReadBigEndian(out short rsaHeaderSize) || reader.Remaining < rsaHeaderSize)
+            if (!reader.TryReadBigEndian(out short rsaHeaderSize) || rsaHeaderSize <= 0 || reader.Remaining < rsaHeaderSize)
             {
                 rsaBigInteger = default;
                 return false;
@@ -55,23 +58,25 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(rsaBuffer);
+                CryptographicOperations.ZeroMemory(rsaBuffer.AsSpan(0, rsaHeaderSize));
+                ArrayPool<byte>.Shared.Return(rsaBuffer, clearArray: true);
             }
         }
 
         public static bool TryParseRsaBlock(BigInteger rsaBigInteger, out uint[] isaacSeed, out string password)
         {
             var rsaData = ArrayPool<byte>.Shared.Rent(rsaBigInteger.GetByteCount());
+            var rsaDataLength = 0;
             try
             {
-                if (!rsaBigInteger.TryWriteBytes(rsaData, out var _, false, true))
+                if (!rsaBigInteger.TryWriteBytes(rsaData, out rsaDataLength, false, true) || rsaDataLength <= 0)
                 {
                     isaacSeed = default!;
                     password = default!;
                     return false;
                 }
 
-                var rsaDataReader = new SequenceReader<byte>(new ReadOnlySequence<byte>(rsaData));
+                var rsaDataReader = new SequenceReader<byte>(new ReadOnlySequence<byte>(rsaData.AsMemory(0, rsaDataLength)));
                 // check for fake packet or encryption
                 if (!rsaDataReader.TryRead(out byte rsaMagic) || rsaMagic != 10)
                 {
@@ -115,7 +120,43 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(rsaData);
+                CryptographicOperations.ZeroMemory(rsaData.AsSpan(0, rsaDataLength));
+                ArrayPool<byte>.Shared.Return(rsaData, clearArray: true);
+            }
+        }
+
+        internal static bool TryParseXteaBlock(ref SequenceReader<byte> reader, uint[] isaacSeed, XteaPayloadParser parser)
+            => TryParseXteaBlock(ref reader, isaacSeed, parser, ArrayPool<byte>.Shared);
+
+        internal static bool TryParseXteaBlock(
+            ref SequenceReader<byte> reader,
+            uint[] isaacSeed,
+            XteaPayloadParser parser,
+            ArrayPool<byte> bufferPool)
+        {
+            ArgumentNullException.ThrowIfNull(isaacSeed);
+            ArgumentNullException.ThrowIfNull(parser);
+            ArgumentNullException.ThrowIfNull(bufferPool);
+
+            var xteaBlockSize = reader.Remaining;
+            if (xteaBlockSize <= 0 || xteaBlockSize > int.MaxValue || xteaBlockSize % 8 != 0)
+            {
+                return false;
+            }
+
+            var length = (int)xteaBlockSize;
+            var xteaData = bufferPool.Rent(length);
+            try
+            {
+                reader.UnreadSequence.CopyTo(xteaData.AsSpan(0, length));
+                XTEA.Decrypt(xteaData.AsSpan(0, length), xteaData.AsSpan(0, length), isaacSeed);
+
+                return parser(new ReadOnlySequence<byte>(xteaData.AsMemory(0, length)));
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(xteaData.AsSpan(0, length));
+                bufferPool.Return(xteaData, clearArray: true);
             }
         }
 
@@ -176,6 +217,10 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                 return false;
             }
 
+            if (reader.Remaining < 3)
+            {
+                return false;
+            }
             reader.Advance(3); // medium int cpu data
 
             if (!reader.TryReadBigEndian(out short cpuData))

--- a/Hagalaz.Services.GameWorld/Network/Handshake/Decoders/LobbyHandshakeRequestDecoder.cs
+++ b/Hagalaz.Services.GameWorld/Network/Handshake/Decoders/LobbyHandshakeRequestDecoder.cs
@@ -2,7 +2,6 @@
 using System.Buffers;
 using Hagalaz.Cache.Abstractions;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
-using Hagalaz.Security;
 using Hagalaz.Services.GameWorld.Configuration.Model;
 using Hagalaz.Services.GameWorld.Network.Handshake.Messages;
 using Microsoft.Extensions.Options;
@@ -25,6 +24,7 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 
         public bool TryDecodeMessage(in ReadOnlySequence<byte> input, out RaidoMessage? message)
         {
+            message = default;
             var reader = new SequenceReader<byte>(input);
             if (!HandshakeDecoderHelper.TryParsePacketHeader(ref reader, out var clientRevision, out var clientRevisionPatch))
             {
@@ -42,17 +42,14 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
             }
 
             // XTEA block
-            var xteaBlockSize = (int)reader.Remaining;
-            var xteaData = ArrayPool<byte>.Shared.Rent(xteaBlockSize);
-            try
-            {
-                XTEA.Decrypt(reader.UnreadSpan, xteaData, isaacSeed);
-
-                var xteaDataReader = new SequenceReader<byte>(new ReadOnlySequence<byte>(xteaData));
+            RaidoMessage? decodedMessage = default;
+            var decoded = HandshakeDecoderHelper.TryParseXteaBlock(ref reader, isaacSeed,
+                (in ReadOnlySequence<byte> xteaData) =>
+                {
+                var xteaDataReader = new SequenceReader<byte>(xteaData);
 
                 if (!xteaDataReader.TryRead(out bool isLoginString))
                 {
-                    message = default;
                     return false;
                 }
 
@@ -61,7 +58,6 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                 {
                     if (!xteaDataReader.TryReadBigEndian(out long encodedLogin))
                     {
-                        message = default;
                         return false;
                     }
                     login = encodedLogin.LongToString();
@@ -70,56 +66,52 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                 {
                     if (!xteaDataReader.TryRead(out login))
                     {
-                        message = default;
                         return false;
                     }
                 }
                 if (login == null)
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte gameId))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte localeId))
                 {
-                    message = default;
                     return false;
                 }
 
                 var userId = new byte[24];
                 if (!xteaDataReader.TryCopyTo(userId))
                 {
-                    message = default;
                     return false;
                 }
                 xteaDataReader.Advance(24);
 
                 if (!xteaDataReader.TryRead(out string settings))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte settingsDataLength))
                 {
-                    message = default;
                     return false;
                 }
 
                 // TODO - read settings block
+                if (xteaDataReader.Remaining < settingsDataLength)
+                {
+                    return false;
+                }
                 xteaDataReader.Advance(settingsDataLength);
 
                 // start hardware block
 
                 if (!HandshakeDecoderHelper.TryParseHardwareBlock(ref xteaDataReader))
                 {
-                    message = default;
                     return false;
                 }
 
@@ -127,43 +119,43 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 
                 if (!xteaDataReader.TryRead(out string staticClientId))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out int affiliateId))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out int staticClientNumber))
                 {
-                    message = default;
                     return false;
                 }
 
                 // TODO - validate servertoken
                 if (!xteaDataReader.TryRead(out string serverToken))
                 {
-                    message = default;
                     return false;
                 }
 
                 // start cache CRC block
-                var cacheCrCs = new int[_cacheApi.GetFileCount(byte.MaxValue) - 1];
-                for (byte indexId = 0; indexId < cacheCrCs.Length; indexId++) 
+                var cacheCrcCount = _cacheApi.GetFileCount(byte.MaxValue) - 1;
+                if (cacheCrcCount < 0)
+                {
+                    return false;
+                }
+                var cacheCrCs = new int[cacheCrcCount];
+                for (var indexId = 0; indexId < cacheCrCs.Length; indexId++)
                 {
                     if (!xteaDataReader.TryReadBigEndian(out int crc))
                     {
-                        message = default;
                         return false;
                     }
                     cacheCrCs[indexId] = crc;
                 }
 
                 // stop cache CRC block
-                message = new LobbySignInRequest()
+                decodedMessage = new LobbySignInRequest()
                 {
                     ClientRevision = clientRevision,
                     ClientRevisionPatch = clientRevisionPatch,
@@ -175,11 +167,9 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                     DisplayMode = DisplayMode.LobbyScreen
                 };
                 return true;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(xteaData);
-            }
+                });
+            message = decoded ? decodedMessage : default;
+            return decoded;
         }
     }
 }

--- a/Hagalaz.Services.GameWorld/Network/Handshake/Decoders/WorldHandshakeRequestDecoder.cs
+++ b/Hagalaz.Services.GameWorld/Network/Handshake/Decoders/WorldHandshakeRequestDecoder.cs
@@ -2,7 +2,6 @@
 using System.Buffers;
 using Hagalaz.Cache.Abstractions;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
-using Hagalaz.Security;
 using Hagalaz.Services.GameWorld.Configuration.Model;
 using Hagalaz.Services.GameWorld.Network.Handshake.Messages;
 using Microsoft.Extensions.Options;
@@ -25,6 +24,7 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 
         public bool TryDecodeMessage(in ReadOnlySequence<byte> input, out RaidoMessage? message)
         {
+            message = default;
             var reader = new SequenceReader<byte>(input);
             if (!HandshakeDecoderHelper.TryParsePacketHeader(ref reader, out var clientRevision, out var clientRevisionPatch))
             {
@@ -47,17 +47,14 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
             }
 
             // XTEA block
-            var xteaBlockSize = (int)reader.Remaining;
-            var xteaData = ArrayPool<byte>.Shared.Rent(xteaBlockSize);
-            try
-            {
-                XTEA.Decrypt(reader.UnreadSpan, xteaData, isaacSeed);
-
-                var xteaDataReader = new SequenceReader<byte>(new ReadOnlySequence<byte>(xteaData));
+            RaidoMessage? decodedMessage = default;
+            var decoded = HandshakeDecoderHelper.TryParseXteaBlock(ref reader, isaacSeed,
+                (in ReadOnlySequence<byte> xteaData) =>
+                {
+                var xteaDataReader = new SequenceReader<byte>(xteaData);
 
                 if (!xteaDataReader.TryRead(out bool isLoginString))
                 {
-                    message = default;
                     return false;
                 }
 
@@ -66,7 +63,6 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                 {
                     if (!xteaDataReader.TryReadBigEndian(out long encodedLogin))
                     {
-                        message = default;
                         return false;
                     }
                     login = encodedLogin.LongToString();
@@ -75,74 +71,67 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                 {
                     if (!xteaDataReader.TryRead(out login))
                     {
-                        message = default;
                         return false;
                     }
                 }
                 if (login == null)
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte displayMode))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out short screenSizeX))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out short screenSizeY))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte somePreferenceValue))
                 {
-                    message = default;
                     return false;
                 }
 
                 var userId = new byte[24];
                 if (!xteaDataReader.TryCopyTo(userId))
                 {
-                    message = default;
                     return false;
                 }
                 xteaDataReader.Advance(24);
 
                 if (!xteaDataReader.TryRead(out string settings))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out int affliateId))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte settingsDataLength))
                 {
-                    message = default;
                     return false;
                 }
 
                 // TODO - read settings block
+                if (xteaDataReader.Remaining < settingsDataLength)
+                {
+                    return false;
+                }
                 xteaDataReader.Advance(settingsDataLength);
 
                 // start hardware block
 
                 if (!HandshakeDecoderHelper.TryParseHardwareBlock(ref xteaDataReader))
                 {
-                    message = default;
                     return false;
                 }
 
@@ -150,25 +139,21 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 
                 if (!xteaDataReader.TryReadBigEndian(out int somePacketIncrementalValue)) 
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out long someAppletLongSetting))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out string randomLoaderId))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out bool someClientSetting2))
                 {
-                    message = default;
                     return false;
                 }
 
@@ -176,59 +161,55 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                 {
                     if (!xteaDataReader.TryRead(out string clientSetting2))
                     {
-                        message = default;
                         return false;
                     }
                 }
 
                 if (!xteaDataReader.TryRead(out bool jagTheoraLoaded))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out bool supportsJavascript))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out bool someRandomBool))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out byte afflicateId))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryReadBigEndian(out int randomLoaderNumber))
                 {
-                    message = default;
                     return false;
                 }
 
                 if (!xteaDataReader.TryRead(out string serverToken))
                 {
-                    message = default;
                     return false;
                 }
                 if (!xteaDataReader.TryRead(out bool loggedInFromLobby))
                 {
-                    message = default;
                     return false;
                 }
 
                 // start cache CRC block
-                var cacheCrCs = new int[_cacheApi.GetFileCount(byte.MaxValue) - 1];
-                for (byte indexId = 0; indexId < cacheCrCs.Length; indexId++)
+                var cacheCrcCount = _cacheApi.GetFileCount(byte.MaxValue) - 1;
+                if (cacheCrcCount < 0)
+                {
+                    return false;
+                }
+                var cacheCrCs = new int[cacheCrcCount];
+                for (var indexId = 0; indexId < cacheCrCs.Length; indexId++)
                 {
                     if (!xteaDataReader.TryReadBigEndian(out int crc))
                     {
-                        message = default;
                         return false;
                     }
                     cacheCrCs[indexId] = crc;
@@ -236,7 +217,7 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
 
                 // stop cache CRC block
 
-                message = new WorldSignInRequest
+                decodedMessage = new WorldSignInRequest
                 {
                     ClientRevision = clientRevision,
                     ClientRevisionPatch = clientRevisionPatch,
@@ -250,11 +231,9 @@ namespace Hagalaz.Services.GameWorld.Network.Handshake.Decoders
                     ClientSizeY = screenSizeY
                 };
                 return true;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(xteaData);
-            }
+                });
+            message = decoded ? decodedMessage : default;
+            return decoded;
         }
     }
 }

--- a/openspec/changes/fix-handshake-payload-bounds/.openspec.yaml
+++ b/openspec/changes/fix-handshake-payload-bounds/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/fix-handshake-payload-bounds/design.md
+++ b/openspec/changes/fix-handshake-payload-bounds/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`HandshakeProtocol` passes world and lobby payloads to `WorldHandshakeRequestDecoder` and `LobbyHandshakeRequestDecoder`. Both decoders parse the plain header and RSA block, then decrypt the remaining XTEA payload. The current code uses `UnreadSpan`, rents a buffer whose capacity can exceed the payload, constructs readers over the full rented arrays, and advances over settings data without checking the remaining length. `ReadOnlySequence<byte>` inputs can also be multi-segment. The decoder returns `false` for normal parse failures, so the correction must preserve that boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the shared handshake framing and temporary-buffer paths exact-length and multi-segment safe.
+- Keep malformed and truncated input on the existing `false`/null-message failure convention.
+- Ensure pooled encrypted/decrypted handshake bytes are cleared on every exit path.
+- Cover both world and lobby decoders where the shared defect applies.
+
+**Non-Goals:**
+
+- Changing RSA or XTEA algorithms, credentials, cache CRC semantics, or authentication decisions.
+- Rewriting the general Raido protocol framing or adding fuzzing infrastructure.
+- Replacing existing sequence readers, string readers, or cache services.
+
+## Decisions
+
+1. **Use the declared packet length as the outer bound.** `TryParsePacketHeader` will require the declared length to equal the remaining input. This matches the existing login protocol contract and prevents trailing bytes from becoming part of the XTEA region. A looser `remaining >= declared` check is rejected because it cannot distinguish the current packet from trailing data.
+
+2. **Centralize XTEA copy, decryption, and cleanup in the handshake helper.** A focused helper will validate the remaining length, copy `UnreadSequence` into the exact used prefix of a rented buffer, decrypt only that prefix, invoke the existing decoder-specific parser over a bounded sequence, then clear and return the buffer in `finally`. This removes the duplicated unsafe buffer lifecycle from world and lobby decoders. Returning a fresh exact-sized managed array is rejected because it would abandon the existing pooling path and leave sensitive data unmanaged by an explicit cleanup owner.
+
+3. **Bound RSA parsing by the actual written byte count.** `BigInteger.TryWriteBytes` provides the number of initialized bytes; the RSA reader will use only that prefix and the helper will clear it before returning the rented array. The RSA header copy will likewise clear its used prefix. This closes the same full-capacity class of bug before XTEA begins.
+
+4. **Validate before every variable advance.** Settings and hardware skips will check `SequenceReader.Remaining` before advancing. Existing `TryRead` operations remain the authoritative field and string validation mechanism; no new protocol-validation framework is introduced.
+
+The decoder owns construction of the final sign-in request, while the shared handshake helper owns temporary buffer acquisition, bounded exposure, and cleanup. There is no retry or reconciliation state in this path; malformed input is rejected by the decoder and the connection lifecycle remains the existing owner of subsequent handling.
+
+## Risks / Trade-offs
+
+- [Strict packet equality rejects payloads with unexpected trailing bytes] → This is required by the login framing contract and prevents ambiguous packet ownership; valid clients already provide the declared exact length.
+- [Clearing pooled buffers adds a small per-handshake cost] → The buffers contain credentials and key material, so deterministic cleanup is required and limited to the used ranges.
+- [The shared callback helper changes the shape of decoder parsing] → Keep all field parsing and message construction in the existing decoder-specific code so behavior remains reviewable and protocol semantics do not move into a generic parser.
+
+## Migration Plan
+
+No data or deployment migration is required. Deploy the code and focused tests together. Rollback is a source revert if a valid client packet is found to violate the declared-length contract; no persisted state is changed.
+
+## Open Questions
+
+None for issue #348. Any protocol framing discrepancy discovered outside the confirmed exact-payload behavior is a separate follow-up.

--- a/openspec/changes/fix-handshake-payload-bounds/proposal.md
+++ b/openspec/changes/fix-handshake-payload-bounds/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Issue #348 identifies that world and lobby handshakes can parse bytes outside the current packet. The decoders use the first segment of the unread input and then expose the full capacity of rented buffers, so stale pooled bytes, incomplete sequences, and truncated fields can affect unauthenticated parsing. This is a high-severity security correctness issue because the decrypted handshake contains credentials, identifiers, tokens, and key material.
+
+## What Changes
+
+- Require the declared handshake packet length to match the current input exactly.
+- Copy the complete encrypted XTEA payload from the unread `ReadOnlySequence<byte>` before decrypting it.
+- Reject empty or non-XTEA-block-aligned encrypted payloads and expose only the exact decrypted length to the parser.
+- Bound RSA and XTEA temporary readers to the number of bytes actually written or decrypted.
+- Reject truncated length-prefixed settings blocks, hardware fields, and cache CRC blocks without advancing beyond the payload.
+- Clear used encrypted/decrypted pooled buffer ranges before returning them to `ArrayPool<byte>`.
+- Add focused regression tests for stale capacity, segmented input, malformed lengths, truncation, and cleanup behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `handshake-payload-validation`: World and lobby handshake decoders parse only exact packet payloads and fail closed for malformed input.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change is limited to `Hagalaz.Services.GameWorld` handshake decoders and their existing helper, plus `Hagalaz.Services.GameWorld.Tests`. It reuses `ReadOnlySequence<byte>`, `SequenceReader<byte>`, `XTEA`, `ArrayPool<byte>`, and existing decoder return-value conventions. No protocol redesign, dependency, worker, persistence, or retry mechanism is introduced.
+
+## Acceptance Criteria
+
+- A valid contiguous or multi-segment handshake produces the same sign-in request.
+- Declared packet lengths, XTEA block lengths, strings, settings blocks, hardware fields, and cache CRCs cannot read beyond the current packet.
+- Unwritten rented capacity and bytes from prior pool users cannot influence a decode.
+- Used pooled ranges containing handshake data are cleared before return.
+- Invalid or truncated input returns `false` with a null message and does not throw from buffer advancement.
+
+## Stop Conditions
+
+Stop and record a follow-up if fixing the issue requires changing post-handshake protocol framing, RSA/XTEA algorithms, authentication semantics, or introducing a general buffer-management framework.

--- a/openspec/changes/fix-handshake-payload-bounds/specs/handshake-payload-validation/spec.md
+++ b/openspec/changes/fix-handshake-payload-bounds/specs/handshake-payload-validation/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Handshake decoding is bounded to the current packet
+
+World and lobby handshake decoders MUST require the declared packet payload length to match the current input and MUST parse the encrypted and decrypted portions only within that exact payload.
+
+#### Scenario: Exact contiguous payload is decoded
+
+- **WHEN** a valid world or lobby handshake is provided as one contiguous sequence whose declared length matches the input
+- **THEN** the decoder produces the corresponding sign-in request
+
+#### Scenario: Exact multi-segment payload is decoded
+
+- **WHEN** the same valid handshake bytes are split across multiple `ReadOnlySequence<byte>` segments
+- **THEN** the decoder produces the same result as the contiguous input
+
+#### Scenario: Trailing bytes are not part of the packet
+
+- **WHEN** the declared packet length is smaller than the available input or the encrypted payload length is smaller than bytes available to a rented buffer
+- **THEN** decoding fails closed and trailing or unwritten bytes cannot satisfy required fields
+
+### Requirement: Malformed handshake input fails closed
+
+The decoders MUST reject invalid XTEA block lengths, truncated fixed-size fields, unterminated strings, settings blocks that exceed the remaining payload, invalid hardware blocks, and missing cache CRC values without throwing or producing a sign-in request.
+
+#### Scenario: Encrypted payload is not block aligned
+
+- **WHEN** the encrypted XTEA payload length is zero or is not a multiple of the XTEA block size
+- **THEN** decoding returns `false` with no message
+
+#### Scenario: Length-prefixed data exceeds the payload
+
+- **WHEN** a settings length is greater than the bytes remaining in the decrypted payload
+- **THEN** decoding returns `false` without advancing beyond the payload
+
+#### Scenario: Required field or cache CRC is truncated
+
+- **WHEN** any required field, hardware value, or expected cache CRC is missing
+- **THEN** decoding returns `false` with no partially constructed message
+
+### Requirement: Sensitive temporary data is cleared
+
+Handshake parsing MUST clear the used ranges of pooled buffers that contain encrypted or decrypted handshake data before returning those buffers to the pool.
+
+#### Scenario: Decode succeeds
+
+- **WHEN** a handshake containing credentials, identifiers, tokens, or key material is decoded
+- **THEN** the used temporary buffer ranges are cleared before pooled reuse
+
+#### Scenario: Decode fails after temporary data is populated
+
+- **WHEN** malformed input causes parsing to fail after a temporary buffer has been populated
+- **THEN** the used temporary buffer ranges are still cleared before pooled reuse

--- a/openspec/changes/fix-handshake-payload-bounds/tasks.md
+++ b/openspec/changes/fix-handshake-payload-bounds/tasks.md
@@ -1,0 +1,15 @@
+## 1. Shared handshake bounds and ownership
+
+- [x] 1.1 Make packet-header and RSA parsing use exact declared/written lengths and clear used pooled ranges.
+- [x] 1.2 Add a shared XTEA payload helper that copies the complete unread sequence, rejects invalid block lengths, exposes only the exact decrypted range, and clears it on every exit path.
+- [x] 1.3 Guard settings and hardware variable advances so malformed lengths fail closed.
+
+## 2. Decoder integration and regression coverage
+
+- [x] 2.1 Route world and lobby handshake decoders through the shared bounded XTEA helper without changing successful sign-in fields.
+- [x] 2.2 Add focused tests for exact packet lengths, contiguous versus multi-segment encrypted input, stale/unwritten capacity, non-aligned payloads, truncated fields/cache CRCs, and pooled cleanup.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused `Hagalaz.Services.GameWorld.Tests` handshake tests and the project test suite.
+- [x] 3.2 Build the affected project and review the final diff for scope, failure handling, and sensitive-buffer cleanup.

--- a/openspec/changes/fix-handshake-payload-bounds/tasks.md
+++ b/openspec/changes/fix-handshake-payload-bounds/tasks.md
@@ -7,7 +7,7 @@
 ## 2. Decoder integration and regression coverage
 
 - [x] 2.1 Route world and lobby handshake decoders through the shared bounded XTEA helper without changing successful sign-in fields.
-- [x] 2.2 Add focused tests for exact packet lengths, contiguous versus multi-segment encrypted input, stale/unwritten capacity, non-aligned payloads, truncated fields/cache CRCs, and pooled cleanup.
+- [x] 2.2 Add focused decoder tests comparing valid world/lobby requests from contiguous versus multi-segment input, rejecting missing/truncated cache CRCs, and covering exact packet lengths, stale/unwritten capacity, non-aligned payloads, truncated fields, and pooled cleanup.
 
 ## 3. Verification
 


### PR DESCRIPTION
## Summary

- Link handshake payload validation to #348
- Reject malformed packet, RSA, XTEA, settings, hardware, and cache-length data
- Centralize XTEA decoding for segmented input and securely clear pooled buffers
- Add regression coverage for truncated, misaligned, and trailing payloads

## Testing

- Added unit tests covering handshake bounds validation, segmented XTEA payloads, and pooled-buffer clearing
- Not run (not requested)