### PR TITLE
Pass character-owned dependencies explicitly (#408)

### DIFF
--- a/.agents/skills/unslop/SKILL.md
+++ b/.agents/skills/unslop/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: unslop
+description: Cut AI tells from any writing. Must always apply.
+---
+
+# Unslop
+
+Edit text to remove AI patterns and add human voice.
+
+## Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+## Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+## Patterns to detect and fix
+
+### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.

--- a/Hagalaz.Game.Abstractions/Factories/ICharacterNpcScriptActivator.cs
+++ b/Hagalaz.Game.Abstractions/Factories/ICharacterNpcScriptActivator.cs
@@ -1,0 +1,18 @@
+using System;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+
+namespace Hagalaz.Game.Abstractions.Factories
+{
+    /// <summary>
+    /// Creates a character-NPC script selected by runtime type.
+    /// </summary>
+    public interface ICharacterNpcScriptActivator
+    {
+        /// <summary>
+        /// Creates a character-NPC script in the active character scope.
+        /// </summary>
+        /// <param name="scriptType">The selected script type.</param>
+        /// <returns>The created character-NPC script.</returns>
+        ICharacterNpcScript Create(Type scriptType);
+    }
+}

--- a/Hagalaz.Game.Abstractions/Factories/ICharacterScriptActivator.cs
+++ b/Hagalaz.Game.Abstractions/Factories/ICharacterScriptActivator.cs
@@ -1,0 +1,17 @@
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+
+namespace Hagalaz.Game.Abstractions.Factories
+{
+    /// <summary>
+    /// Creates character scripts from the active character scope.
+    /// </summary>
+    public interface ICharacterScriptActivator
+    {
+        /// <summary>
+        /// Creates a registered character script.
+        /// </summary>
+        /// <typeparam name="TScript">The character script type.</typeparam>
+        /// <returns>The created script.</returns>
+        TScript Create<TScript>() where TScript : class, ICharacterScript;
+    }
+}

--- a/Hagalaz.Game.Abstractions/Factories/IFamiliarScriptActivator.cs
+++ b/Hagalaz.Game.Abstractions/Factories/IFamiliarScriptActivator.cs
@@ -1,0 +1,18 @@
+using System;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+
+namespace Hagalaz.Game.Abstractions.Factories
+{
+    /// <summary>
+    /// Creates a familiar script selected by runtime type.
+    /// </summary>
+    public interface IFamiliarScriptActivator
+    {
+        /// <summary>
+        /// Creates a familiar script in the active character scope.
+        /// </summary>
+        /// <param name="scriptType">The selected script type.</param>
+        /// <returns>The created familiar script.</returns>
+        IFamiliarScript Create(Type scriptType);
+    }
+}

--- a/Hagalaz.Game.Abstractions/Factories/IWidgetScriptActivator.cs
+++ b/Hagalaz.Game.Abstractions/Factories/IWidgetScriptActivator.cs
@@ -1,0 +1,19 @@
+using System;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Widgets;
+
+namespace Hagalaz.Game.Abstractions.Factories;
+
+/// <summary>
+/// Creates widget scripts in the owning character's scope.
+/// </summary>
+public interface IWidgetScriptActivator
+{
+    /// <summary>
+    /// Creates a widget script of the requested registered type.
+    /// </summary>
+    /// <param name="character">The character that owns the scope.</param>
+    /// <param name="scriptType">The concrete widget script type.</param>
+    /// <returns>The created widget script.</returns>
+    IWidgetScript Create(ICharacter character, Type scriptType);
+}

--- a/Hagalaz.Game.Scripts.Tests/Characters/TradeExchangeTests.cs
+++ b/Hagalaz.Game.Scripts.Tests/Characters/TradeExchangeTests.cs
@@ -14,7 +14,6 @@ using Hagalaz.Game.Abstractions.Model.Widgets;
 using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Game.Scripts.Characters;
 using Hagalaz.Services.GameWorld.Model.Creatures.Characters;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -94,13 +93,10 @@ public sealed class TradeExchangeTests
     {
         var inventory = new TestInventory(14);
         var character = CreateCharacter(inventory, Substitute.For<IMoneyPouchContainer>());
-        character.ServiceProvider.Returns(new ServiceCollection()
-            .AddSingleton<IItemBuilder>(CreateItemBuilder())
-            .BuildServiceProvider());
         var eventManager = Substitute.For<IEventManager>();
         eventManager.SendEvent(Arg.Any<IEvent>()).Returns(_ => throw new InvalidOperationException("Controlled observer failure."));
         character.EventManager.Returns(eventManager);
-        var moneyPouch = new MoneyPouchContainer(character);
+        var moneyPouch = new MoneyPouchContainer(character, CreateItemBuilder());
 
         var result = moneyPouch.AddForTrade(1);
 
@@ -114,12 +110,9 @@ public sealed class TradeExchangeTests
         var firstInventory = new TestInventory(3);
         var secondInventory = new TestInventory(3);
         var first = CreateCharacter(firstInventory, Substitute.For<IMoneyPouchContainer>());
-        first.ServiceProvider.Returns(new ServiceCollection()
-            .AddSingleton<IItemBuilder>(CreateItemBuilder())
-            .BuildServiceProvider());
         var eventManager = Substitute.For<IEventManager>();
         first.EventManager.Returns(eventManager);
-        var firstMoneyPouch = new MoneyPouchContainer(first);
+        var firstMoneyPouch = new MoneyPouchContainer(first, CreateItemBuilder());
         first.MoneyPouch.Returns(firstMoneyPouch);
 
         var secondExisting = new TestItem(100, 1, stackable: true) { ThrowOnStackCheck = true };
@@ -609,12 +602,8 @@ public sealed class TradeExchangeTests
 
     private static RewardContainer CreateRewardContainer(ICharacter owner)
     {
-        var services = new ServiceCollection()
-            .AddSingleton<IItemBuilder>(CreateItemBuilder())
-            .BuildServiceProvider();
-        owner.ServiceProvider.Returns(services);
         owner.EventManager.Returns(Substitute.For<IEventManager>());
-        return new RewardContainer(owner);
+        return new RewardContainer(owner, CreateItemBuilder());
     }
 
     private static IMoneyPouchContainer CreateEmptyMoneyPouch()

--- a/Hagalaz.Services.GameWorld.Tests/CharacterRenderInformationTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CharacterRenderInformationTests.cs
@@ -17,7 +17,6 @@ namespace Hagalaz.Services.GameWorld.Tests
     public class CharacterRenderInformationTests
     {
         private ICharacter _owner = null!;
-        private IServiceProvider _serviceProvider = null!;
         private ICharacterLocationService _locationService = null!;
         private CharacterRenderInformation _renderInfo = null!;
         private ILocation _location = null!;
@@ -26,17 +25,13 @@ namespace Hagalaz.Services.GameWorld.Tests
         public void Setup()
         {
             _owner = Substitute.For<ICharacter>();
-            _serviceProvider = Substitute.For<IServiceProvider>();
             _locationService = Substitute.For<ICharacterLocationService>();
             _location = Substitute.For<ILocation>();
 
-            _owner.ServiceProvider.Returns(_serviceProvider);
             _owner.Location.Returns(_location);
             _location.Clone().Returns(_location);
 
-            _serviceProvider.GetService(typeof(ICharacterLocationService)).Returns(_locationService);
-
-            _renderInfo = new CharacterRenderInformation(_owner);
+            _renderInfo = new CharacterRenderInformation(_owner, _locationService);
         }
 
         [TestMethod]

--- a/Hagalaz.Services.GameWorld.Tests/CharacterStatePersistenceTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CharacterStatePersistenceTests.cs
@@ -4,15 +4,21 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Hagalaz.Cache.Abstractions.Types.Providers;
 using Hagalaz.Game.Abstractions.Builders.Animation;
+using Hagalaz.Game.Abstractions.Builders.Audio;
 using Hagalaz.Game.Abstractions.Builders.Graphic;
+using Hagalaz.Game.Abstractions.Builders.GroundItem;
+using Hagalaz.Game.Abstractions.Builders.HitSplat;
 using Hagalaz.Game.Abstractions.Builders.Item;
 using Hagalaz.Game.Abstractions.Builders.Projectile;
 using Hagalaz.Game.Abstractions.Collections;
 using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Game.Abstractions.Features;
 using Hagalaz.Game.Abstractions.Features.States;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
+using Hagalaz.Game.Abstractions.Factories;
 using Hagalaz.Game.Abstractions.Logic.Dehydrations;
 using Hagalaz.Game.Abstractions.Logic.Hydrations;
+using Hagalaz.Game.Abstractions.Logic.Skills;
 using Hagalaz.Game.Abstractions.Mediator;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
@@ -123,7 +129,50 @@ public sealed class CharacterStatePersistenceTests
         Register(serviceProvider, itemBuilder);
         Register<IStateService>(serviceProvider, stateService);
 
-        var character = new Character(serviceScope, Substitute.For<IGameSession>(), Substitute.For<IGameClient>());
+        var character = new Character(
+            serviceScope,
+            Substitute.For<IGameSession>(),
+            Substitute.For<IGameClient>(),
+            Substitute.For<ICharacterContextProvider>(),
+            Substitute.For<IEventManager>(),
+            Substitute.For<IScopedGameMediator>(),
+            Substitute.For<ISmartPathFinder>(),
+            Substitute.For<IProjectilePathFinder>(),
+            Options.Create(new CombatOptions()),
+            Options.Create(new SkillOptions()),
+            scripts,
+            Substitute.For<ICharacterScriptActivator>(),
+            Substitute.For<IFamiliarScriptProvider>(),
+            Substitute.For<IFamiliarScriptActivator>(),
+            stateService,
+            Substitute.For<IMapRegionService>(),
+            Substitute.For<IMapUpdateService>(),
+            Substitute.For<IMusicService>(),
+            Substitute.For<IGameCommandPrompt>(),
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<ICharacter>>(),
+            Substitute.For<IAudioBuilder>(),
+            Substitute.For<IGameMessageService>(),
+            itemBuilder,
+            Substitute.For<IGroundItemBuilder>(),
+            Substitute.For<IAnimationBuilder>(),
+            Substitute.For<IGraphicBuilder>(),
+            Substitute.For<IProjectileBuilder>(),
+            Substitute.For<IHitSplatBuilder>(),
+            Substitute.For<INpcService>(),
+            bodyDataRepository,
+            Substitute.For<ICharacterNpcScriptProvider>(),
+            Substitute.For<ICharacterNpcScriptActivator>(),
+            Substitute.For<IItemPartFactory>(),
+            Substitute.For<ICharacterLocationService>(),
+            Substitute.For<IItemService>(),
+            Substitute.For<IClientMapDefinitionProvider>(),
+            Substitute.For<ISlayerService>(),
+            Substitute.For<IRatesService>(),
+            Substitute.For<ISlayerTaskGenerator>(),
+            Substitute.For<ISlayerTaskCompletedDialogue>(),
+            Substitute.For<IFarmingService>(),
+            Substitute.For<IGameObjectService>(),
+            Substitute.For<IWidgetScriptProvider>());
         ((IHydratable<HydratedDetailsDto>)character).Hydrate(new HydratedDetailsDto
         {
             CoordX = 3200,

--- a/Hagalaz.Services.GameWorld.Tests/CharacterStatisticsTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CharacterStatisticsTests.cs
@@ -1,4 +1,5 @@
 using Hagalaz.Game.Configuration;
+using Hagalaz.Game.Abstractions.Builders.HitSplat;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
@@ -17,17 +18,15 @@ public sealed class CharacterStatisticsTests
     {
         var character = Substitute.For<ICharacter>();
         var movement = Substitute.For<IMovement>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
         character.Movement.Returns(movement);
-        character.ServiceProvider.Returns(serviceProvider);
         movement.Moving.Returns(false);
         character.HasState<RestingState>().Returns(true);
-        serviceProvider.GetService(typeof(IOptions<CombatOptions>))
-            .Returns(Options.Create(new CombatOptions()));
-        serviceProvider.GetService(typeof(IOptions<SkillOptions>))
-            .Returns(Options.Create(new SkillOptions()));
 
-        var statistics = new CharacterStatistics(character);
+        var statistics = new CharacterStatistics(
+            character,
+            Options.Create(new CombatOptions()),
+            Options.Create(new SkillOptions()),
+            Substitute.For<IHitSplatBuilder>());
 
         Assert.AreEqual(350, statistics.GetRunEnergyRestoreRate());
     }

--- a/Hagalaz.Services.GameWorld.Tests/CreatureCombatTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/CreatureCombatTests.cs
@@ -1,5 +1,7 @@
 using Hagalaz.Game.Abstractions.Builders.Animation;
 using Hagalaz.Game.Abstractions.Builders.Graphic;
+using Hagalaz.Game.Abstractions.Builders.GroundItem;
+using Hagalaz.Game.Abstractions.Builders.HitSplat;
 using Hagalaz.Game.Abstractions.Builders.Projectile;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
@@ -35,22 +37,17 @@ namespace Hagalaz.Services.GameWorld.Tests
             _mockOwner.Viewport.Returns(_mockViewport);
             _mockViewport.VisibleCreatures.Returns(_visibleCreatures);
 
-            var serviceProviderMock = Substitute.For<IServiceProvider>();
-            serviceProviderMock.GetService(typeof(IAnimationBuilder)).Returns(Substitute.For<IAnimationBuilder>());
-            serviceProviderMock.GetService(typeof(IGraphicBuilder)).Returns(Substitute.For<IGraphicBuilder>());
-            serviceProviderMock.GetService(typeof(IProjectileBuilder)).Returns(Substitute.For<IProjectileBuilder>());
-            serviceProviderMock.GetService(typeof(IProjectilePathFinder)).Returns(Substitute.For<IProjectilePathFinder>());
-            serviceProviderMock.GetService(typeof(ISmartPathFinder)).Returns(Substitute.For<ISmartPathFinder>());
-            serviceProviderMock.GetService(typeof(IMapRegionService)).Returns(Substitute.For<IMapRegionService>());
-
-            var combatOptions = new CombatOptions();
-            var optionsMock = Substitute.For<IOptions<CombatOptions>>();
-            optionsMock.Value.Returns(combatOptions);
-            serviceProviderMock.GetService(typeof(IOptions<CombatOptions>)).Returns(optionsMock);
-
-            _mockOwner.ServiceProvider.Returns(serviceProviderMock);
-
-            _characterCombat = new TestableCharacterCombat(_mockOwner);
+            _characterCombat = new TestableCharacterCombat(
+                _mockOwner,
+                Substitute.For<IAnimationBuilder>(),
+                Substitute.For<IGraphicBuilder>(),
+                Substitute.For<IProjectileBuilder>(),
+                Substitute.For<IMapRegionService>(),
+                Substitute.For<IGroundItemBuilder>(),
+                Substitute.For<IHitSplatBuilder>(),
+                Substitute.For<IProjectilePathFinder>(),
+                Substitute.For<ISmartPathFinder>(),
+                Options.Create(new CombatOptions()));
         }
 
         [TestMethod]
@@ -178,7 +175,21 @@ namespace Hagalaz.Services.GameWorld.Tests
 
     public class TestableCharacterCombat : CharacterCombat
     {
-        public TestableCharacterCombat(ICharacter owner) : base(owner) { }
+        public TestableCharacterCombat(
+            ICharacter owner,
+            IAnimationBuilder animationBuilder,
+            IGraphicBuilder graphicBuilder,
+            IProjectileBuilder projectileBuilder,
+            IMapRegionService mapRegionService,
+            IGroundItemBuilder groundItemBuilder,
+            IHitSplatBuilder hitSplatBuilder,
+            IProjectilePathFinder projectilePathFinder,
+            ISmartPathFinder smartPathFinder,
+            IOptions<CombatOptions> combatOptions)
+            : base(owner, animationBuilder, graphicBuilder, projectileBuilder, mapRegionService, groundItemBuilder,
+                hitSplatBuilder, projectilePathFinder, smartPathFinder, combatOptions)
+        {
+        }
 
         public void SetDead(bool isDead)
         {

--- a/Hagalaz.Services.GameWorld.Tests/Factories/CharacterScriptActivatorTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Factories/CharacterScriptActivatorTests.cs
@@ -1,0 +1,82 @@
+using Hagalaz.Game.Abstractions.Factories;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Widgets;
+using Hagalaz.Services.GameWorld.Factories;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Hagalaz.Services.GameWorld.Tests.Factories;
+
+[TestClass]
+public sealed class CharacterScriptActivatorTests
+{
+    [TestMethod]
+    public void CharacterScriptActivator_ResolvesFromProvidedScope()
+    {
+        var rootScript = Substitute.For<ICharacterScript>();
+        var scopedScript = Substitute.For<ICharacterScript>();
+        using var provider = new ServiceCollection()
+            .AddSingleton(rootScript)
+            .AddScoped<ICharacterScript>(_ => scopedScript)
+            .BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var result = new CharacterScriptActivator(scope.ServiceProvider).Create<ICharacterScript>();
+
+        Assert.AreSame(scopedScript, result);
+        Assert.AreNotSame(rootScript, result);
+    }
+
+    [TestMethod]
+    public void FamiliarScriptActivator_ResolvesTypeFromProvidedScope()
+    {
+        var rootScript = Substitute.For<IFamiliarScript>();
+        var scopedScript = Substitute.For<IFamiliarScript>();
+        using var provider = new ServiceCollection()
+            .AddSingleton(rootScript)
+            .AddScoped<IFamiliarScript>(_ => scopedScript)
+            .BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var result = new FamiliarScriptActivator(scope.ServiceProvider).Create(typeof(IFamiliarScript));
+
+        Assert.AreSame(scopedScript, result);
+        Assert.AreNotSame(rootScript, result);
+    }
+
+    [TestMethod]
+    public void CharacterNpcScriptActivator_ResolvesTypeFromProvidedScope()
+    {
+        var rootScript = Substitute.For<ICharacterNpcScript>();
+        var scopedScript = Substitute.For<ICharacterNpcScript>();
+        using var provider = new ServiceCollection()
+            .AddSingleton(rootScript)
+            .AddScoped<ICharacterNpcScript>(_ => scopedScript)
+            .BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var result = new CharacterNpcScriptActivator(scope.ServiceProvider).Create(typeof(ICharacterNpcScript));
+
+        Assert.AreSame(scopedScript, result);
+        Assert.AreNotSame(rootScript, result);
+    }
+
+    [TestMethod]
+    public void WidgetScriptActivator_ResolvesFromCharacterScope()
+    {
+        var rootScript = Substitute.For<IWidgetScript>();
+        var scopedScript = Substitute.For<IWidgetScript>();
+        using var provider = new ServiceCollection()
+            .AddSingleton(rootScript)
+            .AddScoped<IWidgetScript>(_ => scopedScript)
+            .BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var character = Substitute.For<ICharacter>();
+        character.ServiceProvider.Returns(scope.ServiceProvider);
+
+        var result = new WidgetScriptActivator().Create(character, typeof(IWidgetScript));
+
+        Assert.AreSame(scopedScript, result);
+        Assert.AreNotSame(rootScript, result);
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/Model/Creatures/Characters/WidgetContainerTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/Model/Creatures/Characters/WidgetContainerTests.cs
@@ -6,10 +6,10 @@ using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Game.Messages.Protocol;
 using Hagalaz.Services.GameWorld.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model;
-using Microsoft.Extensions.DependencyInjection;
 using Hagalaz.Game.Abstractions.Data;
 using Hagalaz.Services.GameWorld.Builders;
 using Hagalaz.Game.Abstractions.Builders.Widget;
+using Hagalaz.Game.Abstractions.Factories;
 
 namespace Hagalaz.Services.GameWorld.Tests.Model.Creatures.Characters
 {
@@ -32,13 +32,9 @@ namespace Hagalaz.Services.GameWorld.Tests.Model.Creatures.Characters
             _eventManagerMock = Substitute.For<IEventManager>();
             _characterMock.EventManager.Returns(_eventManagerMock);
 
-            var serviceProviderMock = Substitute.For<IServiceProvider>();
-            _characterMock.ServiceProvider.Returns(serviceProviderMock);
-
             _widgetScriptProviderMock = Substitute.For<IWidgetScriptProvider>();
-            serviceProviderMock.GetService(typeof(IWidgetScriptProvider)).Returns(_widgetScriptProviderMock);
 
-            _widgetContainer = new WidgetContainer(_characterMock);
+            _widgetContainer = new WidgetContainer(_characterMock, _widgetScriptProviderMock);
             _characterMock.Widgets.Returns(_widgetContainer);
         }
 
@@ -103,11 +99,12 @@ namespace Hagalaz.Services.GameWorld.Tests.Model.Creatures.Characters
         public void WidgetBuilder_BuildNonFrameWithoutActiveFrame_ThrowsInvalidOperationException()
         {
             // Arrange
-            var builder = new WidgetBuilder(_widgetScriptProviderMock);
+            var scriptActivatorMock = Substitute.For<IWidgetScriptActivator>();
+            var builder = new WidgetBuilder(_widgetScriptProviderMock, scriptActivatorMock);
             _widgetScriptProviderMock.FindScriptTypeById(100).Returns(typeof(IWidgetScript));
 
             var scriptMock = Substitute.For<IWidgetScript>();
-            _characterMock.ServiceProvider.GetService(typeof(IWidgetScript)).Returns(scriptMock);
+            scriptActivatorMock.Create(_characterMock, typeof(IWidgetScript)).Returns(scriptMock);
 
             // Act & Assert
             var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
@@ -122,11 +119,12 @@ namespace Hagalaz.Services.GameWorld.Tests.Model.Creatures.Characters
         public void WidgetBuilder_BuildAsFrameWithoutActiveFrame_Succeeds()
         {
             // Arrange
-            var builder = new WidgetBuilder(_widgetScriptProviderMock);
+            var scriptActivatorMock = Substitute.For<IWidgetScriptActivator>();
+            var builder = new WidgetBuilder(_widgetScriptProviderMock, scriptActivatorMock);
             _widgetScriptProviderMock.FindScriptTypeById(100).Returns(typeof(IWidgetScript));
 
             var scriptMock = Substitute.For<IWidgetScript>();
-            _characterMock.ServiceProvider.GetService(typeof(IWidgetScript)).Returns(scriptMock);
+            scriptActivatorMock.Create(_characterMock, typeof(IWidgetScript)).Returns(scriptMock);
 
             // Act
             var widget = builder.ForCharacter(_characterMock)

--- a/Hagalaz.Services.GameWorld/Builders/WidgetBuilder.cs
+++ b/Hagalaz.Services.GameWorld/Builders/WidgetBuilder.cs
@@ -1,16 +1,17 @@
 using System;
 using Hagalaz.Game.Abstractions.Builders.Widget;
+using Hagalaz.Game.Abstractions.Factories;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Widgets;
 using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Services.GameWorld.Model.Widgets;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Builders
 {
     public class WidgetBuilder : IWidgetBuilder, IWidgetId, IWidgetOptional, IWidgetCharacter
     {
         private readonly IWidgetScriptProvider _iWidgetScriptProvider;
+        private readonly IWidgetScriptActivator _widgetScriptActivator;
         private int _id;
         private int _transparency;
         private int? _parentId;
@@ -20,8 +21,13 @@ namespace Hagalaz.Services.GameWorld.Builders
         private ICharacter _character = default!;
         private bool _isFrame;
 
-        public WidgetBuilder(IWidgetScriptProvider iWidgetScriptProvider) => _iWidgetScriptProvider = iWidgetScriptProvider;
-        public IWidgetCharacter Create() => new WidgetBuilder(_iWidgetScriptProvider);
+        public WidgetBuilder(IWidgetScriptProvider iWidgetScriptProvider, IWidgetScriptActivator widgetScriptActivator)
+        {
+            _iWidgetScriptProvider = iWidgetScriptProvider;
+            _widgetScriptActivator = widgetScriptActivator;
+        }
+
+        public IWidgetCharacter Create() => new WidgetBuilder(_iWidgetScriptProvider, _widgetScriptActivator);
 
         public IWidgetOptional WithId(int id)
         {
@@ -34,7 +40,7 @@ namespace Hagalaz.Services.GameWorld.Builders
             if (_script == null)
             {
                 var scriptType = _scriptType ?? _iWidgetScriptProvider.FindScriptTypeById(_id);
-                _script = (IWidgetScript)_character.ServiceProvider.GetRequiredService(scriptType);
+                _script = _widgetScriptActivator.Create(_character, scriptType);
             }
 
             IWidget widget;

--- a/Hagalaz.Services.GameWorld/Factories/CharacterFactory.cs
+++ b/Hagalaz.Services.GameWorld/Factories/CharacterFactory.cs
@@ -18,8 +18,15 @@ namespace Hagalaz.Services.GameWorld.Factories
         public ICharacter Create(IGameSession session, IGameClient client)
         {
             var serviceScope = _serviceProvider.CreateScope();
-            var character = new Character(serviceScope, session, client);
-            return character;
+            try
+            {
+                return ActivatorUtilities.CreateInstance<Character>(serviceScope.ServiceProvider, serviceScope, session, client);
+            }
+            catch
+            {
+                serviceScope.Dispose();
+                throw;
+            }
         }
     }
 }

--- a/Hagalaz.Services.GameWorld/Factories/CharacterNpcScriptActivator.cs
+++ b/Hagalaz.Services.GameWorld/Factories/CharacterNpcScriptActivator.cs
@@ -1,0 +1,23 @@
+using System;
+using Hagalaz.Game.Abstractions.Factories;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hagalaz.Services.GameWorld.Factories
+{
+    /// <summary>
+    /// Activates character-NPC scripts from the current character scope.
+    /// </summary>
+    public sealed class CharacterNpcScriptActivator : ICharacterNpcScriptActivator
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public CharacterNpcScriptActivator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public ICharacterNpcScript Create(Type scriptType) =>
+            (ICharacterNpcScript)_serviceProvider.GetRequiredService(scriptType);
+    }
+}

--- a/Hagalaz.Services.GameWorld/Factories/CharacterScriptActivator.cs
+++ b/Hagalaz.Services.GameWorld/Factories/CharacterScriptActivator.cs
@@ -1,0 +1,23 @@
+using System;
+using Hagalaz.Game.Abstractions.Factories;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hagalaz.Services.GameWorld.Factories
+{
+    /// <summary>
+    /// Activates registered character scripts from the current character scope.
+    /// </summary>
+    public sealed class CharacterScriptActivator : ICharacterScriptActivator
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public CharacterScriptActivator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public TScript Create<TScript>() where TScript : class, ICharacterScript =>
+            _serviceProvider.GetRequiredService<TScript>();
+    }
+}

--- a/Hagalaz.Services.GameWorld/Factories/FamiliarScriptActivator.cs
+++ b/Hagalaz.Services.GameWorld/Factories/FamiliarScriptActivator.cs
@@ -1,0 +1,23 @@
+using System;
+using Hagalaz.Game.Abstractions.Factories;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hagalaz.Services.GameWorld.Factories
+{
+    /// <summary>
+    /// Activates familiar scripts from the current character scope.
+    /// </summary>
+    public sealed class FamiliarScriptActivator : IFamiliarScriptActivator
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public FamiliarScriptActivator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IFamiliarScript Create(Type scriptType) =>
+            (IFamiliarScript)_serviceProvider.GetRequiredService(scriptType);
+    }
+}

--- a/Hagalaz.Services.GameWorld/Factories/ItemContainerFactory.cs
+++ b/Hagalaz.Services.GameWorld/Factories/ItemContainerFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Hagalaz.Game.Abstractions.Collections;
 using Hagalaz.Game.Abstractions.Factories;
+using Hagalaz.Game.Abstractions.Builders.Item;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Services.GameWorld.Model.Creatures.Characters;
 
@@ -7,6 +8,11 @@ namespace Hagalaz.Services.GameWorld.Factories
 {
     public class ItemContainerFactory : IItemContainerFactory
     {
-        public IFamiliarInventoryContainer Create(ICharacter character, StorageType storageType, int capacity) => new FamiliarInventoryContainer(character, storageType, capacity);
+        private readonly IItemBuilder _itemBuilder;
+
+        public ItemContainerFactory(IItemBuilder itemBuilder) => _itemBuilder = itemBuilder;
+
+        public IFamiliarInventoryContainer Create(ICharacter character, StorageType storageType, int capacity) =>
+            new FamiliarInventoryContainer(character, storageType, capacity, _itemBuilder);
     }
 }

--- a/Hagalaz.Services.GameWorld/Factories/WidgetScriptActivator.cs
+++ b/Hagalaz.Services.GameWorld/Factories/WidgetScriptActivator.cs
@@ -1,0 +1,15 @@
+using System;
+using Hagalaz.Game.Abstractions.Factories;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Widgets;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hagalaz.Services.GameWorld.Factories;
+
+/// <inheritdoc />
+public sealed class WidgetScriptActivator : IWidgetScriptActivator
+{
+    /// <inheritdoc />
+    public IWidgetScript Create(ICharacter character, Type scriptType) =>
+        (IWidgetScript)character.ServiceProvider.GetRequiredService(scriptType);
+}

--- a/Hagalaz.Services.GameWorld/Logic/Characters/FarmingPatchTickTask.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Characters/FarmingPatchTickTask.cs
@@ -8,7 +8,6 @@ using Hagalaz.Game.Abstractions.Services.Model;
 using Hagalaz.Game.Abstractions.Tasks;
 using Hagalaz.Game.Common;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
-using Microsoft.Extensions.DependencyInjection;
 using Hagalaz.Game.Extensions;
 
 namespace Hagalaz.Services.GameWorld.Logic.Characters
@@ -32,6 +31,8 @@ namespace Hagalaz.Services.GameWorld.Logic.Characters
         /// The owner.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IFarmingService _farmingService;
+        private readonly IGameObjectService _gameObjectService;
 
         /// <summary>
         /// The flags
@@ -63,12 +64,17 @@ namespace Hagalaz.Services.GameWorld.Logic.Characters
         /// </summary>
         /// <param name="owner">The owner.</param>
         /// <param name="patchObjectID">The patch object identifier.</param>
-        public FarmingPatchTickTask(ICharacter owner, int patchObjectID)
+        public FarmingPatchTickTask(
+            ICharacter owner,
+            int patchObjectID,
+            IFarmingService farmingService,
+            IGameObjectService gameObjectService)
             : base()
         {
             _owner = owner;
-            var farmingManager = _owner.ServiceProvider.GetRequiredService<IFarmingService>();
-            PatchDefinition = farmingManager.FindPatchById(patchObjectID).Result!;
+            _farmingService = farmingService;
+            _gameObjectService = gameObjectService;
+            PatchDefinition = _farmingService.FindPatchById(patchObjectID).Result!;
             CurrentCycle = 0;
             TickActionMethod = Tick;
         }
@@ -234,8 +240,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Characters
         {
             _owner.QueueTask(async () =>
             {
-                var manager = _owner.ServiceProvider.GetRequiredService<IGameObjectService>();
-                var objDefinition = await manager.FindGameObjectDefinitionById(PatchDefinition.ObjectID);
+                var objDefinition = await _gameObjectService.FindGameObjectDefinitionById(PatchDefinition.ObjectID);
                 _owner.Configurations.SendBitConfiguration(objDefinition.VarpBitFileId,
                     HasCondition(PatchCondition.Planted) ? GetVarpBitValue() : CurrentCycle);
             });
@@ -374,8 +379,7 @@ namespace Hagalaz.Services.GameWorld.Logic.Characters
             TickCount = -hydration.CurrentCycleTicks;
             if (HasCondition(PatchCondition.Planted))
             {
-                var farmingManager = _owner.ServiceProvider.GetRequiredService<IFarmingService>();
-                Seed = farmingManager.FindSeedById(hydration.SeedId).Result;
+                Seed = _farmingService.FindSeedById(hydration.SeedId).Result;
             }
 
             // calculate the current cycle

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/BankContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/BankContainer.cs
@@ -10,7 +10,6 @@ using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Resources;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -35,11 +34,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// </summary>
         /// <param name="owner">The owner of the container.</param>
         /// <param name="capacity">The capacity of the container.</param>
-        public BankContainer(ICharacter owner, int capacity)
+        public BankContainer(ICharacter owner, int capacity, IItemBuilder itemBuilder)
             : base(StorageType.AlwaysStack, capacity)
         {
             _owner = owner;
-            _itemBuilder = owner.ServiceProvider.GetRequiredService<IItemBuilder>();
+            _itemBuilder = itemBuilder;
             _maximumCapacity = capacity;
         }
 

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Character.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Character.cs
@@ -2,21 +2,38 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hagalaz.Cache.Abstractions.Types.Providers;
 using Hagalaz.Game.Abstractions.Authorization;
+using Hagalaz.Game.Abstractions.Builders.Animation;
+using Hagalaz.Game.Abstractions.Builders.Audio;
+using Hagalaz.Game.Abstractions.Builders.Graphic;
+using Hagalaz.Game.Abstractions.Builders.GroundItem;
+using Hagalaz.Game.Abstractions.Builders.HitSplat;
+using Hagalaz.Game.Abstractions.Builders.Item;
+using Hagalaz.Game.Abstractions.Builders.Projectile;
 using Hagalaz.Game.Abstractions.Collections;
+using Hagalaz.Game.Abstractions.Factories;
 using Hagalaz.Game.Abstractions.Features.Clans;
+using Hagalaz.Game.Abstractions.Features;
 using Hagalaz.Game.Abstractions.Features.Shops;
+using Hagalaz.Game.Abstractions.Mediator;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Logic.Skills;
 using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
 using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
 using Hagalaz.Game.Common.Events;
+using Hagalaz.Configuration;
+using Hagalaz.Game.Configuration;
 using Hagalaz.Game.Extensions;
 using Hagalaz.Services.GameWorld.Model.Maps;
 using Hagalaz.Services.GameWorld.Providers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -44,6 +61,18 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// The path finder
         /// </summary>
         private readonly IPathFinder _pathFinder;
+
+        private readonly IMapRegionService _mapRegionService;
+        private readonly IMapUpdateService _mapUpdateService;
+        private readonly IMusicService _musicService;
+        private readonly IGameCommandPrompt _gameCommandPrompt;
+        private readonly ILogger<ICharacter> _logger;
+        private readonly IAudioBuilder _audioBuilder;
+        private readonly IGameMessageService _gameMessageService;
+        private readonly IFamiliarScriptProvider _familiarScriptProvider;
+        private readonly IFamiliarScriptActivator _familiarScriptActivator;
+        private readonly IStateService _stateService;
+        private readonly ICharacterScriptActivator _characterScriptActivator;
 
         /// <summary>
         /// The event manager
@@ -237,45 +266,100 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         public ClientChatType CurrentChatType { get; set; }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public Character(IServiceScope serviceScope, IGameSession session, IGameClient gameClient) : base(serviceScope)
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public Character(
+            IServiceScope serviceScope,
+            IGameSession session,
+            IGameClient gameClient,
+            ICharacterContextProvider contextProvider,
+            IEventManager eventManager,
+            IScopedGameMediator mediator,
+            ISmartPathFinder pathFinder,
+            IProjectilePathFinder projectilePathFinder,
+            IOptions<CombatOptions> combatOptions,
+            IOptions<SkillOptions> skillOptions,
+            IDefaultCharacterScriptProvider defaultCharacterScriptProvider,
+            ICharacterScriptActivator characterScriptActivator,
+            IFamiliarScriptProvider familiarScriptProvider,
+            IFamiliarScriptActivator familiarScriptActivator,
+            IStateService stateService,
+            IMapRegionService mapRegionService,
+            IMapUpdateService mapUpdateService,
+            IMusicService musicService,
+            IGameCommandPrompt gameCommandPrompt,
+            ILogger<ICharacter> logger,
+            IAudioBuilder audioBuilder,
+            IGameMessageService gameMessageService,
+            IItemBuilder itemBuilder,
+            IGroundItemBuilder groundItemBuilder,
+            IAnimationBuilder animationBuilder,
+            IGraphicBuilder graphicBuilder,
+            IProjectileBuilder projectileBuilder,
+            IHitSplatBuilder hitSplatBuilder,
+            INpcService npcService,
+            IBodyDataRepository bodyDataRepository,
+            ICharacterNpcScriptProvider characterNpcScriptProvider,
+            ICharacterNpcScriptActivator characterNpcScriptActivator,
+            IItemPartFactory itemPartFactory,
+            ICharacterLocationService characterLocationService,
+            IItemService itemService,
+            IClientMapDefinitionProvider clientMapDefinitionProvider,
+            ISlayerService slayerService,
+            IRatesService ratesService,
+            ISlayerTaskGenerator slayerTaskGenerator,
+            ISlayerTaskCompletedDialogue slayerTaskCompletedDialogue,
+            IFarmingService farmingService,
+            IGameObjectService gameObjectService,
+            IWidgetScriptProvider widgetScriptProvider)
+            : base(serviceScope)
         {
             GameClient = gameClient;
             Session = session;
-            var contextProvider = serviceScope.ServiceProvider.GetRequiredService<ICharacterContextProvider>();
+            _mapRegionService = mapRegionService;
+            _mapUpdateService = mapUpdateService;
+            _musicService = musicService;
+            _gameCommandPrompt = gameCommandPrompt;
+            _logger = logger;
+            _audioBuilder = audioBuilder;
+            _gameMessageService = gameMessageService;
+            _familiarScriptProvider = familiarScriptProvider;
+            _familiarScriptActivator = familiarScriptActivator;
+            _stateService = stateService;
+            _characterScriptActivator = characterScriptActivator;
             contextProvider.Context = new CharacterContext(this);
-            EventManager = ServiceProvider.GetRequiredService<IEventManager>();
-            _pathFinder = ServiceProvider.GetRequiredService<ISmartPathFinder>();
+            EventManager = eventManager;
+            _pathFinder = pathFinder;
             Configurations = new Configurations(this);
-            Widgets = new WidgetContainer(this);
+            Widgets = new WidgetContainer(this, widgetScriptProvider);
 
-            Viewport = new Viewport(this, MapRegionService, MapSize.Default);
-            Movement = new Movement(this);
+            Viewport = new Viewport(this, mapRegionService, MapSize.Default);
+            Movement = new Movement(this, pathFinder, mediator);
 
             // Render information is required while appearance details are hydrated.
-            RenderInformation = new CharacterRenderInformation(this);
+            RenderInformation = new CharacterRenderInformation(this, characterLocationService);
 
-            Inventory = new InventoryContainer(this, 28);
-            Equipment = new EquipmentContainer(this, 15);
-            Bank = new BankContainer(this, 500);
-            Rewards = new RewardContainer(this);
-            MoneyPouch = new MoneyPouchContainer(this);
-            Statistics = new CharacterStatistics(this);
-            Appearance = new CharacterAppearance(this);
-            Prayers = new Prayers(this);
-            Combat = new CharacterCombat(this);
+            Inventory = new InventoryContainer(this, 28, mapRegionService, groundItemBuilder, itemBuilder);
+            Equipment = new EquipmentContainer(this, 15, itemBuilder);
+            Bank = new BankContainer(this, 500, itemBuilder);
+            Rewards = new RewardContainer(this, itemBuilder);
+            MoneyPouch = new MoneyPouchContainer(this, itemBuilder);
+            Statistics = new CharacterStatistics(this, combatOptions, skillOptions, hitSplatBuilder);
+            Appearance = new CharacterAppearance(this, npcService, bodyDataRepository, characterNpcScriptProvider, characterNpcScriptActivator, itemPartFactory);
+            Prayers = new Prayers(this, animationBuilder, graphicBuilder);
+            Combat = new CharacterCombat(this, animationBuilder, graphicBuilder, projectileBuilder, mapRegionService, groundItemBuilder, hitSplatBuilder,
+                projectilePathFinder, pathFinder, combatOptions);
             Quests = new Quests(this);
-            Farming = new Farming(this);
-            Slayer = new Slayer(this);
-            Music = new Music(this);
+            Farming = new Farming(this, farmingService, gameObjectService);
+            Slayer = new Slayer(this, slayerService, ratesService, slayerTaskGenerator, slayerTaskCompletedDialogue, mediator);
+            Music = new Music(this, clientMapDefinitionProvider, musicService);
             Notes = new Notes(this);
-            Magic = new Magic(this);
+            Magic = new Magic(this, itemService);
             Profile = new Profile();
 
             // load scripts.
-            var scripts = ServiceProvider.GetRequiredService<IDefaultCharacterScriptProvider>().GetAllScripts().Cast<ICharacterScript>().ToList();
+            var scripts = defaultCharacterScriptProvider.GetAllScripts().Cast<ICharacterScript>().ToList();
             _scripts = scripts.ToDictionary(s => s.GetType(), s => s);
         }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         /// <summary>
         /// Character's cannot be destroyed,

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterAppearance.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterAppearance.cs
@@ -12,7 +12,6 @@ using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -61,11 +60,13 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// 
         /// </summary>
         private readonly ICharacterNpcScriptProvider _characterNpcScriptProvider;
+        private readonly ICharacterNpcScriptActivator _characterNpcScriptActivator;
 
         /// <summary>
         /// 
         /// </summary>
         private readonly IBodyDataRepository _bodyDataRepository;
+        private readonly IItemPartFactory _itemPartFactory;
 
         /// <summary>
         /// Contains boolean if character is visible.
@@ -214,11 +215,19 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Construct's new appearance class.
         /// </summary>
         /// <param name="owner"></param>
-        public CharacterAppearance(ICharacter owner)
+        public CharacterAppearance(
+            ICharacter owner,
+            INpcService npcDefinitionRepository,
+            IBodyDataRepository bodyDataRepository,
+            ICharacterNpcScriptProvider characterNpcScriptProvider,
+            ICharacterNpcScriptActivator characterNpcScriptActivator,
+            IItemPartFactory itemPartFactory)
         {
-            _npcDefinitionRepository = owner.ServiceProvider.GetRequiredService<INpcService>();
-            _bodyDataRepository = owner.ServiceProvider.GetRequiredService<IBodyDataRepository>();
-            _characterNpcScriptProvider = owner.ServiceProvider.GetRequiredService<ICharacterNpcScriptProvider>();
+            _npcDefinitionRepository = npcDefinitionRepository;
+            _bodyDataRepository = bodyDataRepository;
+            _characterNpcScriptProvider = characterNpcScriptProvider;
+            _characterNpcScriptActivator = characterNpcScriptActivator;
+            _itemPartFactory = itemPartFactory;
             _owner = owner;
             Size = 1;
             NpcId = -1;
@@ -237,7 +246,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         {
             NpcId = npcId;
             Size = _npcDefinitionRepository.FindNpcDefinitionById(npcId).Size;
-            PnpcScript = pnpcScript ?? (ICharacterNpcScript)_owner.ServiceProvider.GetRequiredService(_characterNpcScriptProvider.GetCharacterNpcScriptTypeById(npcId));
+            PnpcScript = pnpcScript ?? _characterNpcScriptActivator.Create(_characterNpcScriptProvider.GetCharacterNpcScriptTypeById(npcId));
             PnpcScript.Initialize(_owner);
             PnpcScript.OnTurnToNpc();
             DrawCharacter();
@@ -347,7 +356,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 return value;
             }
 
-            value = _owner.ServiceProvider.GetRequiredService<IItemPartFactory>().Create(itemId);
+            value = _itemPartFactory.Create(itemId);
             _allItemParts.Add(itemId, value);
             return value;
         }
@@ -542,10 +551,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
         public void Hydrate(HydratedItemAppearanceCollectionDto hydration)
         {
-            var itemPartFactory = _owner.ServiceProvider.GetRequiredService<IItemPartFactory>();
             foreach (var item in hydration.Appearances)
             {
-                var itemPart = itemPartFactory.Create(item.Id);
+                var itemPart = _itemPartFactory.Create(item.Id);
                 if (itemPart is IHydratable<HydratedItemAppearanceDto> itemPartHydratable)
                 {
                     itemPartHydratable.Hydrate(item);

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterCombat.cs
@@ -13,15 +13,17 @@ using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters.Actions;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
+using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Abstractions.Tasks;
 using Hagalaz.Game.Common;
 using Hagalaz.Game.Common.Events;
 using Hagalaz.Game.Common.Events.Character;
+using Hagalaz.Game.Configuration;
 using Hagalaz.Game.Extensions;
 using Hagalaz.Game.Resources;
 using Hagalaz.Game.Utilities;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -39,20 +41,34 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         private readonly IGraphicBuilder _graphicBuilder;
         private readonly IProjectileBuilder _projectileBuilder;
         private readonly IMapRegionService _mapRegionService;
+        private readonly IGroundItemBuilder _groundItemBuilder;
+        private readonly IHitSplatBuilder _hitSplatBuilder;
 
         /// <summary>
         /// Construct's new combat class for specified
         /// character.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public CharacterCombat(ICharacter owner)
-            : base(owner)
+        public CharacterCombat(
+            ICharacter owner,
+            IAnimationBuilder animationBuilder,
+            IGraphicBuilder graphicBuilder,
+            IProjectileBuilder projectileBuilder,
+            IMapRegionService mapRegionService,
+            IGroundItemBuilder groundItemBuilder,
+            IHitSplatBuilder hitSplatBuilder,
+            IProjectilePathFinder projectilePathFinder,
+            ISmartPathFinder smartPathFinder,
+            IOptions<CombatOptions> combatOptions)
+            : base(owner, projectilePathFinder, smartPathFinder, combatOptions, hitSplatBuilder)
         {
             _character = owner;
-            _animationBuilder = _character.ServiceProvider.GetRequiredService<IAnimationBuilder>();
-            _graphicBuilder = _character.ServiceProvider.GetRequiredService<IGraphicBuilder>();
-            _projectileBuilder = _character.ServiceProvider.GetRequiredService<IProjectileBuilder>();
-            _mapRegionService = _character.ServiceProvider.GetRequiredService<IMapRegionService>();
+            _animationBuilder = animationBuilder;
+            _graphicBuilder = graphicBuilder;
+            _projectileBuilder = projectileBuilder;
+            _mapRegionService = mapRegionService;
+            _groundItemBuilder = groundItemBuilder;
+            _hitSplatBuilder = hitSplatBuilder;
         }
 
 
@@ -130,11 +146,10 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 groundItemOwner = characterKiller;
             }
 
-            var groundItemBuilder = groundItemOwner.ServiceProvider.GetRequiredService<IGroundItemBuilder>();
             foreach (var item in
                      itemsOnDeath.droppedItems.Where(item => item.ItemScript.CanTradeItem(item, _character))) // check the current item owner if it can trade
             {
-                var groundItem = groundItemBuilder.Create()
+                var groundItem = _groundItemBuilder.Create()
                     .WithItem(item)
                     .WithLocation(Owner.Location)
                     .WithOwner(groundItemOwner)
@@ -143,7 +158,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                     .Add(groundItem); // we spawn it with this method, as the container was normally stacked.
             }
 
-            var bones = groundItemBuilder.Create()
+            var bones = _groundItemBuilder.Create()
                 .WithItem(builder => builder.Create().WithId(526))
                 .WithLocation(Owner.Location)
                 .WithOwner(groundItemOwner)
@@ -1365,7 +1380,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
             _character.Speak("Taste Vengeance!");
             _character.RemoveState<VengeanceState>();
-            var reflectSplat = _character.ServiceProvider.GetRequiredService<IHitSplatBuilder>()
+            var reflectSplat = _hitSplatBuilder
                 .Create()
                 .AddSprite(builder => builder.WithDamage(reflectBack).WithSplatType(HitSplatType.HitSimpleDamage))
                 .AddSprite(builder => builder.WithDamage(soaked).WithSplatType(HitSplatType.HitDefendedDamage))

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterRenderInformation.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterRenderInformation.cs
@@ -6,7 +6,6 @@ using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Messages.Protocol;
-using Microsoft.Extensions.DependencyInjection;
 using Characters_UpdateFlags = Hagalaz.Game.Abstractions.Model.Creatures.Characters.UpdateFlags;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
@@ -99,13 +98,13 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// <value>The current animation.</value>
         public IAnimation? CurrentAnimation { get; private set; }
 
-        public CharacterRenderInformation(ICharacter renderable)
+        public CharacterRenderInformation(ICharacter renderable, ICharacterLocationService characterLocationService)
         {
             _owner = renderable;
             LocalCharacters = [];
             LocalNpcs = [];
             _currentGraphics = new IGraphic[4];
-            _characterLocationMap = renderable.ServiceProvider.GetRequiredService<ICharacterLocationService>();
+            _characterLocationMap = characterLocationService;
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterStatistics.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/CharacterStatistics.cs
@@ -16,7 +16,6 @@ using Hagalaz.Game.Messages.Protocol;
 using Hagalaz.Game.Resources;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 using Hagalaz.Services.GameWorld.Model.Creatures.Combat;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Hagalaz.Game.Extensions;
 using Hagalaz.Game.Abstractions.Features.States.Effects;
@@ -90,6 +89,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         private readonly IOptions<CombatOptions> _combatOptions;
 
         private readonly IOptions<SkillOptions> _skillOptions;
+        private readonly IHitSplatBuilder _hitSplatBuilder;
 
         /// <summary>
         /// Gets the character's combat level. (Including summoning)
@@ -274,7 +274,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Constructs new statistics class.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public CharacterStatistics(ICharacter owner)
+        public CharacterStatistics(
+            ICharacter owner,
+            IOptions<CombatOptions> combatOptions,
+            IOptions<SkillOptions> skillOptions,
+            IHitSplatBuilder hitSplatBuilder)
         {
             _owner = owner;
             Bonuses = new Bonuses();
@@ -296,8 +300,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             RunEnergy = MaximumRunEnergy;
             SpecialEnergy = MaximumSpecialEnergy;
 
-            _combatOptions = owner.ServiceProvider.GetRequiredService<IOptions<CombatOptions>>();
-            _skillOptions = owner.ServiceProvider.GetRequiredService<IOptions<SkillOptions>>();
+            _combatOptions = combatOptions;
+            _skillOptions = skillOptions;
+            _hitSplatBuilder = hitSplatBuilder;
         }
 
         /// <summary>
@@ -1341,7 +1346,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 if (PoisonAmount >= 10)
                 {
                     var amt = DamageLifePoints(PoisonAmount);
-                    var splat = _owner.ServiceProvider.GetRequiredService<IHitSplatBuilder>()
+                    var splat = _hitSplatBuilder
                         .Create()
                         .AddSprite(builder => builder.WithDamage(amt).WithSplatType(HitSplatType.HitPoisonDamage))
                         .Build();

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/EquipmentContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/EquipmentContainer.cs
@@ -11,7 +11,6 @@ using Hagalaz.Game.Abstractions.Model.Creatures.Characters.Actions;
 using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -25,6 +24,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Instance of the character who owns this container.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IItemBuilder _itemBuilder;
 
         /// <summary>
         /// Gets the item by the specified array index.
@@ -38,9 +38,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// </summary>
         /// <param name="owner">The owner of the container.</param>
         /// <param name="capacity">The capacity of the container.</param>
-        public EquipmentContainer(ICharacter owner, int capacity)
+        public EquipmentContainer(ICharacter owner, int capacity, IItemBuilder itemBuilder)
             : base(StorageType.Normal, capacity) =>
-            _owner = owner;
+            (_owner, _itemBuilder) = (owner, itemBuilder);
 
         /// <summary>
         /// Called when multiple items from specified slot(s) have changed.
@@ -326,10 +326,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         public void Hydrate(IReadOnlyList<HydratedItemDto> equipment)
         {
             var items = new IItem[Capacity];
-            var itemBuilder = _owner.ServiceProvider.GetRequiredService<IItemBuilder>();
             foreach (var hydrated in equipment)
             {
-                var builder = itemBuilder.Create().WithId(hydrated.ItemId).WithCount(hydrated.Count);
+                var builder = _itemBuilder.Create().WithId(hydrated.ItemId).WithCount(hydrated.Count);
                 if (!string.IsNullOrEmpty(hydrated.ExtraData))
                 {
                     builder.WithExtraData(hydrated.ExtraData);

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/EventMethods.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/EventMethods.cs
@@ -4,7 +4,6 @@ using Hagalaz.Game.Abstractions.Features;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Events;
 using Hagalaz.Game.Common.Events.Character.Packet;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
@@ -28,14 +27,12 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         {
             try
             {
-                var commands = ServiceProvider.GetRequiredService<IGameCommandPrompt>();
                 var (command, arguments) = ParseCommandAndArguments(commandAndArgs);
-                return await commands.ExecuteAsync(command, this, arguments);
+                return await _gameCommandPrompt.ExecuteAsync(command, this, arguments);
             }
             catch (Exception ex)
             {
-                var logger = ServiceProvider.GetRequiredService<ILogger<ICharacter>>();
-                logger.LogError(ex, "Error while handling character command: {Command}", commandAndArgs);
+                _logger.LogError(ex, "Error while handling character command: {Command}", commandAndArgs);
                 return false;
             }
         }

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/FamiliarInventoryContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/FamiliarInventoryContainer.cs
@@ -9,7 +9,6 @@ using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Resources;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -22,6 +21,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Instance of the character who owns this container.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IItemBuilder _itemBuilder;
 
         /// <summary>
         /// Constructs a container for character inventories.
@@ -29,9 +29,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// <param name="owner">The owner of the container.</param>
         /// <param name="type">The type of container.</param>
         /// <param name="capacity">The capacity of the container.</param>
-        public FamiliarInventoryContainer(ICharacter owner, StorageType type, int capacity)
+        public FamiliarInventoryContainer(ICharacter owner, StorageType type, int capacity, IItemBuilder itemBuilder)
             : base(type, capacity) =>
-            _owner = owner;
+            (_owner, _itemBuilder) = (owner, itemBuilder);
 
         /// <summary>
         /// Deposit's specific item into familiars inventory.
@@ -109,10 +109,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         public void Hydrate(IReadOnlyList<HydratedItem> inventory)
         {
             var items = new IItem[Capacity];
-            var itemBuilder = _owner.ServiceProvider.GetRequiredService<IItemBuilder>();
             foreach (var hydrated in inventory)
             {
-                var builder = itemBuilder.Create().WithId(hydrated.ItemId).WithCount(hydrated.Count);
+                var builder = _itemBuilder.Create().WithId(hydrated.ItemId).WithCount(hydrated.Count);
                 if (!string.IsNullOrEmpty(hydrated.ExtraData))
                 {
                     builder.WithExtraData(hydrated.ExtraData);

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Farming.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Farming.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Hagalaz.Game.Abstractions.Logic.Dehydrations;
 using Hagalaz.Game.Abstractions.Logic.Hydrations;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Services.GameWorld.Logic.Characters;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 
@@ -17,6 +18,8 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// The owner.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IFarmingService _farmingService;
+        private readonly IGameObjectService _gameObjectService;
 
         /// <summary>
         /// The patches.
@@ -27,7 +30,12 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Initializes a new instance of the <see cref="Farming"/> class.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public Farming(ICharacter owner) => _owner = owner;
+        public Farming(ICharacter owner, IFarmingService farmingService, IGameObjectService gameObjectService)
+        {
+            _owner = owner;
+            _farmingService = farmingService;
+            _gameObjectService = gameObjectService;
+        }
 
         /// <summary>
         /// Gets the or create farming patch.
@@ -42,7 +50,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 return patch;
             }
 
-            var patchTickTask = new FarmingPatchTickTask(_owner, patchObjectID);
+            var patchTickTask = new FarmingPatchTickTask(_owner, patchObjectID, _farmingService, _gameObjectService);
             _patches.Add(patchObjectID, patchTickTask);
             _owner.QueueTask(patchTickTask);
             return patchTickTask;
@@ -78,7 +86,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         {
             foreach (var hydratedPatch in hydration.Patches)
             {
-                var patch = new FarmingPatchTickTask(_owner, hydratedPatch.Id);
+                var patch = new FarmingPatchTickTask(_owner, hydratedPatch.Id, _farmingService, _gameObjectService);
                 patch.Hydrate(hydratedPatch);
                 _patches.Add(hydratedPatch.Id, patch);
                 _owner.QueueTask(patch);

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/GameMethods.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/GameMethods.cs
@@ -14,7 +14,6 @@ using Hagalaz.Game.Abstractions.Services.Model;
 using Hagalaz.Game.Common.Events;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Messages.Protocol;
-using Microsoft.Extensions.DependencyInjection;
 using Hagalaz.Game.Extensions;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
@@ -152,9 +151,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 return;
             }
 
-            var soundBuilder = ServiceProvider.GetRequiredService<IAudioBuilder>();
-
-            var sound = soundBuilder.Create().AsMusicEffect().WithId(90).Build(); // death music effect
+            var sound = _audioBuilder.Create().AsMusicEffect().WithId(90).Build(); // death music effect
             Session.SendMessage(sound.ToMessage());
             EventManager.SendEvent(new CreatureDiedEvent(this));
             Movement.Lock(true); // reset the movement and lock the character
@@ -410,8 +407,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 //database.ExecuteAsync(new ActivityLogQuery(MasterId,
                 //    "Max-Experience",
                 //    "I have achieved 200 million XP in " + StatisticsConstants.SkillNames[skillID] + "."));
-                var announcement = ServiceProvider.GetRequiredService<IGameMessageService>();
-                announcement.MessageAsync(DisplayName + " has just achieved 200 million XP in " + StatisticsConstants.SkillNames[skillID] + ".",
+                _gameMessageService.MessageAsync(DisplayName + " has just achieved 200 million XP in " + StatisticsConstants.SkillNames[skillID] + ".",
                     GameMessageType.WorldSpecific,
                     DisplayName);
             }
@@ -498,7 +494,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// </summary>
         /// <typeparam name="TScriptType">The type of the script type.</typeparam>
         /// <returns></returns>
-        public TScriptType AddScript<TScriptType>() where TScriptType : class, ICharacterScript => AddScript(ServiceProvider.GetRequiredService<TScriptType>());
+        public TScriptType AddScript<TScriptType>() where TScriptType : class, ICharacterScript => AddScript(_characterScriptActivator.Create<TScriptType>());
 
         /// <summary>
         /// Loads the script.

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/HydrationMethods.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/HydrationMethods.cs
@@ -9,7 +9,6 @@ using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 using Hagalaz.Services.GameWorld.Services.Model;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -178,9 +177,8 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
         public void Hydrate(HydratedFamiliarDto hydration)
         {
-            var provider = ServiceProvider.GetRequiredService<IFamiliarScriptProvider>();
-            var scriptType = provider.FindFamiliarScriptTypeById(hydration.FamiliarId);
-            FamiliarScript = (IFamiliarScript)ServiceProvider.GetRequiredService(scriptType);
+            var scriptType = _familiarScriptProvider.FindFamiliarScriptTypeById(hydration.FamiliarId);
+            FamiliarScript = _familiarScriptActivator.Create(scriptType);
             if (FamiliarScript is IHydratable<HydratedFamiliar> hydratable)
             {
                 hydratable.Hydrate(new HydratedFamiliar
@@ -313,10 +311,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
         public void Hydrate(HydratedStateDto hydration)
         {
-            var stateService = ServiceProvider.GetRequiredService<IStateService>();
             foreach (var state in hydration.StatesEx)
             {
-                if (!stateService.TryCreateState(state.Id, out var stateObject) || stateObject is not IPersistentState)
+                if (!_stateService.TryCreateState(state.Id, out var stateObject) || stateObject is not IPersistentState)
                 {
                     continue;
                 }
@@ -332,11 +329,10 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
         HydratedStateDto IDehydratable<HydratedStateDto>.Dehydrate()
         {
-            var stateService = ServiceProvider.GetRequiredService<IStateService>();
             var states = new List<HydratedStateDto.HydratedStateExDto>();
             foreach (var state in GetStates())
             {
-                if (state is not IPersistentState || !stateService.TryGetStateId(state, out var stateId))
+                if (state is not IPersistentState || !_stateService.TryGetStateId(state, out var stateId))
                 {
                     continue;
                 }

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/InventoryContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/InventoryContainer.cs
@@ -10,7 +10,6 @@ using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -25,15 +24,22 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// </summary>
         private readonly ICharacter _owner;
         private readonly IMapRegionService _mapRegionService;
+        private readonly IGroundItemBuilder _groundItemBuilder;
+        private readonly IItemBuilder _itemBuilder;
 
         /// <summary>
         /// Contstructs a container for character inventories.
         /// </summary>
         /// <param name="owner">The owner of the container.</param>
         /// <param name="capacity">The capacity of the container.</param>
-        public InventoryContainer(ICharacter owner, int capacity)
+        public InventoryContainer(
+            ICharacter owner,
+            int capacity,
+            IMapRegionService mapRegionService,
+            IGroundItemBuilder groundItemBuilder,
+            IItemBuilder itemBuilder)
             : base(StorageType.Normal, capacity) =>
-            (_owner, _mapRegionService) = (owner, owner.ServiceProvider.GetRequiredService<IMapRegionService>());
+            (_owner, _mapRegionService, _groundItemBuilder, _itemBuilder) = (owner, mapRegionService, groundItemBuilder, itemBuilder);
 
         /// <summary>
         /// Called when multiple items from specified slot(s) have changed.
@@ -51,8 +57,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
             var slot = GetInstanceSlot(item);
             if (slot == -1) return false;
             if (Remove(item, slot) < item.Count) return false;
-            var groundItemBuilder = _owner.ServiceProvider.GetRequiredService<IGroundItemBuilder>();
-            var groundItem = groundItemBuilder.Create()
+            var groundItem = _groundItemBuilder.Create()
                 .WithItem(item)
                 .WithLocation(_owner.Location)
                 .WithOwner(_owner)
@@ -65,10 +70,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         public void Hydrate(IReadOnlyList<HydratedItemDto> inventory)
         {
             var items = new IItem[Capacity];
-            var itemBuilder = _owner.ServiceProvider.GetRequiredService<IItemBuilder>();
             foreach (var hydrated in inventory)
             {
-                var builder = itemBuilder.Create().WithId(hydrated.ItemId).WithCount(hydrated.Count);
+                var builder = _itemBuilder.Create().WithId(hydrated.ItemId).WithCount(hydrated.Count);
                 if (!string.IsNullOrEmpty(hydrated.ExtraData))
                 {
                     builder.WithExtraData(hydrated.ExtraData);

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Magic.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Magic.cs
@@ -4,7 +4,6 @@ using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters.Actions;
 using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Abstractions.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -17,6 +16,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Contains owner of this class.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IItemService _itemService;
         /// <summary>
         /// Contains spell that is being autocasted.
         /// </summary>
@@ -30,9 +30,10 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Construct's new magic class with given owner.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public Magic(ICharacter owner)
+        public Magic(ICharacter owner, IItemService itemService)
         {
             _owner = owner;
+            _itemService = itemService;
         }
 
         /// <summary>
@@ -137,7 +138,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                     continue;
                 }
 
-                _owner.SendChatMessage("You don't have enough " + _owner.ServiceProvider.GetRequiredService<IItemService>().FindItemDefinitionById((int)types[i]).Name.ToLower() + "s" + " to cast this spell.");
+                _owner.SendChatMessage("You don't have enough " + _itemService.FindItemDefinitionById((int)types[i]).Name.ToLower() + "s" + " to cast this spell.");
                 return false;
             }
             return true;

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/MoneyPouchContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/MoneyPouchContainer.cs
@@ -11,7 +11,6 @@ using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Resources;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 using Hagalaz.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -57,11 +56,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Contstructs a container for character inventories.
         /// </summary>
         /// <param name="owner">The owner of the container.</param>
-        public MoneyPouchContainer(ICharacter owner)
+        public MoneyPouchContainer(ICharacter owner, IItemBuilder itemBuilder)
             : base(StorageType.Normal, 1)
         {
             _owner = owner;
-            _itemBuilder = owner.ServiceProvider.GetRequiredService<IItemBuilder>();
+            _itemBuilder = itemBuilder;
             var coins = _itemBuilder.Create().WithId(995).WithCount(0).Build();
             Items = [coins];
             CountToResetTo = 0;

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Music.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Music.cs
@@ -13,7 +13,6 @@ using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Messages.Protocol;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 using Hagalaz.Game.Extensions;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -36,6 +35,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         private readonly ICharacter _owner;
 
         private readonly IClientMapDefinitionProvider _clientMapDefinitionProvider;
+        private readonly IMusicService _musicService;
 
         /// <summary>
         /// The unlocked music.
@@ -103,11 +103,12 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Initializes a new instance of the <see cref="Music"/> class.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public Music(ICharacter owner)
+        public Music(ICharacter owner, IClientMapDefinitionProvider clientMapDefinitionProvider, IMusicService musicService)
         {
             _owner = owner;
             PlayingMusicIndex = -1;
-            _clientMapDefinitionProvider = owner.ServiceProvider.GetRequiredService<IClientMapDefinitionProvider>();
+            _clientMapDefinitionProvider = clientMapDefinitionProvider;
+            _musicService = musicService;
         }
 
         /// <summary>
@@ -184,8 +185,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         {
             _owner.QueueTask(async () =>
             {
-                var service = _owner.ServiceProvider.GetRequiredService<IMusicService>();
-                var music = await service.FindMusicByIndex(musicIndex);
+                var music = await _musicService.FindMusicByIndex(musicIndex);
                 if (music != null)
                 {
                     _owner.SendChatMessage(music.Hint);

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Prayers.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Prayers.cs
@@ -7,7 +7,6 @@ using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Common.Events;
 using Hagalaz.Game.Common.Events.Character;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -49,14 +48,14 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Construct's new prayers component.
         /// </summary>
         /// <param name="owner"></param>
-        public Prayers(ICharacter owner)
+        public Prayers(ICharacter owner, IAnimationBuilder animationBuilder, IGraphicBuilder graphicBuilder)
         {
             _owner = owner;
             _prayerStatus = new int[30];
             _prayersDrainStatus = new int[30];
             QuickPrayer = new QuickPrayer(owner);
-            _animationBuilder = owner.ServiceProvider.GetRequiredService<IAnimationBuilder>();
-            _graphicBuilder = owner.ServiceProvider.GetRequiredService<IGraphicBuilder>();
+            _animationBuilder = animationBuilder;
+            _graphicBuilder = graphicBuilder;
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/RegionMethods.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/RegionMethods.cs
@@ -2,7 +2,6 @@
 using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Services;
 using Hagalaz.Game.Common;
-using Microsoft.Extensions.DependencyInjection;
 using Hagalaz.Game.Extensions;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
@@ -16,7 +15,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Update's character visible regions.
         /// </summary>
         public void UpdateMap(bool forceUpdate, bool renderViewPort = false) =>
-            ServiceProvider.GetRequiredService<IMapUpdateService>().UpdateMap(this, forceUpdate, renderViewPort);
+            _mapUpdateService.UpdateMap(this, forceUpdate, renderViewPort);
 
         /// <summary>
         /// Notifies character that it must add itself to given region.
@@ -37,10 +36,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         {
             this.QueueTask(async () =>
             {
-                var musicService = ServiceProvider.GetRequiredService<IMusicService>();
-                var region = ServiceProvider.GetRequiredService<IMapRegionService>()
+                var region = _mapRegionService
                     .GetOrCreateMapRegion(Location.RegionId, Location.Dimension, false);
-                var musicIds = await musicService.FindMusicIdsByRegionId(region.Id);
+                var musicIds = await _musicService.FindMusicIdsByRegionId(region.Id);
                 if (musicIds.Any(musicId => Music.UnlockMusic(musicId)))
                 {
                     Music.RefreshMusicList();

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/RewardContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/RewardContainer.cs
@@ -9,7 +9,6 @@ using Hagalaz.Game.Abstractions.Model.Items;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Resources;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -30,11 +29,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Contstructs a container for character ingame mail.
         /// </summary>
         /// <param name="owner">The owner of the container.</param>
-        public RewardContainer(ICharacter owner)
+        public RewardContainer(ICharacter owner, IItemBuilder itemBuilder)
             : base(StorageType.AlwaysStack, byte.MaxValue)
         {
             _owner = owner;
-            _itemBuilder = owner.ServiceProvider.GetRequiredService<IItemBuilder>();
+            _itemBuilder = itemBuilder;
         }
 
         /// <summary>

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Slayer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/Slayer.cs
@@ -3,6 +3,7 @@ using Hagalaz.Configuration;
 using Hagalaz.Game.Abstractions.Logic.Dehydrations;
 using Hagalaz.Game.Abstractions.Logic.Hydrations;
 using Hagalaz.Game.Abstractions.Logic.Skills;
+using Hagalaz.Game.Abstractions.Mediator;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters.Actions;
 using Hagalaz.Game.Abstractions.Model.Creatures.Npcs;
@@ -12,7 +13,6 @@ using Hagalaz.Game.Common.Events;
 using Hagalaz.Game.Configuration;
 using Hagalaz.Services.GameWorld.Logic.Characters.Model;
 using Hagalaz.Game.Extensions;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -25,6 +25,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// The owner.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly ISlayerService _slayerService;
+        private readonly IRatesService _ratesService;
+        private readonly ISlayerTaskGenerator _slayerTaskGenerator;
+        private readonly ISlayerTaskCompletedDialogue _slayerTaskCompletedDialogue;
+        private readonly IGameMediator _mediator;
 
         /// <summary>
         /// The creature killed handler.
@@ -45,7 +50,21 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Initializes a new instance of the <see cref="Slayer"/> class.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public Slayer(ICharacter owner) => _owner = owner;
+        public Slayer(
+            ICharacter owner,
+            ISlayerService slayerService,
+            IRatesService ratesService,
+            ISlayerTaskGenerator slayerTaskGenerator,
+            ISlayerTaskCompletedDialogue slayerTaskCompletedDialogue,
+            IGameMediator mediator)
+        {
+            _owner = owner;
+            _slayerService = slayerService;
+            _ratesService = ratesService;
+            _slayerTaskGenerator = slayerTaskGenerator;
+            _slayerTaskCompletedDialogue = slayerTaskCompletedDialogue;
+            _mediator = mediator;
+        }
 
         /// <summary>
         /// Called when [started].
@@ -69,8 +88,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                     return false; // allow other events to catch a creature killed event.
                 }
 
-                var slayerService = _owner.ServiceProvider.GetRequiredService<ISlayerService>();
-                var task = slayerService.FindSlayerTaskDefinition(CurrentTaskId).Result;
+                var task = _slayerService.FindSlayerTaskDefinition(CurrentTaskId).Result;
                 if (task == null)
                 {
                     return false; // allow other events to catch a creature killed event.
@@ -98,7 +116,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 _creatureKilledHandler = null;
             }
 
-            var task = _owner.ServiceProvider.GetRequiredService<ISlayerService>().FindSlayerTaskDefinition(CurrentTaskId).Result;
+            var task = _slayerService.FindSlayerTaskDefinition(CurrentTaskId).Result;
             if (task == null)
             {
                 return;
@@ -106,15 +124,13 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
             if (task.CoinCount > 0)
             {
-                var ratesService = _owner.ServiceProvider.GetRequiredService<IRatesService>();
-                var coinCountRate = ratesService.GetRate<ItemOptions>(i => i.CoinCountRate);
+                var coinCountRate = _ratesService.GetRate<ItemOptions>(i => i.CoinCountRate);
                 // TODO - Calculate coins earned based on difficulty
                 var coinsEarned = (int)(task.CoinCount * coinCountRate);
                 _owner.Inventory.TryAddItems(_owner, [(995, coinsEarned)], out _);
             }
 
-            var slayerManager = _owner.ServiceProvider.GetRequiredService<ISlayerService>();
-            var masterTable = slayerManager.FindSlayerMasterTableByNpcId(task.SlayerMasterId).Result;
+            var masterTable = _slayerService.FindSlayerMasterTableByNpcId(task.SlayerMasterId).Result;
             if (masterTable == null)
             {
                 return;
@@ -122,9 +138,9 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 
             var pointsEarned = masterTable.BaseSlayerRewardPoints;
             // TODO - x5 points after 10 tasks, x15 points after 50 tasks
-            _owner.Mediator.Publish(new ProfileIncrementIntAction(ProfileConstants.SlayerRewardPoints, pointsEarned));
+            _mediator.Publish(new ProfileIncrementIntAction(ProfileConstants.SlayerRewardPoints, pointsEarned));
 
-            _owner.Widgets.OpenDialogue(_owner.ServiceProvider.GetRequiredService<ISlayerTaskCompletedDialogue>(), true);
+            _owner.Widgets.OpenDialogue(_slayerTaskCompletedDialogue, true);
             CurrentTaskId = -1;
         }
 
@@ -140,17 +156,15 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
                 _creatureKilledHandler = null;
             }
 
-            var slayerManager = _owner.ServiceProvider.GetRequiredService<ISlayerService>();
-            var slayerTaskGenerator = _owner.ServiceProvider.GetRequiredService<ISlayerTaskGenerator>();
             _owner.QueueTask(async () =>
             {
-                var table = await slayerManager.FindSlayerMasterTableByNpcId(slayerMasterId);
+                var table = await _slayerService.FindSlayerMasterTableByNpcId(slayerMasterId);
                 if (table == null)
                 {
                     return;
                 }
 
-                var results = slayerTaskGenerator.GenerateTask(new SlayerTaskParams(table, _owner)).ToArray();
+                var results = _slayerTaskGenerator.GenerateTask(new SlayerTaskParams(table, _owner)).ToArray();
 
                 var result = results.FirstOrDefault();
                 if (result == null)

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/WidgetContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/WidgetContainer.cs
@@ -9,7 +9,6 @@ using Hagalaz.Game.Abstractions.Providers;
 using Hagalaz.Game.Common.Events.Character;
 using Hagalaz.Game.Messages.Protocol;
 using Hagalaz.Services.GameWorld.Model.Widgets;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
 {
@@ -22,6 +21,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Contains owner of this class.
         /// </summary>
         private readonly ICharacter _owner;
+        private readonly IWidgetScriptProvider _widgetScriptProvider;
 
         /// <summary>
         /// Contains opened interfaces.
@@ -55,7 +55,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// Construct's new interfaces container.
         /// </summary>
         /// <param name="owner">The owner.</param>
-        public WidgetContainer(ICharacter owner) => _owner = owner;
+        public WidgetContainer(ICharacter owner, IWidgetScriptProvider widgetScriptProvider)
+        {
+            _owner = owner;
+            _widgetScriptProvider = widgetScriptProvider;
+        }
 
         /// <summary>
         /// Opens standart interface.
@@ -497,8 +501,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// <returns>Return's if the Id is valid.</returns>
         private bool IsValidInterfaceID(int interfaceID)
         {
-            var manager = _owner.ServiceProvider.GetRequiredService<IWidgetScriptProvider>();
-            return interfaceID >= 0 && interfaceID < manager.GetInterfacesCount();
+            return interfaceID >= 0 && interfaceID < _widgetScriptProvider.GetInterfacesCount();
         }
 
         public bool TryGetOpenWidget(int interfaceId, [NotNullWhen(true)] out IWidget? gameInterface)

--- a/Hagalaz.Services.GameWorld/Model/Creatures/CreatureCombat.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/CreatureCombat.cs
@@ -40,6 +40,7 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
         /// <summary>
         /// The projectile path finder
         /// </summary>
+        protected readonly IHitSplatBuilder HitSplatBuilder;
         private readonly IProjectilePathFinder _projectilePathFinder;
 
         /// <summary>
@@ -94,13 +95,29 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
         /// </summary>
         /// <param name="owner">Owner of this class.</param>
         protected CreatureCombat(ICreature owner)
+            : this(
+                owner,
+                owner.ServiceProvider.GetRequiredService<IProjectilePathFinder>(),
+                owner.ServiceProvider.GetRequiredService<ISmartPathFinder>(),
+                owner.ServiceProvider.GetRequiredService<IOptions<CombatOptions>>(),
+                owner.ServiceProvider.GetRequiredService<IHitSplatBuilder>())
+        {
+        }
+
+        protected CreatureCombat(
+            ICreature owner,
+            IProjectilePathFinder projectilePathFinder,
+            ISmartPathFinder smartPathFinder,
+            IOptions<CombatOptions> combatOptions,
+            IHitSplatBuilder hitSplatBuilder)
         {
             Owner = owner;
             DelayTick = 17;
 
-            _projectilePathFinder = owner.ServiceProvider.GetRequiredService<IProjectilePathFinder>();
-            _smartPathFinder = owner.ServiceProvider.GetRequiredService<ISmartPathFinder>();
-            _combatOptions = owner.ServiceProvider.GetRequiredService<IOptions<CombatOptions>>();
+            HitSplatBuilder = hitSplatBuilder;
+            _projectilePathFinder = projectilePathFinder;
+            _smartPathFinder = smartPathFinder;
+            _combatOptions = combatOptions;
         }
 
         /// <summary>
@@ -303,13 +320,12 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
             var distance = Owner.Location.GetDistance(attackParams.Target.Location);
             var delay = attackParams.Delay + (int)Math.Round(Math.Max(0, distance - 1) * 2);
 
-            var hitSplatBuilder = Owner.ServiceProvider.GetRequiredService<IHitSplatBuilder>();
             var incomingDamage = attackParams.Target.Combat.IncomingAttack(Owner, attackParams.DamageType, attackParams.Damage, delay);
             return attackParams.Target.QueueTask(new RsTask<AttackResult>(() =>
             {
                 var soak = -1;
                 var damage = attackParams.Target.Combat.Attack(Owner, attackParams.DamageType, incomingDamage, ref soak);
-                var splat = hitSplatBuilder.Create()
+                var splat = HitSplatBuilder.Create()
                     .AddSprite(builder =>
                     {
                         builder

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Movement.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Movement.cs
@@ -4,6 +4,7 @@ using Hagalaz.Configuration;
 using Hagalaz.Game.Abstractions.Model;
 using Hagalaz.Game.Abstractions.Model.Creatures;
 using Hagalaz.Game.Abstractions.Model.Creatures.Characters.Events;
+using Hagalaz.Game.Abstractions.Mediator;
 using Hagalaz.Game.Abstractions.Model.Maps;
 using Hagalaz.Game.Abstractions.Model.Maps.PathFinding;
 using Microsoft.Extensions.DependencyInjection;
@@ -164,11 +165,16 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures
         /// </summary>
         /// <param name="owner"></param>
         public Movement(Creature owner)
+            : this(owner, owner.ServiceProvider.GetRequiredService<ISmartPathFinder>(), owner.Mediator)
+        {
+        }
+
+        public Movement(Creature owner, IPathFinder pathFinder, IGameMediator mediator)
         {
             _owner = owner;
             _movementType = MovementType.Walk;
-            _pathFinder = owner.ServiceProvider.GetRequiredService<ISmartPathFinder>();
-            owner.Mediator.ConnectHandler<ProfileValueChanged<bool>>(context =>
+            _pathFinder = pathFinder;
+            mediator.ConnectHandler<ProfileValueChanged<bool>>(context =>
             {
                 if (context.Message.Key == ProfileConstants.RunSettingsToggled)
                 {

--- a/Hagalaz.Services.GameWorld/Startup.cs
+++ b/Hagalaz.Services.GameWorld/Startup.cs
@@ -184,6 +184,9 @@ namespace Hagalaz.Services.GameWorld
             services.AddSingleton<ICharacterStore, CharacterStore>();
             services.AddScoped<ICharacterRenderMasksWriter, CharacterRenderMasksWriter>();
             services.AddScoped<IDefaultCharacterScriptProvider, DefaultCharacterScriptProvider>();
+            services.AddScoped<ICharacterScriptActivator, CharacterScriptActivator>();
+            services.AddScoped<IFamiliarScriptActivator, FamiliarScriptActivator>();
+            services.AddScoped<ICharacterNpcScriptActivator, CharacterNpcScriptActivator>();
             services.AddSingleton<CharacterNpcScriptProvider>();
             services.AddSingleton<ICharacterNpcScriptProvider>(provider => provider.GetRequiredService<CharacterNpcScriptProvider>());
             services.AddScoped<ICharacterNpcScriptFactory, CharacterNpcScriptMetaDataFactory>();
@@ -309,6 +312,7 @@ namespace Hagalaz.Services.GameWorld
             services.AddSingleton<WidgetScriptProvider>();
             services.AddSingleton<IWidgetScriptProvider>(provider => provider.GetRequiredService<WidgetScriptProvider>());
             services.AddScoped<IWidgetScriptFactory, WidgetScriptMetaDataFactory>();
+            services.AddSingleton<IWidgetScriptActivator, WidgetScriptActivator>();
             services.AddSingleton<IWidgetBuilder, WidgetBuilder>();
             services.AddSingleton<IWidgetOptionBuilder, WidgetOptionBuilder>();
 

--- a/openspec/changes/pass-character-owned-dependencies/.openspec.yaml
+++ b/openspec/changes/pass-character-owned-dependencies/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/pass-character-owned-dependencies/design.md
+++ b/openspec/changes/pass-character-owned-dependencies/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`CharacterFactory` already creates the nested `IServiceScope` whose lifetime ends in `Creature.Destroy`. `Character` currently passes that scope to `Creature`, then manually creates its component graph while each component resolves extra services through the owner's provider. The refactor must keep the nested scope and the existing manually ordered initialization, because rendering information, containers, appearance, and combat have observable construction order dependencies.
+
+The covered graph is `Character`, its partial methods, the components it constructs, the farming patch task it creates, and the explicit constructor inputs needed by character `Movement` and `CharacterCombat`. General `Creature` and `Npc` composition remains outside this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make ordinary character dependencies visible in the constructors that own them.
+- Resolve the graph from the nested character scope at `CharacterFactory`, not from ordinary domain methods.
+- Preserve construction order, object identity, scoped lifetimes, runtime script behavior, and character gameplay behavior.
+- Make focused component tests pass direct substitutes without mocking `ICharacter.ServiceProvider` for normal dependencies.
+
+**Non-Goals:**
+
+- Remove `IServiceProvider` from the entire creature hierarchy.
+- Replace all runtime type activation across GameWorld.
+- Introduce a generic resolver, dependency bag, second character scope, or new retry/lifecycle mechanism.
+- Change public gameplay, persistence, protocol, or database behavior.
+
+## Decisions
+
+1. **Use `ActivatorUtilities` only in `CharacterFactory`.** The factory creates the nested scope and calls `ActivatorUtilities.CreateInstance<Character>` with the scope, session, and client as explicit arguments. The container supplies the remaining typed constructor dependencies from that scope. A manually expanded factory constructor was rejected because it would duplicate the character dependency graph and create a second composition list.
+
+2. **Keep `IServiceScope` as a lifetime input, but never use it for ordinary lookup in `Character`.** `Creature` owns and disposes the scope, so `Character` must still pass it to the base constructor. The scope is not used as a service resolver by `Character` or its components. Removing it from the base path would require the unrelated creature lifetime refactor excluded by issue #408.
+
+3. **Pass component dependencies directly and preserve the existing order.** Each constructor receives only the services it uses. `Character` passes those services when it calls `new` for containers and skills. A shared `CharacterDependencies` object was rejected because it would hide the same dependency graph behind a service bag.
+
+4. **Use narrow activators for runtime-selected scripts.** Familiar scripts, character-NPC scripts, generic character scripts, and widget scripts selected through existing public operations receive separate typed activators. Scoped activators own the type-specific `GetRequiredService(Type)` operation inside the character scope; the stateless widget activator receives the owning character and resolves through that character's scope because `IWidgetBuilder` is an existing singleton. This keeps runtime selection where it belongs without exposing an arbitrary resolver to a domain component. The existing metadata providers continue to map IDs to types.
+
+5. **Inject the dialogue implementation into `Slayer`.** `ISlayerTaskCompletedDialogue` is a fixed skill-specific dependency, not a runtime-selected type. Injecting it directly avoids a normal service lookup on task completion and keeps its existing scoped activation behavior.
+
+6. **Update shared constructors only where character construction needs them.** `Movement` and `CreatureCombat` gain explicit constructor paths for path finding, mediator, combat options, and hit-splat creation. Existing NPC construction is preserved through its current path so this change does not become a general NPC refactor. Character combat uses the explicit path and no longer reaches through a character owner for these services.
+
+7. **Do not add optional constructor parameters.** Every new dependency is required and appears as a required constructor argument. Existing public method optionality is not expanded by this change.
+
+## Risks / Trade-offs
+
+- [Risk] Constructor changes can leave hidden direct callers or tests behind. → Search all production and test call sites after each component group, then run focused tests and a solution build.
+- [Risk] A typed activator could accidentally resolve from the application root. → Register activators in the character scope and construct them from the nested provider; add a factory activation test that checks scoped identity.
+- [Risk] Initialization order could change while wiring many components. → Keep `Character`'s current order and preserve the comment that render information must exist before appearance hydration.
+- [Risk] Existing NPC paths still contain service-provider lookups. → Keep those paths unchanged and scope the final scan to the character composition graph covered by this change.
+
+## Migration Plan
+
+1. Add the OpenSpec requirements and narrow activator contracts.
+2. Add scoped activator registrations and change `CharacterFactory` to compose `Character` from the nested scope.
+3. Migrate character partials and owned components, including character-created movement/combat and farming patch tasks.
+4. Update focused GameWorld and Game.Scripts tests and add coverage for direct dependency construction and nested scope lifetime.
+5. Run the focused test projects, solution build, strict OpenSpec validation, and final character-graph scan. Rollback is a source revert; no persisted data migration is needed.
+
+## Open Questions
+
+None. The issue defines the scope, the composition boundary, and the required runtime activation behavior.

--- a/openspec/changes/pass-character-owned-dependencies/proposal.md
+++ b/openspec/changes/pass-character-owned-dependencies/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+`Character` still stores a per-character service scope and lets itself and its owned components resolve ordinary dependencies through `IServiceProvider`. That hides the real construction contract, couples domain components to the DI container, and makes focused tests assemble a provider instead of passing the dependency under test. Issue #408 asks for this graph to use explicit constructor dependencies while preserving the existing per-character scope lifetime and gameplay behavior.
+
+## What Changes
+
+- Keep per-character scope creation and disposal in `CharacterFactory`, and activate `Character` from that scope with typed constructor dependencies.
+- **BREAKING**: Make `Character` and its partial methods use explicit fields for the services they directly require.
+- **BREAKING**: Pass typed dependencies into character-owned containers, appearance, rendering, statistics, prayers, combat, magic, music, slayer, widgets, and related components instead of resolving them through the owner.
+- Add narrow typed activation paths for familiar scripts and character-NPC scripts that must be selected by runtime type.
+- Pass the explicit services needed by character-created `Movement` and `CharacterCombat` instances through their constructors without redesigning the general creature hierarchy.
+- Update focused component and character construction tests to provide fakes directly, and verify scope activation/lifetime behavior.
+- Finish with a character-graph scan for ordinary service-provider lookups and strict OpenSpec/build/test validation.
+
+## Capabilities
+
+### New Capabilities
+
+- `explicit-character-dependencies`: Character composition and character-owned components expose their required typed services through constructors while retaining scoped lifetime ownership at the factory boundary.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Production code under `Hagalaz.Services.GameWorld/Factories` and `Model/Creatures/Characters`, plus the shared constructor boundaries required by character-owned combat and movement.
+- Character factory activation and many internal constructor signatures change. Persisted data, network messages, and gameplay rules do not change.
+- Focused GameWorld tests that currently mock `ICharacter.ServiceProvider` or construct a scope only for hidden lookups must be updated.
+- No new package, generic resolver, service bag, or second lifetime owner is introduced.
+
+## Acceptance Criteria
+
+- `CharacterFactory` remains the owner of the per-character scope and activates `Character` from that scope.
+- `Character` and its partials do not resolve normal dependencies from `ServiceProvider`.
+- Character-owned components declare their ordinary service requirements in constructors.
+- Runtime familiar and character-NPC type activation goes through narrow typed activators owned by the composition boundary.
+- No optional constructor parameters are added.
+- Focused unit tests can instantiate migrated components with direct fakes, and existing character behavior tests pass.
+- The final character composition scan finds no ordinary service-provider lookup in the covered graph.
+
+## Non-goals and Stop Conditions
+
+- Do not refactor every `Creature`/`Npc` subtype or remove every `IServiceProvider` use in GameWorld.
+- Do not introduce a generic resolver/context facade or alter gameplay, persistence, protocol, or service lifetime policy.
+- Stop and record follow-up work if a dependency belongs only to an unrelated creature/NPC graph and cannot be changed without broadening this issue.

--- a/openspec/changes/pass-character-owned-dependencies/specs/explicit-character-dependencies/spec.md
+++ b/openspec/changes/pass-character-owned-dependencies/specs/explicit-character-dependencies/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Character composition uses explicit dependencies
+
+The character composition graph MUST expose ordinary service dependencies through typed constructors, and `CharacterFactory` MUST compose the graph from the nested per-character scope.
+
+#### Scenario: Character creation resolves from the character scope
+
+- **WHEN** `CharacterFactory` creates a character with a session and game client
+- **THEN** the factory creates one nested scope
+- **AND** the character receives the scope, session, client, and typed services from that scope
+- **AND** the character's owned components receive their required typed services directly
+
+#### Scenario: Character destruction ends the nested scope
+
+- **WHEN** a created character is destroyed
+- **THEN** the nested scope created for that character is disposed
+- **AND** scoped dependencies from that character are not promoted to the application root
+
+### Requirement: Character methods do not resolve ordinary services
+
+`Character` and its partial implementations MUST use constructor-injected fields or properties for normal service dependencies and MUST NOT call `ServiceProvider.GetRequiredService<T>()`, `ServiceProvider.GetService`, or equivalent provider lookup for those dependencies.
+
+#### Scenario: Region and event operations use injected services
+
+- **WHEN** a character updates its map, handles a console command, or reacts to a region change
+- **THEN** the operation uses the service supplied during character construction
+- **AND** no provider lookup occurs at the point of use
+
+### Requirement: Character-owned components declare service requirements
+
+Character-owned containers, appearance, rendering, statistics, prayers, combat, magic, music, slayer, widgets, and farming tasks MUST receive each ordinary service they use through required constructor parameters.
+
+#### Scenario: A component is unit-tested with direct substitutes
+
+- **WHEN** a focused test constructs a character-owned component
+- **THEN** the test supplies the component's required services directly
+- **AND** the test does not need to create or configure an `IServiceProvider` solely for that component
+
+### Requirement: Runtime-selected character scripts use narrow activators
+
+Familiar scripts, character-NPC scripts, and other character scripts selected by runtime type MUST be created through a type-specific activator composed from the character scope. Character-owned components MUST NOT store or use an arbitrary service provider for this activation.
+
+#### Scenario: Hydration creates the selected familiar script
+
+- **WHEN** familiar state is hydrated for a character
+- **THEN** the familiar provider maps the familiar ID to its script type
+- **AND** the familiar activator creates that script in the character scope
+- **AND** the hydrated script receives the same character-scoped dependencies as other character scripts
+
+#### Scenario: Appearance creates the selected character-NPC script
+
+- **WHEN** a character transforms into an NPC without a supplied script instance
+- **THEN** the character-NPC provider maps the NPC ID to its script type
+- **AND** the character-NPC activator creates that script in the character scope
+- **AND** the appearance component initializes the created script as before
+
+### Requirement: Gameplay behavior remains unchanged
+
+The refactor MUST preserve existing character gameplay, persistence, protocol, and construction-order behavior while changing only how dependencies enter the graph.
+
+#### Scenario: Character hydration and registration retain their order
+
+- **WHEN** a character is hydrated and registered
+- **THEN** appearance, inventory, statistics, script, map, and event behavior follows the existing lifecycle order
+- **AND** no component observes an uninitialized required sibling caused by the constructor wiring
+
+#### Scenario: Character-owned runtime actions keep their services
+
+- **WHEN** combat, item drops, music, slayer completion, widget validation, or farming updates run
+- **THEN** each action uses the same service implementation and scope as before
+- **AND** the action produces the existing gameplay result

--- a/openspec/changes/pass-character-owned-dependencies/tasks.md
+++ b/openspec/changes/pass-character-owned-dependencies/tasks.md
@@ -1,0 +1,22 @@
+## 1. Record and compose the character graph
+
+- [x] 1.1 Add the explicit-character-dependencies delta spec and design decisions for scope ownership, required constructors, and narrow runtime activators.
+- [x] 1.2 Add type-specific character, familiar, and character-NPC activator contracts and scoped implementations, then register them in GameWorld.
+- [x] 1.3 Change `CharacterFactory` to activate `Character` from its nested scope with `ActivatorUtilities`, preserving scope disposal by `Creature`.
+
+## 2. Migrate Character and owned components
+
+- [x] 2.1 Inject `Character`'s direct service dependencies and update all Character partials to use those fields.
+- [x] 2.2 Pass explicit dependencies into character-owned containers, appearance, render information, statistics, prayers, magic, music, slayer, widgets, and familiar item containers.
+- [x] 2.3 Migrate familiar, character-NPC, dialogue, widget, and character-script runtime activation to their narrow typed boundaries without adding optional constructor parameters.
+- [x] 2.4 Pass explicit dependencies into character-created movement/combat and farming patch tasks, while preserving existing non-character creature/NPC paths.
+
+## 3. Update tests and callers
+
+- [x] 3.1 Update focused component tests and Game.Scripts callers to pass direct dependencies instead of configuring owner service providers.
+- [x] 3.2 Add regression coverage for nested character-scope composition, direct component construction, and runtime script activation.
+
+## 4. Validate and close
+
+- [x] 4.1 Run focused GameWorld and Game.Scripts tests, then build the solution with the repository's normal validation commands.
+- [x] 4.2 Run strict OpenSpec validation and scan the covered character composition graph for ordinary provider lookups, optional constructor parameters added by this change, and missed call sites.


### PR DESCRIPTION
## Summary

- Pass character-owned dependencies explicitly through character models, containers, factories, and script activators.
- Update widget, farming, combat, and lifecycle code to use the revised dependency boundaries.
- Add and update regression tests covering character state, rendering, combat, persistence, widgets, trading, and script activation.

Closes #408.

## Testing

- Not run (not requested).