### PR TITLE
Add review remediation scope guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,35 @@ solutions proportional to the problem and prevent accidental architecture expans
 - Before completion: review for regressions, duplicate paths, dead code, ownership leaks, cancellation behavior, dependency weight, and readability—not only test failures.
 - Validate the actual runtime topology with targeted tests, integration tests where boundaries are distributed, a build, and a clean diff check. Report what was not verified.
 
+### Review remediation and scope retention
+
+Pull-request review comments are findings, not independent implementation tasks. The originating issue/spec and the complete cumulative PR diff remain the primary context throughout the review-fix cycle. Never narrow attention to only the latest comment, latest commit, or commented line.
+
+Before implementing review feedback:
+
+1. Re-read the originating issue/spec, including its acceptance criteria, design decisions, and non-goals.
+2. Re-read the complete cumulative diff from the original PR base to `HEAD`. Incremental diffs may be used to locate new changes, but they are not sufficient for architectural decisions.
+3. Read all unresolved review threads together before changing code.
+4. Group related findings by root cause. Do not fix review comments one by one or treat the review thread list as a task queue.
+5. Produce one minimal, coherent remediation plan that remains within the original issue/spec.
+6. For every proposed change, identify which original requirement, invariant, or required regression test it serves.
+7. Prefer deleting, reverting, or simplifying an earlier attempted fix over adding compensating code on top of it.
+
+Review comments may reveal defects in the implementation, but they do not automatically extend or redefine the originating issue/spec. If a proposed fix introduces a new responsibility, abstraction, lifecycle mechanism, state owner, subsystem, or material scope expansion that is not justified by the original issue/spec, stop and reassess the broader design instead of implementing the local fix.
+
+KISS and YAGNI still apply during review remediation. Do not add generic rollback frameworks, coordinators, wrappers, state machines, recovery mechanisms, or speculative error handling merely to satisfy individual review comments. Prefer the smallest root-cause fix that restores the intended invariant using existing ownership boundaries and project primitives.
+
+After each logical remediation, review the entire affected flow and the cumulative base-to-`HEAD` diff, not only the code that was commented on. Resolve or explicitly supersede stale review threads once their underlying root cause is fixed so later work does not treat obsolete guidance as additional requirements.
+
+Before declaring review feedback complete, explicitly verify:
+
+- The final PR still solves the original issue/spec rather than a collection of review comments.
+- Every original acceptance criterion is satisfied and every non-goal remains respected.
+- Review-driven changes have not introduced unrelated responsibilities or architecture.
+- No second mechanism or duplicate owner was introduced for an existing responsibility.
+- Temporary, compensating, or now-obsolete review-driven code has been removed.
+- The cumulative diff is still the smallest coherent solution now that all findings are understood together.
+
 ## Getting Started
 
 ### Backend
@@ -158,7 +187,7 @@ pnpm run launcher:build
 
 ### Backend
 
-The backend has a suite of unit tests. To run them, execute the following command from the root directory:
+The backend has a suite of unit tests that can be run by executing the following command from the root directory:
 
 ```bash
 dotnet test Hagalaz.sln

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ pnpm run launcher:build
 
 ### Backend
 
-The backend has a suite of unit tests that can be run by executing the following command from the root directory:
+The backend has a suite of unit tests. To run them, execute the following command from the root directory:
 
 ```bash
 dotnet test Hagalaz.sln


### PR DESCRIPTION
## Summary

- treat PR review comments as findings rather than independent implementation tasks
- require agents to re-anchor on the originating issue/spec and the full base-to-HEAD diff before fixing feedback
- require unresolved findings to be consolidated by root cause into one minimal remediation plan
- reinforce KISS/YAGNI by preferring simplification or reversion over layered compensating fixes
- require a final scope audit against acceptance criteria and non-goals

## Motivation

Repeated review cycles can otherwise cause agents to fix each comment locally and stack those fixes on top of one another, gradually losing the broader issue/spec and introducing scope creep. These guardrails make the original change intent and cumulative PR architecture the persistent source of truth throughout remediation.

## Validation

Documentation-only change. Verified the cumulative diff against `main`; only `AGENTS.md` is changed, with 29 added lines and no unrelated modifications.