### PR TITLE
Require exact payment for shop purchases

### DIFF
--- a/Hagalaz.Game.Abstractions/Collections/IMoneyPouchContainer.cs
+++ b/Hagalaz.Game.Abstractions/Collections/IMoneyPouchContainer.cs
@@ -52,5 +52,10 @@
         /// Removes coins using the pouch's normal underflow rules as one checked trade operation.
         /// </summary>
         bool RemoveForTrade(int count);
+
+        /// <summary>
+        /// Removes exactly the requested number of coins from the pouch and inventory, if available.
+        /// </summary>
+        bool TryRemoveExact(int count);
     }
 }

--- a/Hagalaz.Game.Scripts.Tests/Characters/TradeExchangeTests.cs
+++ b/Hagalaz.Game.Scripts.Tests/Characters/TradeExchangeTests.cs
@@ -763,6 +763,8 @@ public sealed class TradeExchangeTests
             return remaining <= 0 || TradeExchange.RemoveForTrade(_overflowInventory,
                 new TestItem(995, remaining, stackable: true));
         }
+
+        public bool TryRemoveExact(int count) => RemoveForTrade(count);
     }
 
     private sealed class TestItem : IItem

--- a/Hagalaz.Services.GameWorld.Tests/ShopStockContainerTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ShopStockContainerTests.cs
@@ -1,0 +1,271 @@
+using System.Collections.Generic;
+using Hagalaz.Game.Abstractions.Builders.Item;
+using Hagalaz.Game.Abstractions.Collections;
+using Hagalaz.Game.Abstractions.Data;
+using Hagalaz.Game.Abstractions.Features.Shops;
+using Hagalaz.Game.Abstractions.Model.Creatures.Characters;
+using Hagalaz.Game.Abstractions.Model.Items;
+using Hagalaz.Game.Abstractions.Services;
+using Hagalaz.Game.Common.Events;
+using Hagalaz.Services.GameWorld.Logic.Shops;
+using Hagalaz.Services.GameWorld.Model.Creatures.Characters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Hagalaz.Services.GameWorld.Tests;
+
+[TestClass]
+public sealed class ShopStockContainerTests
+{
+    private const int CoinId = 995;
+    private const int ItemId = 1000;
+
+    [TestMethod]
+    public void BuyFromShop_WhenPlayerHasOneCoinForTenThousandCoinItem_RejectsAndPreservesCoin()
+    {
+        var scenario = CreateScenario(cost: 10_000, pouchCoins: 1);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(1, scenario.MoneyPouch.Count);
+        Assert.AreEqual(0, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenPlayerHasCostMinusOneCoins_RejectsAndPreservesAllCoins()
+    {
+        const int cost = 10_000;
+        var scenario = CreateScenario(cost, pouchCoins: cost - 1);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(cost - 1, scenario.MoneyPouch.Count);
+        Assert.AreEqual(0, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenPlayerHasExactCoinCost_SucceedsAndRemovesExactCost()
+    {
+        const int cost = 10_000;
+        var scenario = CreateScenario(cost, pouchCoins: cost);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, GetTotalCoins(scenario));
+        Assert.AreEqual(1, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenPlayerHasMoreThanCoinCost_RemovesOnlyExactCost()
+    {
+        const int cost = 10_000;
+        var scenario = CreateScenario(cost, pouchCoins: cost + 1);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(1, GetTotalCoins(scenario));
+        Assert.AreEqual(1, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenCoinsAreSplitBetweenPouchAndInventory_RemovesExactCost()
+    {
+        const int cost = 10_000;
+        var scenario = CreateScenario(cost, pouchCoins: 4_000, inventoryCurrency: 6_000);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, GetTotalCoins(scenario));
+        Assert.AreEqual(1, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenBuyingSampleStock_DoesNotChargeCurrency()
+    {
+        var scenario = CreateScenario(cost: 10_000, sampleStock: true);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, GetTotalCoins(scenario));
+        Assert.AreEqual(1, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenUsingNonCoinCurrency_RemovesExactInventoryCost()
+    {
+        const int currencyId = 2000;
+        const int cost = 5;
+        var scenario = CreateScenario(cost, currencyId, inventoryCurrency: cost);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, scenario.Inventory.GetCountById(currencyId));
+        Assert.AreEqual(1, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
+    public void BuyFromShop_WhenNonCoinCurrencyIsUnderfunded_RejectsAndPreservesCurrency()
+    {
+        const int currencyId = 2000;
+        const int cost = 5;
+        var scenario = CreateScenario(cost, currencyId, inventoryCurrency: cost - 1);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(cost - 1, scenario.Inventory.GetCountById(currencyId));
+        Assert.AreEqual(0, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    private static ShopScenario CreateScenario(
+        int cost,
+        int currencyId = CoinId,
+        int pouchCoins = 0,
+        int inventoryCurrency = 0,
+        bool sampleStock = false)
+    {
+        var inventory = new TestInventory(10);
+        if (inventoryCurrency > 0)
+        {
+            Assert.IsTrue(inventory.Add(new TestItem(currencyId, inventoryCurrency, stackable: true)));
+        }
+
+        var character = Substitute.For<ICharacter>();
+        character.Inventory.Returns(inventory);
+        character.EventManager.Returns(Substitute.For<IEventManager>());
+
+        var itemBuilder = new TestItemBuilder();
+        var moneyPouch = new MoneyPouchContainer(character, itemBuilder);
+        if (pouchCoins > 0)
+        {
+            Assert.IsTrue(moneyPouch.Add(pouchCoins));
+        }
+
+        character.MoneyPouch.Returns(moneyPouch);
+
+        var shop = Substitute.For<IShop>();
+        shop.CurrencyId.Returns(currencyId);
+        shop.GeneralStore.Returns(true);
+        shop.GetBuyValue(Arg.Any<IItem>()).Returns(cost);
+
+        var itemService = Substitute.For<IItemService>();
+        var currencyDefinition = Substitute.For<IItemDefinition>();
+        currencyDefinition.Name.Returns(currencyId == CoinId ? "Coins" : "Tokens");
+        itemService.FindItemDefinitionById(currencyId).Returns(currencyDefinition);
+
+        var stockItem = new TestItem(ItemId, 1, stackable: true);
+        var stock = new ShopStockContainer(
+            shop,
+            itemService,
+            itemBuilder,
+            sampleStock,
+            StorageType.AlwaysStack,
+            1,
+            [stockItem],
+            Substitute.For<IEventManager>());
+
+        return new ShopScenario(character, inventory, moneyPouch, stock, stockItem);
+    }
+
+    private static int GetTotalCoins(ShopScenario scenario) =>
+        scenario.MoneyPouch.Count + scenario.Inventory.GetCountById(CoinId);
+
+    private sealed record ShopScenario(
+        ICharacter Character,
+        IInventoryContainer Inventory,
+        IMoneyPouchContainer MoneyPouch,
+        IShopStockContainer Stock,
+        IItem StockItem);
+
+    private sealed class TestInventory : TestItemContainer, IInventoryContainer
+    {
+        public TestInventory(int capacity) : base(StorageType.Normal, capacity) { }
+
+        public bool DropItem(IItem item) => false;
+    }
+
+    private class TestItemContainer : TradeItemContainer
+    {
+        protected TestItemContainer(StorageType type, int capacity) : base(type, capacity) { }
+
+        public override void OnUpdate(HashSet<int>? slots = null) { }
+    }
+
+    private sealed class TestItemBuilder : IItemBuilder, IItemId, IItemOptional
+    {
+        private int _id;
+        private int _count = 1;
+
+        public IItemId Create() => this;
+
+        public IItemOptional WithId(int id)
+        {
+            _id = id;
+            return this;
+        }
+
+        public IItemOptional WithCount(int count)
+        {
+            _count = count;
+            return this;
+        }
+
+        public IItemOptional WithExtraData(string data) => this;
+
+        public IItem Build() => new TestItem(_id, _count, stackable: true);
+    }
+
+    private sealed class TestItem : IItem
+    {
+        public int Id { get; }
+        public int Count { get; set; }
+        public string Name => $"Test item {Id}";
+        public IItemDefinition ItemDefinition { get; }
+        public IEquipmentDefinition EquipmentDefinition { get; } = Substitute.For<IEquipmentDefinition>();
+        public IItemScript ItemScript { get; }
+        public IEquipmentScript EquipmentScript { get; } = Substitute.For<IEquipmentScript>();
+        public long[] ExtraData => [];
+
+        public TestItem(int id, int count, bool stackable)
+        {
+            Id = id;
+            Count = count;
+            ItemDefinition = Substitute.For<IItemDefinition>();
+            ItemDefinition.Stackable.Returns(stackable);
+            ItemDefinition.Noted.Returns(false);
+
+            ItemScript = Substitute.For<IItemScript>();
+            ItemScript.CanBuyItem(Arg.Any<IItem>(), Arg.Any<ICharacter>()).Returns(true);
+            ItemScript.CanStackItem(Arg.Any<IItem>(), Arg.Any<IItem>(), Arg.Any<bool>()).Returns(callInfo =>
+            {
+                var left = callInfo.ArgAt<IItem>(0);
+                var right = callInfo.ArgAt<IItem>(1);
+                return callInfo.ArgAt<bool>(2) || left.Id == right.Id && left.ItemDefinition.Stackable;
+            });
+        }
+
+        private TestItem(int id, int count, IItemDefinition definition, IItemScript script)
+        {
+            Id = id;
+            Count = count;
+            ItemDefinition = definition;
+            ItemScript = script;
+        }
+
+        public IItem Clone() => new TestItem(Id, Count, ItemDefinition, ItemScript);
+
+        public IItem Clone(int newCount) => new TestItem(Id, newCount, ItemDefinition, ItemScript);
+
+        public bool Equals(IItem otherItem, bool ignoreCount = true) =>
+            otherItem != null && Id == otherItem.Id && (ignoreCount || Count == otherItem.Count);
+
+        public string? SerializeExtraData() => null;
+    }
+}

--- a/Hagalaz.Services.GameWorld.Tests/ShopStockContainerTests.cs
+++ b/Hagalaz.Services.GameWorld.Tests/ShopStockContainerTests.cs
@@ -85,6 +85,20 @@ public sealed class ShopStockContainerTests
     }
 
     [TestMethod]
+    public void BuyFromShop_WhenSplitCoinsAreUnderfunded_RejectsAndPreservesBothBalances()
+    {
+        const int cost = 10_000;
+        var scenario = CreateScenario(cost, pouchCoins: 4_000, inventoryCurrency: 5_999);
+
+        var result = scenario.Stock.BuyFromShop(scenario.Character, scenario.StockItem, 1);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(4_000, scenario.MoneyPouch.Count);
+        Assert.AreEqual(5_999, scenario.Inventory.GetCountById(CoinId));
+        Assert.AreEqual(0, scenario.Inventory.GetCountById(ItemId));
+    }
+
+    [TestMethod]
     public void BuyFromShop_WhenBuyingSampleStock_DoesNotChargeCurrency()
     {
         var scenario = CreateScenario(cost: 10_000, sampleStock: true);

--- a/Hagalaz.Services.GameWorld/Logic/Shops/ShopStockContainer.cs
+++ b/Hagalaz.Services.GameWorld/Logic/Shops/ShopStockContainer.cs
@@ -201,17 +201,12 @@ namespace Hagalaz.Services.GameWorld.Logic.Shops
                     return false;
                 }
 
-                var removed = 0;
-                if (viewer.MoneyPouch.Contains(_shop.CurrencyId))
-                {
-                    removed = viewer.MoneyPouch.Remove((int)cost);
-                }
-                else if (viewer.Inventory.Contains(_shop.CurrencyId, (int)cost))
-                {
-                    removed = viewer.Inventory.Remove(_itemBuilder.Create().WithId(_shop.CurrencyId).WithCount((int)cost).Build());
-                }
+                var paid = _shop.CurrencyId == 995
+                    ? viewer.MoneyPouch.TryRemoveExact((int)cost)
+                    : viewer.Inventory.RemoveForTrade(
+                        _itemBuilder.Create().WithId(_shop.CurrencyId).WithCount((int)cost).Build());
 
-                if (removed <= 0)
+                if (!paid)
                 {
                     viewer.SendChatMessage("You don't have enough " + _itemRepository.FindItemDefinitionById(_shop.CurrencyId).Name.ToLower() + "!");
                     return false;

--- a/Hagalaz.Services.GameWorld/Model/Creatures/Characters/MoneyPouchContainer.cs
+++ b/Hagalaz.Services.GameWorld/Model/Creatures/Characters/MoneyPouchContainer.cs
@@ -180,6 +180,11 @@ namespace Hagalaz.Services.GameWorld.Model.Creatures.Characters
         /// </summary>
         public bool RemoveForTrade(int count) => ExecuteWithInventoryBoundary(() => RemoveForTradeCore(count));
 
+        /// <summary>
+        /// Removes exactly the requested number of coins using the checked pouch and inventory operation.
+        /// </summary>
+        public bool TryRemoveExact(int count) => RemoveForTrade(count);
+
         private bool RemoveForTradeCore(int count)
         {
             if (count <= 0)

--- a/openspec/changes/require-exact-shop-payment/.openspec.yaml
+++ b/openspec/changes/require-exact-shop-payment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/require-exact-shop-payment/design.md
+++ b/openspec/changes/require-exact-shop-payment/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`ShopStockContainer.BuyFromShop` currently calls the partial-removal API and accepts any positive result as payment. `MoneyPouchContainer` already has a checked `RemoveForTrade` operation that validates the combined pouch and inventory balance before mutating either container. The shop needs that same behavior without depending on trade-specific naming. Non-coin shop currencies live in the inventory and must use the inventory's existing checked removal operation.
+
+The purchase flow remains the owner of the payment decision. The money pouch owns coin validation and mutation, while the inventory owns alternative-currency validation and mutation. Stock and item delivery remain unchanged by this issue. Full cross-container purchase rollback belongs to #449.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reject every paid purchase unless the complete calculated cost is removed.
+- Preserve all currency when the player cannot pay the complete cost.
+- Allow coins split between the money pouch and inventory to pay exactly.
+- Keep free/sample purchases free and remove non-coin currencies exactly from inventory.
+- Add a domain-neutral `TryRemoveExact` money-pouch contract that delegates to the existing checked removal algorithm.
+
+**Non-Goals:**
+
+- Do not redesign item-container atomicity from #434 or #437.
+- Do not make stock removal and inventory delivery atomic with payment. That is #449.
+- Do not add locks, queues, transaction objects, coordinators, async APIs, or race handling.
+
+## Decisions
+
+1. **Use `TryRemoveExact` as the shop-facing money operation.** The method will delegate to the existing `RemoveForTrade` implementation, so there is one checked pouch-plus-inventory removal algorithm. Keeping `RemoveForTrade` preserves the current trade contract; adding a domain-neutral name avoids coupling shop code to trade terminology. A second removal implementation or a direct `Remove` followed by an equality check was rejected because both would either duplicate logic or destroy partial currency before failure.
+
+2. **Select the payment owner by currency type.** Coin currency (`995`) uses the money pouch exact operation, which also checks inventory overflow coins. Every other currency uses `IInventoryContainer.RemoveForTrade` with the exact requested item. Reusing `MoneyPouch.Contains` as the branch condition was rejected because that method reports inventory fallback semantics and cannot distinguish a coin payment from an alternative currency.
+
+3. **Keep the existing purchase ordering and checks.** Stock selection, count limiting, capacity checks, price overflow checks, restrictions, and delivery stay in `BuyFromShop`. The payment gate returns before stock or inventory mutation when exact removal fails. A broader rollback coordinator is intentionally deferred to #449.
+
+## Risks / Trade-offs
+
+- [Risk] Adding a method to `IMoneyPouchContainer` requires test doubles to implement it. → Update the existing deterministic money-pouch test double by delegating to its checked removal path; no production adapter is needed.
+- [Risk] Payment can still succeed before a later stock or inventory mutation fails. → This existing atomicity gap is explicitly outside issue 441 and tracked by #449; this change only closes underpayment authorization.
+- [Risk] The shop depends on the coin item ID. → `995` is the established coin ID used by the money pouch and existing shop flow; no new currency registry is introduced.

--- a/openspec/changes/require-exact-shop-payment/proposal.md
+++ b/openspec/changes/require-exact-shop-payment/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`ShopStockContainer.BuyFromShop` treats any positive result from the money pouch as full payment. When the player has less than the price, the pouch can remove the player's remaining coins and the shop still grants the item. This is a direct economy exploit and needs a narrow payment-flow fix before broader shop atomicity work in #449.
+
+## What Changes
+
+- Require a paid shop purchase to remove the exact calculated cost before the item is granted.
+- Reuse the money pouch's existing checked removal behavior for shop payments, exposing only the smallest domain-neutral contract adjustment needed by the shop.
+- Add deterministic MSTest coverage for underpayment, exact payment, overpayment, pouch plus inventory coins, free/sample stock, and non-coin currencies.
+- Preserve stock limits, inventory checks, shop restrictions, and all existing free and alternative-currency behavior.
+
+### Non-goals and stop conditions
+
+- Do not implement the broader container changes in #434 or #437.
+- Do not implement full purchase atomicity from #449.
+- Do not add a transaction framework, coordinator, lock, async container API, or concurrency behavior.
+- If the fix requires those excluded changes, stop and record the blocker instead of expanding this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `shop-purchase-payment`: A paid shop purchase authorizes item delivery only after exact currency removal, while free/sample purchases remain free and alternative shop currencies retain exact-payment semantics.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `Hagalaz.Services.GameWorld/Logic/Shops/ShopStockContainer.cs` will use exact money removal for the payment gate.
+- `Hagalaz.Game.Abstractions/Collections/IMoneyPouchContainer.cs` and its implementation may gain the smallest domain-neutral exact-removal contract needed by the shop.
+- Focused shop and money-pouch tests will cover the payment boundary. No database, messaging, dependency, or public network protocol changes are expected.

--- a/openspec/changes/require-exact-shop-payment/specs/shop-purchase-payment/spec.md
+++ b/openspec/changes/require-exact-shop-payment/specs/shop-purchase-payment/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Paid shop purchases require exact payment
+
+The shop SHALL grant a paid item only when the exact calculated cost has been removed from the player's available shop currency. If the player cannot pay the full cost, the purchase SHALL fail and the player's existing currency SHALL remain unchanged.
+
+#### Scenario: Player has one coin for a ten-thousand-coin item
+
+- **WHEN** the item costs 10,000 coins and the player has 1 coin
+- **THEN** the purchase fails, the item is not granted, and the player's coin remains
+
+#### Scenario: Player is short by one coin
+
+- **WHEN** the item costs `cost` coins and the player has `cost - 1` coins
+- **THEN** the purchase fails and all `cost - 1` coins remain
+
+#### Scenario: Player has the exact coin cost
+
+- **WHEN** the item costs `cost` coins and the player has exactly `cost` coins
+- **THEN** the purchase succeeds and exactly `cost` coins are removed
+
+#### Scenario: Player has more than the coin cost
+
+- **WHEN** the item costs `cost` coins and the player has more than `cost` coins
+- **THEN** the purchase succeeds and exactly `cost` coins are removed
+
+#### Scenario: Coins are split between the pouch and inventory
+
+- **WHEN** the player's money pouch and inventory together contain exactly the coin cost
+- **THEN** the purchase succeeds and the exact cost is removed across those containers
+
+### Requirement: Free and alternative-currency shop purchases keep their existing semantics
+
+The shop SHALL not charge currency for sample stock, and a shop using a non-coin currency SHALL require and remove the exact cost from the player's inventory.
+
+#### Scenario: Sample stock is free
+
+- **WHEN** the player buys an item from sample stock
+- **THEN** the purchase succeeds when the existing stock and inventory checks pass without removing any currency
+
+#### Scenario: Non-coin currency is paid exactly
+
+- **WHEN** a shop item costs `cost` units of a non-coin currency and the player's inventory contains exactly `cost`
+- **THEN** the purchase succeeds and exactly `cost` units of that currency are removed
+
+#### Scenario: Non-coin currency is underfunded
+
+- **WHEN** a shop item costs `cost` units of a non-coin currency and the player's inventory contains less than `cost`
+- **THEN** the purchase fails and the existing currency remains unchanged

--- a/openspec/changes/require-exact-shop-payment/tasks.md
+++ b/openspec/changes/require-exact-shop-payment/tasks.md
@@ -1,0 +1,9 @@
+## 1. Exact payment implementation
+
+- [x] 1.1 Add the domain-neutral `TryRemoveExact` money-pouch contract and delegate it to the existing checked pouch-plus-inventory removal algorithm, updating affected test doubles.
+- [x] 1.2 Change `ShopStockContainer.BuyFromShop` to authorize coin purchases only after exact money-pouch removal and non-coin purchases only after exact inventory removal, without changing stock, capacity, restriction, or sample-stock checks.
+
+## 2. Regression coverage
+
+- [x] 2.1 Add deterministic MSTest coverage for one-coin and `cost - 1` underpayment with currency preservation, exact payment, overpayment, split pouch and inventory coins, free/sample stock, and exact non-coin currency payment.
+- [x] 2.2 Run the focused shop and money-pouch tests, validate the OpenSpec change, and review the final diff for excluded #434, #437, and #449 work.


### PR DESCRIPTION
## Summary

- Fix underpayment exploit in shop purchases by requiring exact currency removal
- Preserve coins when the player cannot afford the full cost
- Support split pouch and inventory coins, free sample stock, and exact non-coin payments
- Add focused MSTest coverage for payment and currency-preservation scenarios
- Closes #441

## Testing

Not run (not requested)